### PR TITLE
Zenodo loader

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -13,6 +13,9 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+  - qcelemental=0.25.1
+  - qcportal
+  - requests
 
     # Pip-only installs
   #- pip:

--- a/modelforge/tests/test_zenodo.py
+++ b/modelforge/tests/test_zenodo.py
@@ -4,19 +4,19 @@ import modelforge
 from modelforge.utils.zenodo import *
 
 def test_zenodo_fetch():
-    files = hdf5_from_zenodo_doi(record='10.5281/zenodo.3588339')
+    files = hdf5_from_zenodo(record='10.5281/zenodo.3588339')
     assert len(files) == 1
     assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
 
-    files = hdf5_from_zenodo_doi(record='https://dx.doi.org/10.5281/zenodo.3588339')
+    files = hdf5_from_zenodo(record='https://dx.doi.org/10.5281/zenodo.3588339')
     assert len(files) == 1
     assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
 
-    files = hdf5_from_zenodo_doi(record='https://zenodo.org/record/3588339')
+    files = hdf5_from_zenodo(record='https://zenodo.org/record/3588339')
     assert len(files) == 1
     assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
 
-    files = hdf5_from_zenodo_doi(record='3588339')
+    files = hdf5_from_zenodo(record='3588339')
     assert len(files) == 1
     assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
 

--- a/modelforge/tests/test_zenodo.py
+++ b/modelforge/tests/test_zenodo.py
@@ -4,13 +4,22 @@ import modelforge
 from modelforge.utils.zenodo import *
 
 def test_zenodo_fetch():
-    files = hdf5_from_zenodo_doi(doi='10.5281/zenodo.3588339')
+    files = hdf5_from_zenodo_doi(record='10.5281/zenodo.3588339')
     assert len(files) == 1
     assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
 
-    files = hdf5_from_zenodo_doi(doi='https://dx.doi.org/10.5281/zenodo.3588339')
+    files = hdf5_from_zenodo_doi(record='https://dx.doi.org/10.5281/zenodo.3588339')
     assert len(files) == 1
     assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+
+    files = hdf5_from_zenodo_doi(record='https://zenodo.org/record/3588339')
+    assert len(files) == 1
+    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+
+    files = hdf5_from_zenodo_doi(record='3588339')
+    assert len(files) == 1
+    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+
 
 def test_fetch_record_id():
 

--- a/modelforge/tests/test_zenodo.py
+++ b/modelforge/tests/test_zenodo.py
@@ -1,0 +1,44 @@
+import sys
+import pytest
+import modelforge
+from modelforge.utils.zenodo import *
+
+def test_zenodo_fetch():
+    files = hdf5_from_zenodo_doi(doi='10.5281/zenodo.3588339')
+    assert len(files) == 1
+    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+
+    files = hdf5_from_zenodo_doi(doi='https://dx.doi.org/10.5281/zenodo.3588339')
+    assert len(files) == 1
+    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+
+def test_fetch_record_id():
+
+    record_id = fetch_record_id_from_doi(doi='10.5281/zenodo.3588339')
+    assert record_id == '3588339'
+
+    with pytest.raises(Exception):
+        fetch_record_id_from_doi(doi='10.5281/zenodo.fake.3588339')
+
+    with pytest.raises(Exception):
+        fetch_record_id_from_doi(doi='10.5281/zenodo.3588339', timeout=0.0000000000001)
+
+def test_fetch_data():
+    files = get_zenodo_datafiles(record_id='3588339', file_extension='.hdf5.gz')
+
+    assert len(files) == 1
+    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+
+    files = get_zenodo_datafiles(record_id='3588339', file_extension='.gz')
+    assert len(files) == 2
+    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+    assert files[1] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.tar.gz'
+
+    files = get_zenodo_datafiles(record_id='3588339', file_extension='.txt')
+    assert len(files) == 0
+
+    with pytest.raises(Exception):
+        get_zenodo_datafiles(record_id='3588339bad', file_extension='.txt')
+
+    with pytest.raises(Exception):
+        get_zenodo_datafiles(record_id='3588339', timeout=0.000000000001, file_extension='.hdf5.gz')

--- a/modelforge/tests/test_zenodo.py
+++ b/modelforge/tests/test_zenodo.py
@@ -4,6 +4,33 @@ import modelforge
 from modelforge.utils.zenodo import *
 
 
+def test_is_url():
+    assert (
+        is_url(query="https://dx.doi.org/10.5281/zenodo.3588339", hostname="doi.org")
+        == True
+    )
+    assert (
+        is_url(query="https://zenodo.org/record/3588339", hostname="zenodo.org") == True
+    )
+    assert (
+        is_url(query="https://zenodo.org/record/3588339", hostname="choderalab.org")
+        == False
+    )
+
+
+def test_record_id_parse():
+    assert (
+        parse_zenodo_record_id_from_url("https://zenodo.org/record/3588339")
+        == "3588339"
+    )
+    assert (
+        parse_zenodo_record_id_from_url("https://zenodo.org/record/3588339/")
+        == "3588339"
+    )
+    with pytest.raises(Exception):
+        parse_zenodo_record_id_from_url("https://zenodo.org/record/bad/3588339")
+
+
 def test_zenodo_fetch():
     # qm9 dataset
     files = hdf5_from_zenodo(record="10.5281/zenodo.3588339")

--- a/modelforge/tests/test_zenodo.py
+++ b/modelforge/tests/test_zenodo.py
@@ -3,51 +3,86 @@ import pytest
 import modelforge
 from modelforge.utils.zenodo import *
 
+
 def test_zenodo_fetch():
-    files = hdf5_from_zenodo(record='10.5281/zenodo.3588339')
+    # qm9 dataset
+    files = hdf5_from_zenodo(record="10.5281/zenodo.3588339")
     assert len(files) == 1
-    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+    assert (
+        files[0]
+        == "https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz"
+    )
 
-    files = hdf5_from_zenodo(record='https://dx.doi.org/10.5281/zenodo.3588339')
+    files = hdf5_from_zenodo(record="https://dx.doi.org/10.5281/zenodo.3588339")
     assert len(files) == 1
-    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+    assert (
+        files[0]
+        == "https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz"
+    )
 
-    files = hdf5_from_zenodo(record='https://zenodo.org/record/3588339')
+    files = hdf5_from_zenodo(record="https://zenodo.org/record/3588339")
     assert len(files) == 1
-    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+    assert (
+        files[0]
+        == "https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz"
+    )
 
-    files = hdf5_from_zenodo(record='3588339')
+    files = hdf5_from_zenodo(record="3588339")
     assert len(files) == 1
-    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+    assert (
+        files[0]
+        == "https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz"
+    )
+
+    # comp6 dataset
+    files = hdf5_from_zenodo("10.5281/zenodo.3588368")
+    assert len(files) == 6
+    assert any("205.hdf5.gz" in file for file in files)
+    assert any("207.hdf5.gz" in file for file in files)
+    assert any("208.hdf5.gz" in file for file in files)
+    assert any("209.hdf5.gz" in file for file in files)
+    assert any("210.hdf5.gz" in file for file in files)
+    assert any("211.hdf5.gz" in file for file in files)
 
 
 def test_fetch_record_id():
-
-    record_id = fetch_record_id_from_doi(doi='10.5281/zenodo.3588339')
-    assert record_id == '3588339'
-
-    with pytest.raises(Exception):
-        fetch_record_id_from_doi(doi='10.5281/zenodo.fake.3588339')
+    record = fetch_url_from_doi(doi="10.5281/zenodo.3588339")
+    assert record == "https://zenodo.org/record/3588339"
 
     with pytest.raises(Exception):
-        fetch_record_id_from_doi(doi='10.5281/zenodo.3588339', timeout=0.0000000000001)
+        fetch_url_from_doi(doi="10.5281/zenodo.fake.3588339")
+
+    with pytest.raises(Exception):
+        fetch_url_from_doi(doi="10.5281/zenodo.3588339", timeout=0.0000000000001)
+
 
 def test_fetch_data():
-    files = get_zenodo_datafiles(record_id='3588339', file_extension='.hdf5.gz')
+    files = get_zenodo_datafiles(record_id="3588339", file_extension=".hdf5.gz")
 
     assert len(files) == 1
-    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
+    assert (
+        files[0]
+        == "https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz"
+    )
 
-    files = get_zenodo_datafiles(record_id='3588339', file_extension='.gz')
+    files = get_zenodo_datafiles(record_id="3588339", file_extension=".gz")
     assert len(files) == 2
-    assert files[0] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz'
-    assert files[1] == 'https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.tar.gz'
+    assert (
+        files[0]
+        == "https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.hdf5.gz"
+    )
+    assert (
+        files[1]
+        == "https://zenodo.org/api/files/0a55a53a-69c3-4cd8-8ab8-d031ca0d6853/155.tar.gz"
+    )
 
-    files = get_zenodo_datafiles(record_id='3588339', file_extension='.txt')
+    files = get_zenodo_datafiles(record_id="3588339", file_extension=".txt")
     assert len(files) == 0
 
     with pytest.raises(Exception):
-        get_zenodo_datafiles(record_id='3588339bad', file_extension='.txt')
+        get_zenodo_datafiles(record_id="3588339bad", file_extension=".txt")
 
     with pytest.raises(Exception):
-        get_zenodo_datafiles(record_id='3588339', timeout=0.000000000001, file_extension='.hdf5.gz')
+        get_zenodo_datafiles(
+            record_id="3588339", timeout=0.000000000001, file_extension=".hdf5.gz"
+        )

--- a/modelforge/utils/__init__.py
+++ b/modelforge/utils/__init__.py
@@ -1,0 +1,1 @@
+"""modelforge utilities."""

--- a/modelforge/utils/zenodo.py
+++ b/modelforge/utils/zenodo.py
@@ -1,9 +1,70 @@
 """Module for fetching datafiles from zenodo"""
 
 import requests
+
+from urllib.parse import urlparse
 from typing import Optional
 
-def fetch_url_from_doi(doi: str, timeout: Optional[int]= 10) -> str:
+
+def is_url(query: str, hostname: str) -> bool:
+    """Validate if a string is a URL associated with a given domain.
+
+    Parameters
+    ----------
+    query : str, required
+        The string to check.
+    hostname : str, required
+        Check if the query URL domain includes the hostname.
+
+    Returns
+    -------
+    bool
+        If True, the string is a url where the domain
+        includes the specified hostname.
+    """
+
+    # parse the url
+    parsed = urlparse(query)
+    # if the string does not start with http
+    # we will just return false
+    if not "http" in parsed.scheme:
+        return False
+    # check to see if hostname is part of the url domain
+    if not hostname in parsed.netloc:
+        return False
+    return True
+
+
+def parse_zenodo_record_id_from_url(url: str) -> str:
+    """Return the record id from a zenodo.org record URL.
+
+    This function will raise an exception if the URL
+    is malformed. Expected format:
+    https://zenodo.org/record/{RECORD_ID}
+
+    Parameters
+    ----------
+    url : str, required
+        The url to parse.
+    Returns
+    -------
+    record_id : str
+        Zenodo record id.
+    """
+    parsed = urlparse(url)
+
+    parsed_path = list(filter(None, parsed.path.split("/")))
+
+    # make sure that we only have two elements in the path
+    # part of the url, namely ['record', f'{record_id}']
+    if len(parsed_path) != 2:
+        raise Exception(f"Malformed zenodo.org record URL: {url}.")
+    record_id = parsed_path[-1]
+
+    return record_id
+
+
+def fetch_url_from_doi(doi: str, timeout: Optional[int] = 10) -> str:
     """Retrieve URL associated with a DOI.
 
     Parameters
@@ -19,8 +80,9 @@ def fetch_url_from_doi(doi: str, timeout: Optional[int]= 10) -> str:
         The target URL linked to the DOI.
     """
 
-    doi_org_url = 'https://dx.doi.org/'
-    if doi.startswith('http'):
+    doi_org_url = "https://dx.doi.org/"
+
+    if is_url(doi, hostname="doi.org"):
         input_url = doi
     else:
         input_url = doi_org_url + doi
@@ -28,14 +90,17 @@ def fetch_url_from_doi(doi: str, timeout: Optional[int]= 10) -> str:
     try:
         response = requests.get(input_url, timeout=timeout)
     except requests.exceptions.ConnectTimeout:
-        raise Exception('Fetching url for DOI timed out.')
+        raise Exception("Fetching url for DOI timed out.")
 
     if not response.ok:
-        raise Exception(f'{doi} could not be accessed.')
+        raise Exception(f"{doi} could not be accessed.")
 
     return response.url
 
-def get_zenodo_datafiles(record_id: str, file_extension: str, timeout: Optional[int]= 10)-> str:
+
+def get_zenodo_datafiles(
+    record_id: str, file_extension: str, timeout: Optional[int] = 10
+) -> str:
     """Retrieve link(s) to datafiles on zenodo with a given extension.
 
     Parameters
@@ -53,35 +118,36 @@ def get_zenodo_datafiles(record_id: str, file_extension: str, timeout: Optional[
         Direct links to files with the given file extension.
     """
 
-    zenodo_base = 'https://zenodo.org/api/records/'
+    zenodo_base = "https://zenodo.org/api/records/"
 
-    #if we are provided the url, santize
-    if record_id.startswith('http'):
-        record_id = record_id.split('/')[-1]
+    # if we are provided the url, santize
+    if is_url(record_id, "zenodo.org"):
+        record_id = parse_zenodo_record_id_from_url(record_id)
 
     zenodo_api_url = zenodo_base + record_id
 
     try:
         data_request = requests.get(zenodo_api_url, timeout=timeout)
     except requests.exceptions.ConnectTimeout:
-        raise Exception('Attempt to access Zenodo timed out')
+        raise Exception("Attempt to access Zenodo timed out")
 
     if not data_request.ok:
-        raise Exception(f'Record id {record_id} could not be accessed.')
+        raise Exception(f"Record id {record_id} could not be accessed.")
 
     # grab the data from zenodo
     json_content = data_request.json()
-    files = json_content['files']
+    files = json_content["files"]
 
     # search through the list of files to find those with desired extension
     data_urls = []
     for file in files:
-        if file['links']['self'].endswith(file_extension):
-            data_urls.append(file['links']['self'])
+        if file["links"]["self"].endswith(file_extension):
+            data_urls.append(file["links"]["self"])
 
     return data_urls
 
-def hdf5_from_zenodo(record: str)->str:
+
+def hdf5_from_zenodo(record: str) -> str:
     """For a given zenodo DOI or record_id, return links to all hdf5 files.
 
     Parameters
@@ -99,21 +165,21 @@ def hdf5_from_zenodo(record: str)->str:
     """
     record_is_doi = True
     # first determine if we are dealing with a doi or a record_id
-    if 'zenodo.org/record/' in record:
+    if is_url(record, hostname="zenodo.org"):
         record_is_doi = False
-    elif not 'zenodo.' in record.split('/')[-1]:
+    elif is_url(record, hostname="doi.org"):
+        record_is_doi = True
+    elif not "zenodo." in record.split("/")[-1]:
         record_is_doi = False
 
     if record_is_doi:
         record_id = fetch_url_from_doi(record)
-        data_urls = get_zenodo_datafiles(record_id, file_extension='hdf5.gz')
+        data_urls = get_zenodo_datafiles(record_id, file_extension="hdf5.gz")
     else:
-        data_urls = get_zenodo_datafiles(record, file_extension='hdf5.gz')
+        data_urls = get_zenodo_datafiles(record, file_extension="hdf5.gz")
 
     # Make sure files were found.
     if len(data_urls) == 0:
         raise Exception(f"No files with extension hdf5.gz were found.")
 
     return data_urls
-
-

--- a/modelforge/utils/zenodo.py
+++ b/modelforge/utils/zenodo.py
@@ -1,0 +1,96 @@
+"""Module for fetching datafiles from zenodo"""
+
+import requests
+from typing import Optional
+
+def fetch_record_id_from_doi(doi: str, timeout: Optional[int]= 10) -> str:
+    """Retrieve URL associated with a DOI.
+
+    Parameters
+    ----------
+    doi : str, required
+        The DOI to be considered.  This can be formatted as a URL.
+    timeout : int, optional, default=10
+        The number of seconds to wait to establish a connection
+
+    Returns
+    -------
+    url : str
+        The target URL linked to the DOI.
+    """
+
+    doi_org_url = 'https://dx.doi.org/'
+    if doi.startswith('http'):
+        input_url = doi
+    else:
+        input_url = doi_org_url + doi
+
+    try:
+        response = requests.get(input_url, timeout=timeout)
+    except requests.exceptions.ConnectTimeout:
+        raise Exception('Fetching url for DOI timed out.')
+
+    if not response.ok:
+        raise Exception(f'{doi} could not be accessed.')
+
+    # the record id is stored at the end of the url
+    # e.g., https://zenodo.org/record/3588339
+    return response.url.split('/')[-1]
+
+def get_zenodo_datafiles(record_id: str, file_extension: str, timeout: Optional[int]= 10)-> str:
+    """Retrieve link(s) to datafiles on zenodo with a given extension.
+
+    Parameters
+    ----------
+    record_id : str, required
+        zenodo.org record id
+    file_extension : str, required
+        Return file(s) with extensions that match file_extension
+    timeout : int, optional, default=10
+        The number of seconds to wait to establish a connection
+
+    Returns
+    -------
+    data_urls : list-like object, dtype=str
+        Direct links to files with the given file extension.
+    """
+
+    zenodo_base = 'https://zenodo.org/api/records/'
+    zenodo_api_url = zenodo_base + record_id
+
+    try:
+        data_request = requests.get(zenodo_api_url, timeout=timeout)
+    except requests.exceptions.ConnectTimeout:
+        raise Exception('Attempt to access Zenodo timed out')
+
+    if not data_request.ok:
+        raise Exception(f'Record id {record_id} could not be accessed.')
+
+    # grab the data from zenodo
+    json_content = data_request.json()
+    files = json_content['files']
+
+    # search through the list of files to find those with desired extension
+    data_urls = []
+    for file in files:
+        if file['links']['self'].endswith(file_extension):
+            data_urls.append(file['links']['self'])
+
+    return data_urls
+
+def hdf5_from_zenodo_doi(doi: str)->str:
+    """For a given zenodo DOI, return links to all hdf5 files.
+
+    Parameters
+    ----------
+    doi : str, required
+        The Zenodo DOI to be considered.  This can be formatted as a URL.
+    Returns
+    -------
+    data_urls : list-like object, dtype=str
+        Direct links to files with the given file extension.
+    """
+    record_id = fetch_record_id_from_doi(doi)
+    data_urls = get_zenodo_datafiles(record_id, file_extension='hdf5.gz')
+
+    return data_urls

--- a/modelforge/utils/zenodo.py
+++ b/modelforge/utils/zenodo.py
@@ -92,17 +92,29 @@ def hdf5_from_zenodo(record: str)->str:
         This can be either Zenodo DOI or Zenodo record id.
         Either of these can be formatted as a URL, e.g.,
         https://dx.doi.org/{DOI} or https://zenodo.org/record/{record_id}
+        Note: this assumes files on Zenodo are gzipped (i.e., extension hdf5.gz).
+
     Returns
     -------
-    data_urls : list-like object, dtype=str
-        Direct links to files with the given file extension.
+    data_urls : list-like, dtype=str
+        Direct link to gzipped hdf5 files.
     """
-    #if we are provided record url or record_id
-    if 'zenodo.org/record/' in record or not 'zenodo.' in record:
-        data_urls = get_zenodo_datafiles(record, file_extension='hdf5.gz')
-    else: # otherwise we have been given a DOI.
+    record_is_doi = True
+    # first determine if we are dealing with a doi or a record_id
+    if 'zenodo.org/record/' in record:
+        record_is_doi = False
+    elif not 'zenodo.' in record.split('/')[-1]:
+        record_is_doi = False
+
+    if record_is_doi:
         record_id = fetch_record_id_from_doi(record)
         data_urls = get_zenodo_datafiles(record_id, file_extension='hdf5.gz')
+    else:
+        data_urls = get_zenodo_datafiles(record, file_extension='hdf5.gz')
+
+    # Make sure files were found.
+    if len(data_urls) != 0:
+        raise Exception(f"No files with extension hdf5.gz were found.")
 
     return data_urls
 

--- a/modelforge/utils/zenodo.py
+++ b/modelforge/utils/zenodo.py
@@ -3,7 +3,7 @@
 import requests
 from typing import Optional
 
-def fetch_record_id_from_doi(doi: str, timeout: Optional[int]= 10) -> str:
+def fetch_url_from_doi(doi: str, timeout: Optional[int]= 10) -> str:
     """Retrieve URL associated with a DOI.
 
     Parameters
@@ -33,9 +33,7 @@ def fetch_record_id_from_doi(doi: str, timeout: Optional[int]= 10) -> str:
     if not response.ok:
         raise Exception(f'{doi} could not be accessed.')
 
-    # the record id is stored at the end of the url
-    # e.g., https://zenodo.org/record/3588339
-    return response.url.split('/')[-1]
+    return response.url
 
 def get_zenodo_datafiles(record_id: str, file_extension: str, timeout: Optional[int]= 10)-> str:
     """Retrieve link(s) to datafiles on zenodo with a given extension.
@@ -107,13 +105,13 @@ def hdf5_from_zenodo(record: str)->str:
         record_is_doi = False
 
     if record_is_doi:
-        record_id = fetch_record_id_from_doi(record)
+        record_id = fetch_url_from_doi(record)
         data_urls = get_zenodo_datafiles(record_id, file_extension='hdf5.gz')
     else:
         data_urls = get_zenodo_datafiles(record, file_extension='hdf5.gz')
 
     # Make sure files were found.
-    if len(data_urls) != 0:
+    if len(data_urls) == 0:
         raise Exception(f"No files with extension hdf5.gz were found.")
 
     return data_urls

--- a/modelforge/utils/zenodo.py
+++ b/modelforge/utils/zenodo.py
@@ -43,7 +43,7 @@ def get_zenodo_datafiles(record_id: str, file_extension: str, timeout: Optional[
     Parameters
     ----------
     record_id : str, required
-        zenodo.org record id
+        zenodo.org record id.  Can also provide url to a record.
     file_extension : str, required
         Return file(s) with extensions that match file_extension
     timeout : int, optional, default=10
@@ -56,6 +56,11 @@ def get_zenodo_datafiles(record_id: str, file_extension: str, timeout: Optional[
     """
 
     zenodo_base = 'https://zenodo.org/api/records/'
+
+    #if we are provided the url, santize
+    if record_id.startswith('http'):
+        record_id = record_id.split('/')[-1]
+
     zenodo_api_url = zenodo_base + record_id
 
     try:
@@ -78,19 +83,27 @@ def get_zenodo_datafiles(record_id: str, file_extension: str, timeout: Optional[
 
     return data_urls
 
-def hdf5_from_zenodo_doi(doi: str)->str:
-    """For a given zenodo DOI, return links to all hdf5 files.
+def hdf5_from_zenodo_doi(record: str)->str:
+    """For a given zenodo DOI or record_id, return links to all hdf5 files.
 
     Parameters
     ----------
-    doi : str, required
-        The Zenodo DOI to be considered.  This can be formatted as a URL.
+    record : str, required
+        This can be either Zenodo DOI or Zenodo record id.
+        Either of these can be formatted as a URL, e.g.,
+        https://dx.doi.org/{DOI} or https://zenodo.org/record/{record_id}
     Returns
     -------
     data_urls : list-like object, dtype=str
         Direct links to files with the given file extension.
     """
-    record_id = fetch_record_id_from_doi(doi)
-    data_urls = get_zenodo_datafiles(record_id, file_extension='hdf5.gz')
+    #if we are provided record url or record_id
+    if 'zenodo.org/record/' in record or not 'zenodo.' in record:
+        data_urls = get_zenodo_datafiles(record, file_extension='hdf5.gz')
+    else: # otherwise we have been given a DOI.
+        record_id = fetch_record_id_from_doi(record)
+        data_urls = get_zenodo_datafiles(record_id, file_extension='hdf5.gz')
 
     return data_urls
+
+

--- a/modelforge/utils/zenodo.py
+++ b/modelforge/utils/zenodo.py
@@ -83,7 +83,7 @@ def get_zenodo_datafiles(record_id: str, file_extension: str, timeout: Optional[
 
     return data_urls
 
-def hdf5_from_zenodo_doi(record: str)->str:
+def hdf5_from_zenodo(record: str)->str:
     """For a given zenodo DOI or record_id, return links to all hdf5 files.
 
     Parameters


### PR DESCRIPTION
## Description
This PR provides a set of functions that will take a zenodo DOI (or zenodo record id) and return the direct link to the associated datafiles (e.g., the gzipped hdf5 files).  

Currently 3 functions have been defined:

* `fetch_url_from_doi` -- for a given DOI, return the associated URL
* `get_zenodo_datafiles` -- for a given zenodo record_id, return all datafiles that match a given file extension
* `hdf5_from_zenodo` -- a wrapper that will return a list of the .hdf5.gz files for a given DOI or record_id

The `hdf5_from_zenodo` function can accept either a zenodo DOI or zenodo record id; additionally, the code will sanitize the input if either of those are passed as urls.  For example, all of the following are equally valid (and in this case equivalent):

```
files = hdf5_from_zenodo('10.5281/zenodo.3588339')
files = hdf5_from_zenodo('https://dx.doi.org/10.5281/zenodo.3588339')
files = hdf5_from_zenodo('https://zenodo.org/record/3588339')
files = hdf5_from_zenodo('588339')
```

I'll note that, if the user provides a DOI (or URL with a DOI) to hdf5_from_zenodo, it will put in a request to doi.org to get the appropriate zenodo url;  that url is then used to extract the zenodo record_id.  This is likely unnecessary, given that the record_id is the numeric portion of the DOI suffix (i.e., the numbers in: `zenodo.3588339`).   This step could probably be skipped in favor of just extracting record_id from the DOI directly, but it is probably safer to just query doi.org as it does not require us to assume the structure of the DOI and doesn't really add much in the way of overhead.

