### PR TITLE
Pedantic is on conda-forge now

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,6 +21,7 @@ dependencies:
   - torchvision
   - openff-units
   - pint
+  - pedantic
 
     # Testing
   - pytest
@@ -29,8 +30,3 @@ dependencies:
   - qcelemental=0.25.1
   - qcportal
   - requests
-
-    # Pip-only installs
-  - pip:
-      - pedantic
-  #  - codecov


### PR DESCRIPTION
This PR installs pedantic from conda-forge now instead of pypi