### PR TITLE
Added in reference energy calculation for qm9.  

### DIFF
--- a/modelforge/curation/qm9_curation.py
+++ b/modelforge/curation/qm9_curation.py
@@ -110,10 +110,6 @@ class QM9Curation(DatasetCuration):
                 "u_in": unit.hartree,
                 "u_out": unit.kilojoule_per_mole,
             },
-            "formation_energy_at_298.15K": {
-                "u_in": unit.hartree,
-                "u_out": unit.kilojoule_per_mole,
-            },
             "reference_energy_at_298.15K": {
                 "u_in": unit.hartree,
                 "u_out": unit.kilojoule_per_mole,
@@ -122,7 +118,15 @@ class QM9Curation(DatasetCuration):
                 "u_in": unit.hartree,
                 "u_out": unit.kilojoule_per_mole,
             },
+            "reference_enthalpy_at_298.15K": {
+                "u_in": unit.hartree,
+                "u_out": unit.kilojoule_per_mole,
+            },
             "free_energy_at_298.15K": {
+                "u_in": unit.hartree,
+                "u_out": unit.kilojoule_per_mole,
+            },
+            "reference_free_energy_at_298.15K": {
                 "u_in": unit.hartree,
                 "u_out": unit.kilojoule_per_mole,
             },
@@ -140,7 +144,8 @@ class QM9Curation(DatasetCuration):
                 "u_out": unit.cm**-1,
             },
         }
-
+        # reference thermochemical data for each atom as provided in the atomref.txt file  provided in the publication
+        # Direct link to the atomref.txt datafile: https://ndownloader.figstatic.com/files/3195395
         self.thermochemical_references = {
             "H": {
                 "ZPVE": 0.000000 * unit.hartree,
@@ -216,10 +221,11 @@ class QM9Curation(DatasetCuration):
             "formation_energy_at_0K": "series_mol",
             "reference_energy_at_0K": "series_mol",
             "internal_energy_at_298.15K": "series_mol",
-            "formation_energy_at_298.15K": "series_mol",
             "reference_energy_at_298.15K": "series_mol",
             "enthalpy_at_298.15K": "series_mol",
+            "reference_enthalpy_at_298.15K": "series_mol",
             "free_energy_at_298.15K": "series_mol",
+            "reference_free_energy_at_298.15K": "series_mol",
             "heat_capacity_at_298.15K": "series_mol",
             "harmonic_vibrational_frequencies": "series_mol",
         }
@@ -463,16 +469,29 @@ class QM9Curation(DatasetCuration):
             U_ref_298K = self._calculate_reference_thermochemistry(
                 elements, "U_298.15K"
             )
+            H_ref_298K = self._calculate_reference_thermochemistry(
+                elements, "H_298.15K"
+            )
+            G_ref_298K = self._calculate_reference_thermochemistry(
+                elements, "G_298.15K"
+            )
 
-            data_temp["reference_energy_at_0K"] = U_ref_0K
-            data_temp["reference_energy_at_298.15K"] = U_ref_298K
+            data_temp["reference_energy_at_0K"] = (
+                np.array(U_ref_0K.m).reshape(1, 1) * U_ref_0K.u
+            )
+            data_temp["reference_energy_at_298.15K"] = (
+                np.array(U_ref_298K.m).reshape(1, 1) * U_ref_298K.u
+            )
+            data_temp["reference_enthalpy_at_298.15K"] = (
+                np.array(H_ref_298K.m).reshape(1, 1) * H_ref_298K.u
+            )
+
+            data_temp["reference_free_energy_at_298.15K"] = (
+                np.array(G_ref_298K.m).reshape(1, 1) * G_ref_298K.u
+            )
 
             data_temp["formation_energy_at_0K"] = (
                 data_temp["internal_energy_at_0K"] - data_temp["reference_energy_at_0K"]
-            )
-            data_temp["formation_energy_at_298.15K"] = (
-                data_temp["internal_energy_at_298.15K"]
-                - data_temp["reference_energy_at_298.15K"]
             )
 
             for h in hvf_temp:

--- a/modelforge/curation/spice_openff_curation.py
+++ b/modelforge/curation/spice_openff_curation.py
@@ -279,11 +279,16 @@ class SPICE12PubChemOpenFFCuration(DatasetCuration):
             Path to the directory that contains the raw hdf5 datafile
         filenames: List[str], required
             Names of the raw sqlite files to process,
-        unit_testing_max_records: int, optional, default=None
-            If set to an integer ('n') the routine will only process the first 'n' records; useful for unit tests.
+        dataset_names: List[str], required
+            List of names of the sqlite datasets to process.
 
         Examples
         --------
+        >>> spice_openff_data = SPICE12PubChemOpenFFCuration(hdf5_file_name='spice_pubchem_12_openff_dataset.hdf5',
+        >>>                             local_cache_dir='~/datasets/spice12_openff_dataset')
+        >>> spice_openff_data._process_downloaded(local_path_dir='~/datasets/spice12_openff_dataset',
+        >>>                                      filenames=['spice_pubchem_set1_v1.2.sqlite'],
+        >>>                                      dataset_names=['SPICE PubChem Set 1 Single Points Dataset v1.2'])
         """
         from tqdm import tqdm
         import numpy as np

--- a/modelforge/tests/test_curation.py
+++ b/modelforge/tests/test_curation.py
@@ -227,6 +227,19 @@ def test_qm9_curation_init_parameters(prep_temp_dir):
     assert qm9_data.convert_units == False
 
 
+def test_qm9_reference_energy(prep_temp_dir):
+    qm9_data = QM9Curation(
+        hdf5_file_name="qm9_dataset.hdf5",
+        output_file_dir=str(prep_temp_dir),
+        local_cache_dir=str(prep_temp_dir),
+        convert_units=True,
+    )
+    assert (
+        qm9_data._calculate_reference_thermochemistry(["C", "H", "H", "H", "H"], "U_0K")
+        == -39.847864 * unit.hartree
+    )
+
+
 def test_qm9_curation_parse_xyz(prep_temp_dir):
     qm9_data = QM9Curation(
         hdf5_file_name="qm9_dataset.hdf5",
@@ -342,6 +355,10 @@ def test_qm9_curation_parse_xyz(prep_temp_dir):
         )
         / unit.centimeter
     )
+    assert data_dict_temp["reference_energy_at_0K"] == -39.847864 * unit.hartree
+    assert data_dict_temp["formation_energy_at_0K"] == -0.631066 * unit.hartree
+    assert data_dict_temp["reference_energy_at_298.15K"] == -39.840783 * unit.hartree
+    assert data_dict_temp["formation_energy_at_298.15K"] == -0.635279 * unit.hartree
 
 
 def test_qm9_local_archive(prep_temp_dir):

--- a/modelforge/tests/test_curation.py
+++ b/modelforge/tests/test_curation.py
@@ -355,10 +355,26 @@ def test_qm9_curation_parse_xyz(prep_temp_dir):
         )
         / unit.centimeter
     )
-    assert data_dict_temp["reference_energy_at_0K"] == -39.847864 * unit.hartree
-    assert data_dict_temp["formation_energy_at_0K"] == -0.631066 * unit.hartree
-    assert data_dict_temp["reference_energy_at_298.15K"] == -39.840783 * unit.hartree
-    assert data_dict_temp["formation_energy_at_298.15K"] == -0.635279 * unit.hartree
+    assert np.allclose(
+        data_dict_temp["reference_energy_at_0K"],
+        np.array([-39.847864]).reshape(1, 1) * unit.hartree,
+    )
+    assert np.allclose(
+        data_dict_temp["formation_energy_at_0K"],
+        np.array([-0.631066]).reshape(1, 1) * unit.hartree,
+    )
+    assert np.allclose(
+        data_dict_temp["reference_energy_at_298.15K"],
+        np.array([-39.840783]).reshape(1, 1) * unit.hartree,
+    )
+    assert np.allclose(
+        data_dict_temp["reference_enthalpy_at_298.15K"],
+        np.array([-39.836059]).reshape(1, 1) * unit.hartree,
+    )
+    assert np.allclose(
+        data_dict_temp["reference_free_energy_at_298.15K"],
+        np.array([-39.905025]).reshape(1, 1) * unit.hartree,
+    )
 
 
 def test_qm9_local_archive(prep_temp_dir):


### PR DESCRIPTION
Reference energy (i.e., energy of the constituent atoms in vacuum) is computed for the QM9 dataset from the data made available in the paper SI; other thermochemical properties calculated and added to the datafile, reference energy at 298.15K, reference enthalpy at 298.15K and reference free energy at 298.15K.    This formation energy is also calculated and added to the data files for 0K (i.e., internal energy - reference energy).

equivalent shifted enthalpy, free energy, and internal energy at 298.15K could also be calculated, but given the very close similarity to internal energy at 0K (and the fact we will be training off internal energy at 0K), I do not think this will be necessary; of course, since the references are provided for each of these, they could be calculated by a user 

## Status
- [x] Ready to go