### PR TITLE
Keep input dimensions consisten

### DIFF
--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -169,9 +169,9 @@ class AbstractBaseNNP(nn.Module, ABC):
         Parameters
         ----------
         inputs : Dict[str, torch.Tensor]
-            - 'atomic_numbers', shape (nr_systems, nr_atoms), 0 indicates non-interacting atoms that will be masked
-            - 'total_charge', shape (nr_systems, 1)
-            - 'positions', shape (n_atoms, 3)
+            - 'atomic_numbers', shape (nr_of_atoms_in_batch, *, *), 0 indicates non-interacting atoms that will be masked
+            - 'total_charge', shape (nr_of_atoms_in_batch, 1)
+            - 'positions', shape (nr_of_atoms_in_batch, 3)
             - 'boxvectors', shape (3, 3)
 
         Returns
@@ -194,8 +194,8 @@ class AbstractBaseNNP(nn.Module, ABC):
             - pairlist, shape (n_paris,2)
             - r_ij, shape (n_pairs, 1)
             - d_ij, shape (n_pairs, 3)
-            - 'atomic_subsystem_indices' (optional), shape n_atoms
-            - positions, shape (n_systems, n_atoms, 3)
+            - 'atomic_subsystem_indices' (optional), shape nr_of_atoms_in_batch
+            - positions, shape (nr_of_atoms_in_batch, 3)
 
         """
         pass
@@ -277,7 +277,7 @@ class BaseNNP(AbstractBaseNNP):
         ----------
         inputs : Dict[str, torch.Tensor]
             Inputs containing atomic numbers ('atomic_numbers'), coordinates ('positions') and pairlist ('pairlist').
-            - 'atomic_numbers': int; shape (nr_of_atoms_in_batch, 1), 0 indicates non-interacting atoms that will be masked
+            - 'atomic_numbers': int; shape (nr_of_atoms_in_batch, *,*), 0 indicates non-interacting atoms that will be masked
             - 'total_charge' : int; shape (n_system)
             - 'positions': float; shape (nr_of_atoms_in_batch, 3)
 
@@ -289,8 +289,8 @@ class BaseNNP(AbstractBaseNNP):
         """
         self.input_checks(inputs)
         nr_of_atoms_in_batch = inputs["atomic_numbers"].shape[0]
-        atomic_numbers = inputs["atomic_numbers"]  # shape (nr_of_atoms_in_batch, *,*)
-        positions = inputs["positions"]  # shape (nr_of_atoms_in_batch, 3)
+        atomic_numbers = inputs["atomic_numbers"]
+        positions = inputs["positions"]
         atomic_subsystem_indices = inputs["atomic_subsystem_indices"]
 
         r = self.calculate_distances_and_pairlist(positions, atomic_subsystem_indices)
@@ -330,11 +330,11 @@ class SingleTopologyAlchemicalBaseNNPModel(AbstractBaseNNP):
         ----------
         inputs : Dict[str, torch.Tensor]
             Inputs containing atomic numbers ('atomic_numbers'), coordinates ('positions') and pairlist ('pairlist').
-            - 'atomic_numbers': shape (n_systems:int, n_atoms:int), 0 indicates non-interacting atoms that will be masked
-            - 'total_charge' : shape (n_system:int)
-            - (only for alchemical transformation) 'alchemical_atomic_number': shape (n_atoms:int)
+            - 'atomic_numbers': shape (nr_of_atoms_in_batch, *, *), 0 indicates non-interacting atoms that will be masked
+            - 'total_charge' : shape (nr_of_atoms_in_batch)
+            - (only for alchemical transformation) 'alchemical_atomic_number': shape (nr_of_atoms_in_batch)
             - (only for alchemical transformation) 'lamb': float
-            - 'positions': shape (n_atoms, 3)
+            - 'positions': shape (nr_of_atoms_in_batch, 3)
 
         Returns
         -------

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -283,9 +283,7 @@ class BaseNNP(AbstractBaseNNP):
 
         """
         self.input_checks(inputs)
-        atomic_numbers = inputs["atomic_numbers"].squeeze(
-            dim=1
-        )  # shape (nr_of_atoms_in_batch, 3)
+        atomic_numbers = inputs["atomic_numbers"]  # shape (nr_of_atoms_in_batch, 3)
         positions = inputs["positions"]  # shape (nr_of_atoms_in_batch, 3)
         atomic_subsystem_indices = inputs["atomic_subsystem_indices"]
 

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -262,7 +262,7 @@ class BaseNNP(AbstractBaseNNP):
 
         super().__init__()
         self.calculate_distances_and_pairlist = PairList(cutoff)
-        self.embedding = embedding  # nn.Embedding(nr_of_embeddings, nr_atom_basis)
+        self.embedding = embedding 
         assert isinstance(
             self.embedding, SlicedEmbedding
         ), "embedding must be SlicedEmbedding"

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -262,6 +262,10 @@ class BaseNNP(AbstractBaseNNP):
         super().__init__()
         self.calculate_distances_and_pairlist = PairList(cutoff)
         self.embedding = embedding  # nn.Embedding(nr_of_embeddings, nr_atom_basis)
+        assert isinstance(
+            self.embedding, nn.Embedding
+        ), "embedding must be nn.Embedding"
+        assert embedding.embedding_dim > 0, "embedding_dim must be > 0"
         self.nr_atom_basis = embedding.embedding_dim
 
     def forward(self, inputs: Dict[str, torch.Tensor]) -> torch.Tensor:
@@ -283,7 +287,8 @@ class BaseNNP(AbstractBaseNNP):
 
         """
         self.input_checks(inputs)
-        atomic_numbers = inputs["atomic_numbers"]  # shape (nr_of_atoms_in_batch, 3)
+        nr_of_atoms_in_batch = inputs["atomic_numbers"].shape[0]
+        atomic_numbers = inputs["atomic_numbers"]  # shape (nr_of_atoms_in_batch, 1)
         positions = inputs["positions"]  # shape (nr_of_atoms_in_batch, 3)
         atomic_subsystem_indices = inputs["atomic_subsystem_indices"]
 
@@ -291,6 +296,12 @@ class BaseNNP(AbstractBaseNNP):
         atomic_numbers_embedding = self.embedding(
             atomic_numbers
         )  # shape (nr_of_atoms_in_batch, n_atom_basis)
+        assert atomic_numbers_embedding.shape == (
+            nr_of_atoms_in_batch,
+            1,
+            self.nr_atom_basis,
+        )
+
         inputs = {
             "pair_indices": r["pair_indices"],
             "d_ij": r["d_ij"],

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -33,7 +33,7 @@ class PaiNN(BaseNNP):
         """
         Parameters
             ----------
-            embedding : torch.Module, contains atomic species embedding. 
+            embedding : torch.Module, contains atomic species embedding.
                 Embedding dimensions also define self.n_atom_basis.
             nr_interaction_blocks : int
                 Number of interaction blocks.
@@ -60,6 +60,13 @@ class PaiNN(BaseNNP):
         super().__init__(embedding)
 
         self.n_atom_basis = embedding.embedding_dim
+
+        log.debug("Initializing PaiNN model.")
+        log.debug(
+            f"Passed parameters to constructor: {self.nr_atom_basis=}, {nr_interaction_blocks=}, {cutoff=}"
+        )
+        log.debug(f"Initialized embedding: {embedding=}")
+
         self.nr_interaction_blocks = nr_interaction_blocks
         self.radial_basis = radial_basis
         self.cutoff = cutoff
@@ -111,8 +118,11 @@ class PaiNN(BaseNNP):
 
         # extract properties from pairlist
         d_ij = inputs["d_ij"].unsqueeze(-1)  # n_pairs, 1
+        nr_of_atoms_in_batch = inputs["atomic_numbers_embedding"].shape[0]
         r_ij = inputs["r_ij"]
-        atomic_numbers_embedding = inputs["atomic_numbers_embedding"]
+        atomic_numbers_embedding = inputs["atomic_numbers_embedding"].view(
+            nr_of_atoms_in_batch, -1
+        )
         qs = atomic_numbers_embedding.shape
 
         q = atomic_numbers_embedding.reshape(qs[0], 1, qs[1])

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -118,11 +118,8 @@ class PaiNN(BaseNNP):
 
         # extract properties from pairlist
         d_ij = inputs["d_ij"].unsqueeze(-1)  # n_pairs, 1
-        nr_of_atoms_in_batch = inputs["atomic_numbers_embedding"].shape[0]
         r_ij = inputs["r_ij"]
-        atomic_numbers_embedding = inputs["atomic_numbers_embedding"].view(
-            nr_of_atoms_in_batch, -1
-        )
+        atomic_numbers_embedding = inputs["atomic_numbers_embedding"]
         qs = atomic_numbers_embedding.shape
 
         q = atomic_numbers_embedding.reshape(qs[0], 1, qs[1])

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -272,10 +272,6 @@ class PaiNNInteraction(nn.Module):
         )
         expanded_idx_i_dmu = idx_i.view(-1, 1, 1).expand_as(dmu)
         dmu_result_native.scatter_add_(0, expanded_idx_i_dmu, dmu)
-        # dmu_results_custom = snn.scatter_add(
-        #    dmu, idx_i, dim_size=nr_of_atoms_in_all_systems
-        # )
-        # assert torch.allclose(dmu_results_custom, dmu_result_native)
 
         q = q + dq_result_native  # .view(nr_of_atoms_in_all_systems)
         mu = mu + dmu_result_native

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -84,8 +84,7 @@ class SchNET(BaseNNP):
         representation = self.schnet_representation(
             inputs["d_ij"]
         )  
-        nr_of_atoms_in_batch = inputs["atomic_numbers_embedding"].shape[0]
-        x = inputs["atomic_numbers_embedding"].view(nr_of_atoms_in_batch, -1) # shape (nr_of_atoms_in_batch)
+        x = inputs["atomic_numbers_embedding"]
         # Iterate over interaction blocks to update features
         for interaction in self.interactions:
             v = interaction(

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -6,25 +6,66 @@ import torch.nn as nn
 
 
 class SlicedEmbedding(nn.Module):
-    def __init__(
-        self, numbers_of_atoms_in_batch: int, embedding_dim: int, sliced_dim: int = 1
-    ):
+    """
+    A module that performs embedding on a selected slice of input tensor.
+
+    Parameters
+    ----------
+    max_Z : int
+        Highest atomic number to embed, this will define the upper bound of the vocabulary that is used for embedding.
+    embedding_dim : int
+        Size of the embedding.
+    sliced_dim : int, optional
+        The dimension along which to slice the input tensor (default is 0).
+        This is relevant since the input dimensions are (n_atoms_in_batch, nr_of_properties, property_size), but we want to embed a specific
+        property.
+
+    Attributes
+    ----------
+    embedding : nn.Embedding
+        The embedding layer.
+    sliced_dim : int
+        The dimension along which the input tensor is sliced.
+
+    Methods
+    -------
+    forward(x)
+        Forward pass for the Embedding.
+
+    Properties
+    ----------
+    embedding_dim : int
+        The dimensionality of the embedding.
+
+    """
+
+    def __init__(self, max_Z: int, embedding_dim: int, sliced_dim: int = 0):
         """
         Initialize the Embedding class.
 
         Parameters
         ----------
-        numbers_of_atoms_in_batch : int
-            Number of atom types.
+        max_Z : int
+            Highest atomic numbers.
         embedding_dim : int
             Dimensionality of the embedding.
+        sliced_dim : int, optional
+            The dimension along which to slice the input tensor (default is 0).
         """
         super().__init__()
-        self.embedding = nn.Embedding(numbers_of_atoms_in_batch, embedding_dim)
+        self.embedding = nn.Embedding(max_Z, embedding_dim)
         self.sliced_dim = sliced_dim
 
     @property
     def embedding_dim(self):
+        """
+        Get the dimensionality of the embedding.
+
+        Returns
+        -------
+        int
+            The dimensionality of the embedding.
+        """
         return self.embedding.embedding_dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -42,7 +83,6 @@ class SlicedEmbedding(nn.Module):
             The output tensor.
         """
         selected_tensor = x[:, self.sliced_dim, ...]
-        
 
         return self.embedding(selected_tensor)
 
@@ -334,7 +374,7 @@ def neighbor_pairs_nopbc(
     # generate index grid
     n = len(atomic_subsystem_indices)
     i_indices, j_indices = torch.triu_indices(n, n, 1)
-    print(atomic_subsystem_indices[i_indices])
+
     # filter pairs to only keep those belonging to the same molecule
     same_molecule_mask = (
         atomic_subsystem_indices[i_indices] == atomic_subsystem_indices[j_indices]
@@ -351,10 +391,6 @@ def neighbor_pairs_nopbc(
     pair_coordinates = positions[pair_indices.T]
     pair_coordinates = pair_coordinates.view(-1, 2, 3)
 
-    # Calculate distances
-    distances = (pair_coordinates[:, 0, :] - pair_coordinates[:, 1, :]).norm(
-        p=2, dim=-1
-    )
     # Calculate distances
     distances = (pair_coordinates[:, 0, :] - pair_coordinates[:, 1, :]).norm(
         p=2, dim=-1

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -42,6 +42,7 @@ class SlicedEmbedding(nn.Module):
             The output tensor.
         """
         selected_tensor = x[:, self.sliced_dim, ...]
+        
 
         return self.embedding(selected_tensor)
 

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -5,6 +5,47 @@ import torch
 import torch.nn as nn
 
 
+class SlicedEmbedding(nn.Module):
+    def __init__(
+        self, numbers_of_atoms_in_batch: int, embedding_dim: int, sliced_dim: int = 1
+    ):
+        """
+        Initialize the Embedding class.
+
+        Parameters
+        ----------
+        numbers_of_atoms_in_batch : int
+            Number of atom types.
+        embedding_dim : int
+            Dimensionality of the embedding.
+        """
+        super().__init__()
+        self.embedding = nn.Embedding(numbers_of_atoms_in_batch, embedding_dim)
+        self.sliced_dim = sliced_dim
+
+    @property
+    def embedding_dim(self):
+        return self.embedding.embedding_dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for the Embedding.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor for the forward pass.
+
+        Returns
+        -------
+        torch.Tensor
+            The output tensor.
+        """
+        selected_tensor = x[:, self.sliced_dim, ...]
+
+        return self.embedding(selected_tensor)
+
+
 def sequential_block(
     in_features: int,
     out_features: int,

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -40,6 +40,7 @@ def setup_simple_model(
     from modelforge.potential import CosineCutoff, GaussianRBF
 
     embedding = torch.nn.Embedding(max_atomic_number, nr_atom_basis)
+    assert embedding.embedding_dim == nr_atom_basis
     rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
     cutoff = CosineCutoff(cutoff)
 

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -38,8 +38,9 @@ def setup_simple_model(
         Initialized model.
     """
     from modelforge.potential import CosineCutoff, GaussianRBF
+    from modelforge.potential.utils import SlicedEmbedding
 
-    embedding = torch.nn.Embedding(max_atomic_number, nr_atom_basis)
+    embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
     assert embedding.embedding_dim == nr_atom_basis
     rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
     cutoff = CosineCutoff(cutoff)

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -119,3 +119,31 @@ def test_GaussianRBF():
 
     # Add assertion to check the shape of the output
     assert y.shape == (dim_of_x, n_rbf)
+
+
+def test_sliced_embedding():
+    """
+    Test the SlicedEmbedding module.
+    """
+    from modelforge.potential.utils import SlicedEmbedding
+    from torch.nn import Embedding
+
+    max_Z = 100
+    embedding_dim = 7
+    sliced_dim = 0
+
+    # Create SlicedEmbedding instance
+    sliced_embedding = SlicedEmbedding(max_Z, embedding_dim, sliced_dim)
+    normal_embedding = Embedding(max_Z, embedding_dim)
+
+    # Test embedding_dim property
+    assert sliced_embedding.embedding_dim == embedding_dim
+
+    # Test forward pass
+    input_tensor = torch.randint(0, 99, (5, 1))
+
+    sliced_output = sliced_embedding(input_tensor)
+    normal_output = normal_embedding(input_tensor)
+
+    assert sliced_output.shape == (5, embedding_dim)
+    assert normal_output.shape == (5, 1, embedding_dim)


### PR DESCRIPTION
## Description
Input dimensions for `inputs["atomic_numbers"]` has shape (nr_of_atoms_in_batch, 1), which was flattended in the `BaseNNP` before. Now we keep dimensions and let the NNP decide what to do with it.

## Question
Should we change the name of the input property `atomic_number` 
https://github.com/choderalab/modelforge/blob/6dab8a1a376a8b0cf83d84ac927793154239e272/modelforge/potential/models.py#L172
 to `atomic_properties`? The way we are approaching the embedding in this PR makes it flexible to have other properties defined in this tensor with the now flexible shape `(nr_of_atoms_in_batch, *, *)`. What do you think @ArnNag ?

## Status
- [x] Ready to go