### PR TITLE
Seperating Neighborlist and Pairlist

### DIFF
--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -11,12 +11,9 @@ from loguru import logger as log
 
 class PairList(nn.Module):
     """
-    A module to handle pair list calculations for neighbor atoms.
+    A module to handle pair list calculations for atoms.
+    This returns a pair list of atom indices and the displacement vectors between them.
 
-    Attributes
-    ----------
-    cutoff : float
-        The cutoff distance for neighbor calculations.
 
     Methods
     -------
@@ -26,22 +23,19 @@ class PairList(nn.Module):
         Forward pass for PairList.
     """
 
-    def __init__(self, cutoff: float = 5.0, only_unique_pairs: bool = False):
+    def __init__(self, only_unique_pairs: bool = False):
         """
         Initialize PairList.
 
         Parameters
         ----------
-        cutoff : float, optional
-            Cutoff distance for neighbor calculations, default is 5.0.
         only_unique_pairs : bool, optional
             If set to True, only unique pairs of atoms are considered, default is False.
         """
         super().__init__()
         from .utils import pair_list
 
-        self.calculate_neighbors = pair_list
-        self.cutoff = cutoff
+        self.calculate_pairs = pair_list
         self.only_unique_pairs = only_unique_pairs
 
     def calculate_r_ij(
@@ -90,10 +84,8 @@ class PairList(nn.Module):
             - 'd_ij' : torch.Tenso, shape (3, n_pairs)
 
         """
-        pair_indices = self.calculate_neighbors(
-            positions,
+        pair_indices = self.calculate_pairs(
             atomic_subsystem_indices,
-            self.cutoff,
             only_unique_pairs=self.only_unique_pairs,
         )
         r_ij = self.calculate_r_ij(pair_indices, positions)

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -80,8 +80,8 @@ class PairList(nn.Module):
         -------
         dict : Dict[str, torch.Tensor], containing atom index pairs, distances, and displacement vectors.
             - 'pair_indices': torch.Tensor, shape (2, n_pairs)
-            - 'r_ij' : torch.Tensor, shape (1, n_pairs)
-            - 'd_ij' : torch.Tenso, shape (3, n_pairs)
+            - 'r_ij' : torch.Tensor, shape (3, n_pairs)
+            - 'd_ij' : torch.Tensor, shape (1, n_pairs)
 
         """
         pair_indices = self.calculate_pairs(
@@ -97,10 +97,11 @@ class PairList(nn.Module):
         }
 
 
-class NeighbourList(PairList):
+class NeighborList(PairList):
     def __init__(self, cutoff: float, only_unique_pairs: bool = False):
         """
-        Initialize PairList.
+        Initialize Neighborlist.
+        A neighbor list is a list of atom pairs that are within a certain cutoff distance.
 
         Parameters
         ----------
@@ -119,7 +120,7 @@ class NeighbourList(PairList):
         self, positions: torch.Tensor, atomic_subsystem_indices: torch.Tensor
     ) -> Dict[str, torch.Tensor]:
         """
-        Forward pass for PairList.
+        Forward pass for NeighborList.
 
         Parameters
         ----------
@@ -130,8 +131,8 @@ class NeighbourList(PairList):
         -------
         dict : Dict[str, torch.Tensor], containing atom index pairs, distances, and displacement vectors.
             - 'pair_indices': torch.Tensor, shape (2, n_pairs)
-            - 'r_ij' : torch.Tensor, shape (1, n_pairs)
-            - 'd_ij' : torch.Tenso, shape (3, n_pairs)
+            - 'r_ij' : torch.Tensor, shape (3, n_pairs)
+            - 'd_ij' : torch.Tensor, shape (1, n_pairs)
 
         """
         pair_indices = self.calculate_pairs(

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -450,9 +450,6 @@ def pair_list(
         i_indices = i_indices[mask]
         j_indices = j_indices[mask]
 
-        # i_indices = i_indices.reshape(-1)
-        # j_indices = j_indices.reshape(-1)
-
     # filter pairs to only keep those belonging to the same molecule
     same_molecule_mask = (
         atomic_subsystem_indices[i_indices] == atomic_subsystem_indices[j_indices]

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -421,22 +421,19 @@ def _distance_to_radial_basis(
 
 
 def pair_list(
-    coordinates: torch.Tensor,
     atomic_subsystem_indices: torch.Tensor,
-    cutoff: float,
     only_unique_pairs: bool = False,
 ) -> torch.Tensor:
-    """Compute pairs of atoms that are neighbors (doesn't use PBC)
+    """Compute all pairs of atoms and their distances.
 
     Parameters
     ----------
-    coordinates : torch.Tensor, shape (nr_atoms_per_systems, 3)
     atomic_subsystem_indices : torch.Tensor, shape (nr_atoms_per_systems)
         Atom indices to indicate which atoms belong to which molecule
-    cutoff : float
-        the cutoff inside which atoms are considered pairs
+    only_unique_pairs : bool, optional
+        If True, only unique pairs are returned (default is False). 
+        Otherwise, all pairs are returned.
     """
-    positions = coordinates.detach()
     # generate index grid
     n = len(atomic_subsystem_indices)
 
@@ -468,12 +465,36 @@ def pair_list(
     # concatenate to form final (2, n_pairs) tensor
     pair_indices = torch.stack((i_final_pairs, j_final_pairs))
 
+    return pair_indices
+
+
+def neighbor_list_with_cutoff(
+    coordinates: torch.Tensor,
+    atomic_subsystem_indices: torch.Tensor,
+    cutoff: float,
+    only_unique_pairs: bool = False,
+) -> torch.Tensor:
+    """Compute all pairs of atoms and their distances.
+
+    Parameters
+    ----------
+    coordinates : torch.Tensor, shape (nr_atoms_per_systems, 3)
+    atomic_subsystem_indices : torch.Tensor, shape (nr_atoms_per_systems)
+        Atom indices to indicate which atoms belong to which molecule
+    cutoff : float
+        The cutoff distance.
+    """
+    positions = coordinates.detach()
+    pair_indices = pair_list(
+        atomic_subsystem_indices, only_unique_pairs=only_unique_pairs
+    )
+
     # create pair_coordinates tensor
     pair_coordinates = positions[pair_indices.T]
     pair_coordinates = pair_coordinates.view(-1, 2, 3)
 
     # Calculate distances
-    distances = (pair_coordinates[:, 1, :] - pair_coordinates[:, 0, :]).norm(
+    distances = (pair_coordinates[:, 0, :] - pair_coordinates[:, 1, :]).norm(
         p=2, dim=-1
     )
 

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -152,7 +152,7 @@ def prepare_pairlist_for_single_batch(
 
     positions = batch["positions"]
     atomic_subsystem_indices = batch["atomic_subsystem_indices"]
-    pairlist = PairList(cutoff=5.0)
+    pairlist = PairList()
     return pairlist(positions, atomic_subsystem_indices)
 
 

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -127,7 +127,7 @@ def test_pairlist_logic():
 
 
 def test_pairlist():
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import PairList, NeighborList
     import torch
 
     atomic_subsystem_indices = torch.tensor([80, 80, 80, 11, 11, 11])
@@ -142,7 +142,7 @@ def test_pairlist():
         ]
     )
     cutoff = 5.0  # no relevant cutoff
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = NeighborList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -172,7 +172,7 @@ def test_pairlist():
 
     # test with cutoff
     cutoff = 2.0  #
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = NeighborList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -196,7 +196,7 @@ def test_pairlist():
 
     # test with complete pairlist
     cutoff = 2.0  #
-    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
+    pairlist = NeighborList(cutoff, only_unique_pairs=False)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -208,7 +208,7 @@ def test_pairlist():
     # make sure that Pairlist and Neighborlist behave the same for large cutoffs
     cutoff = 10.0  #
     only_unique_pairs = False
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    neighborlist = NeighborList(cutoff, only_unique_pairs=only_unique_pairs)
     pairlist = PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
@@ -220,7 +220,7 @@ def test_pairlist():
     # make sure that they are the same also for non-redundant pairs
     cutoff = 10.0  #
     only_unique_pairs = True
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    neighborlist = NeighborList(cutoff, only_unique_pairs=only_unique_pairs)
     pairlist = PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
@@ -232,7 +232,7 @@ def test_pairlist():
     # this should fail
     cutoff = 2.0  #
     only_unique_pairs = True
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    neighborlist = NeighborList(cutoff, only_unique_pairs=only_unique_pairs)
     pairlist = PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
@@ -245,7 +245,7 @@ def test_pairlist():
 @pytest.mark.parametrize("dataset", DATASETS)
 def test_pairlist_on_dataset(dataset):
     from modelforge.dataset.dataset import TorchDataModule
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import PairList, NeighborList
 
     data = dataset(for_unit_testing=True)
     data_module = TorchDataModule(data)
@@ -255,7 +255,7 @@ def test_pairlist_on_dataset(dataset):
         positions = data["positions"]
         atomic_subsystem_indices = data["atomic_subsystem_indices"]
         print(atomic_subsystem_indices)
-        pairlist = NeighbourList(cutoff=5.0)
+        pairlist = NeighborList(cutoff=5.0)
         r = pairlist(positions, atomic_subsystem_indices)
         print(r)
         shape_pairlist = r["pair_indices"].shape
@@ -373,7 +373,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
 
 def test_pairlist_calculate_r_ij_and_d_ij():
     # Define inputs
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import PairList, NeighborList
     import torch
 
     positions = torch.tensor(
@@ -385,7 +385,7 @@ def test_pairlist_calculate_r_ij_and_d_ij():
     # Create Pairlist instance
     # --------------------------- #
     # Only unique pairs
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = NeighborList(cutoff, only_unique_pairs=True)
     pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=True
     )
@@ -409,7 +409,7 @@ def test_pairlist_calculate_r_ij_and_d_ij():
 
     # --------------------------- #
     # ALL pairs
-    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
+    pairlist = NeighborList(cutoff, only_unique_pairs=False)
     pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=False
     )

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -94,7 +94,7 @@ def test_pairlist_logic():
     # Concatenate to form final (2, n_pairs) tensor
     final_pair_indices = torch.stack((i_final_pairs, j_final_pairs))
 
-    torch.allclose(
+    assert torch.allclose(
         final_pair_indices,
         torch.tensor([[0, 0, 1, 3, 5, 5, 6, 8], [1, 2, 2, 4, 6, 7, 7, 9]]),
     )
@@ -127,7 +127,7 @@ def test_pairlist_logic():
 
 
 def test_pairlist():
-    from modelforge.potential.models import PairList
+    from modelforge.potential.models import PairList, NeighbourList
     import torch
 
     atomic_subsystem_indices = torch.tensor([80, 80, 80, 11, 11, 11])
@@ -142,7 +142,7 @@ def test_pairlist():
         ]
     )
     cutoff = 5.0  # no relevant cutoff
-    pairlist = PairList(cutoff, only_unique_pairs=True)
+    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -172,13 +172,13 @@ def test_pairlist():
 
     # test with cutoff
     cutoff = 2.0  #
-    pairlist = PairList(cutoff, only_unique_pairs=True)
+    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
-    torch.allclose(pair_indices, torch.tensor([[0, 1, 3, 4], [1, 2, 4, 5]]))
+    assert torch.equal(pair_indices, torch.tensor([[0, 1, 3, 4], [1, 2, 4, 5]]))
     # pairs that are excluded through cutoff: (0,2) and (3,5)
-    torch.allclose(
+    assert torch.equal(
         r["r_ij"],
         torch.tensor(
             [
@@ -190,24 +190,62 @@ def test_pairlist():
         ),
     )
 
-    torch.allclose(r["d_ij"], torch.tensor([1.7321, 1.7321, 1.7321, 1.7321]))
+    assert torch.allclose(
+        r["d_ij"], torch.tensor([1.7321, 1.7321, 1.7321, 1.7321]), atol=1e-3
+    )
 
     # test with complete pairlist
     cutoff = 2.0  #
-    pairlist = PairList(cutoff, only_unique_pairs=False)
+    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
     print(pair_indices, flush=True)
-    torch.allclose(
+    assert torch.equal(
         pair_indices, torch.tensor([[0, 1, 1, 2, 3, 4, 4, 5], [1, 0, 2, 1, 4, 3, 5, 4]])
     )
+
+    # make sure that Pairlist and Neighborlist behave the same for large cutoffs
+    cutoff = 10.0  #
+    only_unique_pairs = False
+    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    r = pairlist(positions, atomic_subsystem_indices)
+    pair_indices = r["pair_indices"]
+    r = neighborlist(positions, atomic_subsystem_indices)
+    neighbor_indices = r["pair_indices"]
+
+    assert torch.equal(pair_indices, neighbor_indices)
+
+    # make sure that they are the same also for non-redundant pairs
+    cutoff = 10.0  #
+    only_unique_pairs = True
+    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    r = pairlist(positions, atomic_subsystem_indices)
+    pair_indices = r["pair_indices"]
+    r = neighborlist(positions, atomic_subsystem_indices)
+    neighbor_indices = r["pair_indices"]
+
+    assert torch.equal(pair_indices, neighbor_indices)
+
+    # this should fail
+    cutoff = 2.0  #
+    only_unique_pairs = True
+    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    r = pairlist(positions, atomic_subsystem_indices)
+    pair_indices = r["pair_indices"]
+    r = neighborlist(positions, atomic_subsystem_indices)
+    neighbor_indices = r["pair_indices"]
+
+    assert not pair_indices.shape == neighbor_indices.shape
 
 
 @pytest.mark.parametrize("dataset", DATASETS)
 def test_pairlist_on_dataset(dataset):
     from modelforge.dataset.dataset import TorchDataModule
-    from modelforge.potential.models import PairList
+    from modelforge.potential.models import PairList, NeighbourList
 
     data = dataset(for_unit_testing=True)
     data_module = TorchDataModule(data)
@@ -217,7 +255,7 @@ def test_pairlist_on_dataset(dataset):
         positions = data["positions"]
         atomic_subsystem_indices = data["atomic_subsystem_indices"]
         print(atomic_subsystem_indices)
-        pairlist = PairList(cutoff=5.0)
+        pairlist = NeighbourList(cutoff=5.0)
         r = pairlist(positions, atomic_subsystem_indices)
         print(r)
         shape_pairlist = r["pair_indices"].shape
@@ -335,7 +373,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
 
 def test_pairlist_calculate_r_ij_and_d_ij():
     # Define inputs
-    from modelforge.potential.models import PairList
+    from modelforge.potential.models import PairList, NeighbourList
     import torch
 
     positions = torch.tensor(
@@ -347,8 +385,8 @@ def test_pairlist_calculate_r_ij_and_d_ij():
     # Create Pairlist instance
     # --------------------------- #
     # Only unique pairs
-    pairlist = PairList(cutoff, only_unique_pairs=True)
-    pair_indices = pairlist.calculate_neighbors(
+    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=True
     )
 
@@ -371,8 +409,8 @@ def test_pairlist_calculate_r_ij_and_d_ij():
 
     # --------------------------- #
     # ALL pairs
-    pairlist = PairList(cutoff, only_unique_pairs=False)
-    pair_indices = pairlist.calculate_neighbors(
+    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
+    pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=False
     )
 


### PR DESCRIPTION
## Description
Our current Pairlist included a possible cutoff for neighbor calculations; this has been refactored in two separate classes to make sure we use the intended calculation. Typically, with only a few use cases, we want the Pairlist for training. 

## Todos
  - [x] Refactor current PairList in a separate class for pairlist and neighborlist calculation, one taking a cutoff argument

## Status
- [x] Ready to go