### PR TITLE
Adding unit checks to the public API

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,6 +10,7 @@ dependencies:
   - h5py
   - requests
   - tqdm
+  - openmm
   - qcelemental=0.25.1
   - qcportal>=0.50
   - pytorch>=2.1

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,7 +10,6 @@ dependencies:
   - h5py
   - requests
   - tqdm
-  - openmm
   - qcelemental=0.25.1
   - qcportal>=0.50
   - pytorch>=2.1

--- a/modelforge/dataset/qm9.py
+++ b/modelforge/dataset/qm9.py
@@ -95,9 +95,6 @@ class QM9Dataset(HDF5Dataset):
         )
         self.dataset_name = dataset_name
         self.for_unit_testing = for_unit_testing
-        # self.test_id = "17oZ07UOxv2fkEmu-d5mLk6aGIuhV0mJ7"
-        # self.full_id = "1_bSdQjEvI67Tk_LKYbW0j8nmggnb5MoU"
-        # updated tests.
         self.test_id = "18C9Iq_7VZLx0gZbJYje8X6tybZb5m3JY"
         self.full_id = "1damjPgjKviTogDJ2UJvhYjyBZxGvRPP-"
 

--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -1,3 +1,3 @@
 from .schnet import SchNET
 from .painn import PaiNN
-from .utils import _GaussianRBF, CosineCutoff, _shifted_softplus
+from .utils import _GaussianRBF, _CosineCutoff, _shifted_softplus

--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -1,3 +1,3 @@
 from .schnet import SchNET
 from .painn import PaiNN
-from .utils import GaussianRBF, CosineCutoff, shifted_softplus
+from .utils import _GaussianRBF, CosineCutoff, _shifted_softplus

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -339,7 +339,7 @@ class BaseNNP(nn.Module):
         if isinstance(inputs["positions"], unit.Quantity):
             inputs["positions"] = inputs["positions"].to(unit.nanometer).m
 
-        else AttributeError:
+        else:
             if not self._log_message_units:
                 log.warning(
                     "Could not convert positions to nanometer. Assuming positions are already in nanometer."

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -336,7 +336,7 @@ class BaseNNP(nn.Module):
             )
             inputs["positions"] = inputs["positions"].to(self._dtype)
 
-        if isinstance(inputs["positions"], unit.Quantity)
+        if isinstance(inputs["positions"], unit.Quantity):
             inputs["positions"] = inputs["positions"].to(unit.nanometer).m
 
         else AttributeError:

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -11,12 +11,9 @@ from loguru import logger as log
 
 class PairList(nn.Module):
     """
-    A module to handle pair list calculations for neighbor atoms.
+    A module to handle pair list calculations for atoms.
+    This returns a pair list of atom indices and the displacement vectors between them.
 
-    Attributes
-    ----------
-    cutoff : float
-        The cutoff distance for neighbor calculations.
 
     Methods
     -------
@@ -26,22 +23,19 @@ class PairList(nn.Module):
         Forward pass for PairList.
     """
 
-    def __init__(self, cutoff: float = 5.0, only_unique_pairs: bool = False):
+    def __init__(self, only_unique_pairs: bool = False):
         """
         Initialize PairList.
 
         Parameters
         ----------
-        cutoff : float, optional
-            Cutoff distance for neighbor calculations, default is 5.0.
         only_unique_pairs : bool, optional
             If set to True, only unique pairs of atoms are considered, default is False.
         """
         super().__init__()
         from .utils import pair_list
 
-        self.calculate_neighbors = pair_list
-        self.cutoff = cutoff
+        self.calculate_pairs = pair_list
         self.only_unique_pairs = only_unique_pairs
 
     def calculate_r_ij(
@@ -90,10 +84,8 @@ class PairList(nn.Module):
             - 'd_ij' : torch.Tenso, shape (3, n_pairs)
 
         """
-        pair_indices = self.calculate_neighbors(
-            positions,
+        pair_indices = self.calculate_pairs(
             atomic_subsystem_indices,
-            self.cutoff,
             only_unique_pairs=self.only_unique_pairs,
         )
         r_ij = self.calculate_r_ij(pair_indices, positions)

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1,4 +1,3 @@
-from abc import ABC, abstractmethod
 from typing import Dict
 
 import lightning as pl
@@ -160,6 +159,10 @@ class LightningModuleMixin(pl.LightningModule):
         Configures the optimizer for training.
     """
 
+    def _log_batch_size(self, batch: Dict[str, torch.Tensor]):
+        batch_size = int(len(batch["E_label"]))
+        return batch_size
+
     def training_step(
         self, batch: Dict[str, torch.Tensor], batch_idx: int
     ) -> torch.Tensor:
@@ -178,11 +181,39 @@ class LightningModuleMixin(pl.LightningModule):
         torch.Tensor, shape [batch_size, 1]
             Loss tensor.
         """
-
-        E_hat = self.forward(batch).flatten()
-        loss = self.loss_function(E_hat, batch["E_label"])
-        self.log("train_loss", loss)
+        batch_size = self._log_batch_size(batch)
+        predictions = self.forward(batch).flatten()
+        targets = batch["E_label"].flatten()
+        loss = self.loss_function(predictions, targets)
+        # Specify the batch size explicitly using self.log
+        self.log(
+            "train_loss",
+            loss,
+            on_epoch=True,
+            on_step=False,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
         return loss
+
+    def test_step(self, batch, batch_idx):
+        from torch.nn import functional as F
+
+        batch_size = self._log_batch_size(batch)
+
+        predictions = self.forward(batch).flatten()
+        targets = batch["E_label"].flatten()
+        test_loss = F.mse_loss(predictions, targets)
+        self.log("test_loss", test_loss, batch_size=batch_size)
+
+    def validation_step(self, batch: Dict[str, torch.Tensor], batch_idx):
+        from torch.nn import functional as F
+
+        batch_size = self._log_batch_size(batch)
+        predictions = self.forward(batch)
+        targets = batch["E_label"]
+        val_loss = F.mse_loss(predictions, targets)
+        self.log("val_loss", val_loss, batch_size=batch_size, on_epoch=True)
 
     def configure_optimizers(self) -> AdamW:
         """
@@ -195,9 +226,6 @@ class LightningModuleMixin(pl.LightningModule):
         """
 
         return self.optimizer(self.parameters(), lr=self.learning_rate)
-
-
-from openmm import unit
 
 
 class BaseNNP(nn.Module):
@@ -220,6 +248,8 @@ class BaseNNP(nn.Module):
         self._cutoff = cutoff
         self.calculate_distances_and_pairlist = _PairList()
         self._dtype = None  # set at runtime
+        self._log_message_dtype = False
+        self._log_message_units = False
 
     def preate_input(self, inputs: Dict[str, torch.Tensor]):
         # needs to be implemented by the subclass
@@ -258,8 +288,16 @@ class BaseNNP(nn.Module):
     def _set_dtype(self):
         dtypes = list({p.dtype for p in self.parameters()})
         assert len(dtypes) == 1
+
+        if not self._log_message_dtype:
+            log.debug(f"Setting dtype to {dtypes[0]}.")
+            self._log_message_dtype = True
+
+        if self._dtype is not None and self._dtype != dtypes[0]:
+            log.warning(f"Setting dtype to {dtypes[0]}.")
+            log.warning(f"This is new, be carful. You are resetting the dtype!")
+
         self._dtype = dtypes[0]
-        log.debug(f"Setting dtype to {self._dtype}.")
 
     def _input_checks(self, inputs: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         """
@@ -303,9 +341,11 @@ class BaseNNP(nn.Module):
                 unit.md_unit_system
             )
         except AttributeError:
-            log.warning(
-                "Could not convert positions to nanometer. Assuming positions are already in nanometer."
-            )
+            if not self._log_message_units:
+                log.warning(
+                    "Could not convert positions to nanometer. Assuming positions are already in nanometer."
+                )
+                self._log_message_units = True
 
         return inputs
 
@@ -319,7 +359,7 @@ class BaseNNP(nn.Module):
             Inputs containing atomic numbers ('atomic_numbers'), coordinates ('positions') and pairlist ('pairlist').
             - 'atomic_numbers': int; shape (nr_of_atoms_in_batch, 1), 0 indicates non-interacting atoms that will be masked
             - 'total_charge' : int; shape (n_system)
-            - 'positions': float; shape (nr_of_atoms_in_batch, 3), with openmm units attached
+            - 'positions': float; shape (nr_of_atoms_in_batch, 3)
 
         Returns
         -------

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -336,10 +336,10 @@ class BaseNNP(nn.Module):
             )
             inputs["positions"] = inputs["positions"].to(self._dtype)
 
-        try:
+        if isinstance(inputs["positions"], unit.Quantity)
             inputs["positions"] = inputs["positions"].to(unit.nanometer).m
 
-        except AttributeError:
+        else AttributeError:
             if not self._log_message_units:
                 log.warning(
                     "Could not convert positions to nanometer. Assuming positions are already in nanometer."

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -338,7 +338,7 @@ class BaseNNP(nn.Module):
 
         try:
             inputs["positions"] = inputs["positions"].to(unit.nanometer).m
-            )
+
         except AttributeError:
             if not self._log_message_units:
                 log.warning(

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -205,19 +205,19 @@ class BaseNNP(nn.Module):
     Base class for neural network potentials.
     """
 
-    def __init__(self, cutoff: unit.Quantity = unit.Quantity(0.5, unit.nanometer)):
+    def __init__(self, cutoff: float):
         """
         Initialize the NNP class.
 
         Parameters
         ----------
-        cutoff : unit.Quantity, optional
-            Cutoff distance for atom centered interactions, default is 0.5 nanometer.
+        cutoff : float
+            Cutoff distance for atom centered interactions, in nanometer.
         """
         from .models import _PairList
 
         super().__init__()
-        self._cutoff = cutoff.value_in_unit_system(unit.md_unit_system)
+        self._cutoff = cutoff
         self.calculate_distances_and_pairlist = _PairList()
         self._dtype = None  # set at runtime
 

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -315,7 +315,7 @@ class BaseNNP(nn.Module):
             If the input dictionary is missing required keys or has invalid shapes.
 
         """
-        from openmm import unit
+        from openff.units import unit
 
         required_keys = ["atomic_numbers", "positions", "atomic_subsystem_indices"]
         for key in required_keys:
@@ -337,8 +337,7 @@ class BaseNNP(nn.Module):
             inputs["positions"] = inputs["positions"].to(self._dtype)
 
         try:
-            inputs["positions"] = inputs["positions"].value_in_unit_system(
-                unit.md_unit_system
+            inputs["positions"] = inputs["positions"].to(unit.nanometer).m
             )
         except AttributeError:
             if not self._log_message_units:

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -135,7 +135,7 @@ class PaiNN(BaseNNP):
         dir_ij = r_ij / d_ij
         f_ij, _ = _distance_to_radial_basis(d_ij, self.radial_basis_module)
 
-        fcut = self.cutoff_module(d_ij) 
+        fcut = self.cutoff_module(d_ij)
 
         filters = self.filter_net(f_ij) * fcut[..., None]
         if self.share_filters:
@@ -176,13 +176,14 @@ class PaiNN(BaseNNP):
 
         # extract properties from pairlist
         transformed_input = self._generate_representation(inputs)
-
+        q = transformed_input["q"]
+        mu = transformed_input["mu"]
         for i, (interaction_mod, mixing_mod) in enumerate(
             zip(self.interaction_modules, self.mixing_modules)
         ):
             q, mu = interaction_mod(
-                transformed_input["q"],
-                transformed_input["mu"],
+                q,
+                mu,
                 self.filter_list[i],
                 transformed_input["dir_ij"],
                 inputs["pair_indices"],
@@ -296,7 +297,7 @@ class PaiNNInteraction(nn.Module):
         expanded_idx_i_dmu = idx_i.view(-1, 1, 1).expand_as(dmu)
         dmu = zeros.scatter_add(0, expanded_idx_i_dmu, dmu)
 
-        q = q + dq 
+        q = q + dq
         mu = mu + dmu
 
         return q, mu

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -135,7 +135,7 @@ class PaiNN(BaseNNP):
         dir_ij = r_ij / d_ij
         f_ij, _ = _distance_to_radial_basis(d_ij, self.radial_basis_module)
 
-        fcut = self.cutoff_module(d_ij)  # n_pairs, 1
+        fcut = self.cutoff_module(d_ij) 
 
         filters = self.filter_net(f_ij) * fcut[..., None]
         if self.share_filters:
@@ -151,7 +151,7 @@ class PaiNN(BaseNNP):
         qs = q.shape
         mu = torch.zeros(
             (qs[0], 3, qs[2]), device=q.device
-        )  # nr_of_systems * nr_of_atoms, 3, nr_atom_basis
+        )  # total_number_of_atoms_in_the_batch, 3, nr_atom_basis
         return {"mu": mu, "dir_ij": dir_ij, "q": q}
 
     def _forward(
@@ -296,7 +296,7 @@ class PaiNNInteraction(nn.Module):
         expanded_idx_i_dmu = idx_i.view(-1, 1, 1).expand_as(dmu)
         dmu = zeros.scatter_add(0, expanded_idx_i_dmu, dmu)
 
-        q = q + dq  # .view(nr_of_atoms_in_all_systems)
+        q = q + dq 
         mu = mu + dmu
 
         return q, mu

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -34,7 +34,7 @@ class SchNET(BaseNNP):
         """
 
         log.debug("Initializing SchNet model.")
-        super().__init__(cutoff=cutoff_module.cutoff)
+        super().__init__(cutoff=float(cutoff_module.cutoff))
         self.radial_basis_module = radial_basis_module
         self.cutoff_module = cutoff_module
 

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -5,7 +5,7 @@ from loguru import logger as log
 import torch.nn as nn
 
 from .models import BaseNNP, LightningModuleMixin
-from .utils import _distance_to_radial_basis, shifted_softplus
+from .utils import _distance_to_radial_basis, _shifted_softplus
 
 
 class SchNET(BaseNNP):
@@ -17,7 +17,7 @@ class SchNET(BaseNNP):
         cutoff_module: nn.Module,
         nr_filters: int = 2,
         shared_interactions: bool = False,
-        activation: nn.Module = shifted_softplus,
+        activation: nn.Module = _shifted_softplus,
     ) -> None:
         """
         Initialize the SchNet class.
@@ -139,7 +139,7 @@ class SchNETInteractionBlock(nn.Module):
             Number of radial basis functions.
         """
         super().__init__()
-        from .utils import shifted_softplus, Dense
+        from .utils import _shifted_softplus, Dense
 
         assert nr_rbf > 4, "Number of radial basis functions must be larger than 10."
         assert nr_filters > 1, "Number of filters must be larger than 1."
@@ -148,11 +148,11 @@ class SchNETInteractionBlock(nn.Module):
         self.nr_atom_basis = nr_atom_basis  # Initialize parameters
         self.intput_to_feature = nn.Linear(nr_atom_basis, nr_filters)
         self.feature_to_output = nn.Sequential(
-            Dense(nr_filters, nr_atom_basis, activation=shifted_softplus),
+            Dense(nr_filters, nr_atom_basis, activation=_shifted_softplus),
             Dense(nr_atom_basis, nr_atom_basis, activation=None),
         )
         self.filter_network = nn.Sequential(
-            Dense(nr_rbf, nr_filters, activation=shifted_softplus),
+            Dense(nr_rbf, nr_filters, activation=_shifted_softplus),
             Dense(nr_filters, nr_filters, activation=None),
         )
 
@@ -263,7 +263,7 @@ class LightningSchNET(SchNET, LightningModuleMixin):
         cutoff: nn.Module,
         nr_filters: int = 2,
         shared_interactions: bool = False,
-        activation: nn.Module = shifted_softplus,
+        activation: nn.Module = _shifted_softplus,
         loss: Type[nn.Module] = nn.MSELoss(),
         optimizer: Type[torch.optim.Optimizer] = torch.optim.Adam,
         lr: float = 1e-3,

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -450,9 +450,6 @@ def pair_list(
         i_indices = i_indices[mask]
         j_indices = j_indices[mask]
 
-        # i_indices = i_indices.reshape(-1)
-        # j_indices = j_indices.reshape(-1)
-
     # filter pairs to only keep those belonging to the same molecule
     same_molecule_mask = (
         atomic_subsystem_indices[i_indices] == atomic_subsystem_indices[j_indices]

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -172,19 +172,22 @@ def gaussian_rbf(
     return y
 
 
+from openmm import unit
+
+
 class CosineCutoff(nn.Module):
-    def __init__(self, cutoff: float):
-        r"""
+    def __init__(self, cutoff: unit.Quantity):
+        """
         Behler-style cosine cutoff module.
 
-        Args:
-            cutoff (float): The cutoff distance.
-
-        Attributes:
-            cutoff (torch.Tensor): The cutoff distance as a tensor.
+        Parameters:
+        ----------
+        cutoff: unit.Quantity
+            The cutoff distance.
 
         """
         super().__init__()
+        cutoff = cutoff.value_in_unit_system(unit.md_unit_system)
         self.register_buffer("cutoff", torch.FloatTensor([cutoff]))
 
     def forward(self, input: torch.Tensor):

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -361,7 +361,7 @@ class _GaussianRBF(nn.Module):
         ----------
         n_rbf : int
             Number of radial basis functions.
-        cutoff : float
+        cutoff : unit.Quantity
             The cutoff distance. NOTE: IN ANGSTROM #FIXME
         start: float
             center of first Gaussian function.
@@ -467,12 +467,12 @@ def _pair_list(
     return pair_indices
 
 
-from openff.units import unit, Quantity
+from openff.units import unit
 
 def _neighbor_list_with_cutoff(
     coordinates: torch.Tensor,  # in nanometer
     atomic_subsystem_indices: torch.Tensor,
-    cutoff: unit.Quantity,
+    cutoff: float,
     only_unique_pairs: bool = False,
 ) -> torch.Tensor:
     """Compute all pairs of atoms and their distances.
@@ -482,7 +482,7 @@ def _neighbor_list_with_cutoff(
     coordinates : torch.Tensor, shape (nr_atoms_per_systems, 3), in nanometer
     atomic_subsystem_indices : torch.Tensor, shape (nr_atoms_per_systems)
         Atom indices to indicate which atoms belong to which molecule
-    cutoff : unit.Quantity
+    cutoff : float
         The cutoff distance.
     """
     positions = coordinates.detach()
@@ -500,7 +500,8 @@ def _neighbor_list_with_cutoff(
     )
 
     # Find pairs within the cutoff
-    in_cutoff = (distances <= cutoff.to(unit.nanometer).m).nonzero(as_tuple=False).squeeze()
+    #cutoff = cutoff.to(unit.nanometer).m
+    in_cutoff = (distances <= cutoff).nonzero(as_tuple=False).squeeze()
 
     # Get the atom indices within the cutoff
     pair_indices_within_cutoff = pair_indices[:, in_cutoff]

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -172,7 +172,7 @@ def gaussian_rbf(
     return y
 
 
-from openmm import unit
+from openff.units import unit
 
 
 class _CosineCutoff(nn.Module):
@@ -187,7 +187,7 @@ class _CosineCutoff(nn.Module):
 
         """
         super().__init__()
-        cutoff = cutoff.value_in_unit_system(unit.md_unit_system)
+        cutoff = cutoff.to(unit.nanometer).m
         self.register_buffer("cutoff", torch.FloatTensor([cutoff]))
 
     def forward(self, input: torch.Tensor):
@@ -371,7 +371,7 @@ class _GaussianRBF(nn.Module):
         """
         super().__init__()
         self.n_rbf = n_rbf
-        cutoff = cutoff.value_in_unit(unit.nanometer)
+        cutoff = cutoff.to(unit.nanometer).m
         self.cutoff = cutoff
         # compute offset and width of Gaussian functions
         offset = torch.linspace(start, cutoff, n_rbf, dtype=dtype)
@@ -467,8 +467,7 @@ def _pair_list(
     return pair_indices
 
 
-from openmm import unit
-
+from openff.units import unit, Quantity
 
 def _neighbor_list_with_cutoff(
     coordinates: torch.Tensor,  # in nanometer
@@ -501,7 +500,7 @@ def _neighbor_list_with_cutoff(
     )
 
     # Find pairs within the cutoff
-    in_cutoff = (distances <= cutoff).nonzero(as_tuple=False).squeeze()
+    in_cutoff = (distances <= cutoff.to(unit.nanometer).m).nonzero(as_tuple=False).squeeze()
 
     # Get the atom indices within the cutoff
     pair_indices_within_cutoff = pair_indices[:, in_cutoff]

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -421,22 +421,19 @@ def _distance_to_radial_basis(
 
 
 def pair_list(
-    coordinates: torch.Tensor,
     atomic_subsystem_indices: torch.Tensor,
-    cutoff: float,
     only_unique_pairs: bool = False,
 ) -> torch.Tensor:
-    """Compute pairs of atoms that are neighbors (doesn't use PBC)
+    """Compute all pairs of atoms and their distances.
 
     Parameters
     ----------
-    coordinates : torch.Tensor, shape (nr_atoms_per_systems, 3)
     atomic_subsystem_indices : torch.Tensor, shape (nr_atoms_per_systems)
         Atom indices to indicate which atoms belong to which molecule
-    cutoff : float
-        the cutoff inside which atoms are considered pairs
+    only_unique_pairs : bool, optional
+        If True, only unique pairs are returned (default is False). 
+        Otherwise, all pairs are returned.
     """
-    positions = coordinates.detach()
     # generate index grid
     n = len(atomic_subsystem_indices)
 
@@ -468,12 +465,36 @@ def pair_list(
     # concatenate to form final (2, n_pairs) tensor
     pair_indices = torch.stack((i_final_pairs, j_final_pairs))
 
+    return pair_indices
+
+
+def neighbor_list_with_cutoff(
+    coordinates: torch.Tensor,
+    atomic_subsystem_indices: torch.Tensor,
+    cutoff: float,
+    only_unique_pairs: bool = False,
+) -> torch.Tensor:
+    """Compute all pairs of atoms and their distances.
+
+    Parameters
+    ----------
+    coordinates : torch.Tensor, shape (nr_atoms_per_systems, 3)
+    atomic_subsystem_indices : torch.Tensor, shape (nr_atoms_per_systems)
+        Atom indices to indicate which atoms belong to which molecule
+    cutoff : float
+        The cutoff distance.
+    """
+    positions = coordinates.detach()
+    pair_indices = pair_list(
+        atomic_subsystem_indices, only_unique_pairs=only_unique_pairs
+    )
+
     # create pair_coordinates tensor
     pair_coordinates = positions[pair_indices.T]
     pair_coordinates = pair_coordinates.view(-1, 2, 3)
 
     # Calculate distances
-    distances = (pair_coordinates[:, 1, :] - pair_coordinates[:, 0, :]).norm(
+    distances = (pair_coordinates[:, 0, :] - pair_coordinates[:, 1, :]).norm(
         p=2, dim=-1
     )
 

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -152,7 +152,7 @@ def prepare_pairlist_for_single_batch(
 
     positions = batch["positions"]
     atomic_subsystem_indices = batch["atomic_subsystem_indices"]
-    pairlist = PairList(cutoff=5.0)
+    pairlist = PairList()
     return pairlist(positions, atomic_subsystem_indices)
 
 

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -11,8 +11,7 @@ from typing import Optional, Dict
 MODELS_TO_TEST = [SchNET, PaiNN]
 DATASETS = [QM9Dataset]
 
-from openmm import unit
-
+from openff.units import unit
 
 def setup_simple_model(
     model_class,
@@ -20,7 +19,7 @@ def setup_simple_model(
     nr_atom_basis: int = 128,
     max_atomic_number: int = 100,
     n_rbf: int = 20,
-    cutoff: unit.Quantity = unit.Quantity(5.0, unit.angstrom),
+    cutoff: unit.Quantity = 5.0*unit.angstrom,
     nr_interaction_blocks: int = 2,
     nr_filters: int = 2,
 ) -> Optional[BaseNNP]:

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -231,7 +231,7 @@ def generate_interaction_block_data(
     from modelforge.dataset.qm9 import QM9Dataset
     from modelforge.potential import _GaussianRBF
     from modelforge.potential.utils import _distance_to_radial_basis
-    from openmm import unit
+    from openff.units import unit
 
     embedding = nn.Embedding(nr_embeddings, nr_atom_basis, padding_idx=0)
     batch = return_single_batch(QM9Dataset, "fit")

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -37,12 +37,12 @@ def setup_simple_model(
     Optional[BaseNNP]
         Initialized model.
     """
-    from modelforge.potential import CosineCutoff, GaussianRBF
+    from modelforge.potential import CosineCutoff, _GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
 
     embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
     assert embedding.embedding_dim == nr_atom_basis
-    rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
     cutoff = CosineCutoff(cutoff)
 
     if model_class is SchNET:
@@ -148,11 +148,11 @@ def prepare_pairlist_for_single_batch(
         Pairlist with keys 'atom_index12', 'd_ij', 'r_ij'.
     """
 
-    from modelforge.potential.models import PairList
+    from modelforge.potential.models import _PairList
 
     positions = batch["positions"]
     atomic_subsystem_indices = batch["atomic_subsystem_indices"]
-    pairlist = PairList()
+    pairlist = _PairList()
     return pairlist(positions, atomic_subsystem_indices)
 
 
@@ -224,13 +224,15 @@ def generate_interaction_block_data(
     import torch.nn as nn
 
     from modelforge.dataset.qm9 import QM9Dataset
-    from modelforge.potential import GaussianRBF
+    from modelforge.potential import _GaussianRBF
     from modelforge.potential.utils import _distance_to_radial_basis
 
     embedding = nn.Embedding(nr_embeddings, nr_atom_basis, padding_idx=0)
     batch = return_single_batch(QM9Dataset, "fit")
     r = prepare_pairlist_for_single_batch(batch)
-    radial_basis = GaussianRBF(n_rbf=nr_rbf, cutoff=5.0, dtype=batch["positions"].dtype)
+    radial_basis = _GaussianRBF(
+        n_rbf=nr_rbf, cutoff=5.0, dtype=batch["positions"].dtype
+    )
 
     d_ij = r["d_ij"]
     f_ij, rcut_ij = _distance_to_radial_basis(d_ij, radial_basis)

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -232,12 +232,15 @@ def generate_interaction_block_data(
     from modelforge.dataset.qm9 import QM9Dataset
     from modelforge.potential import _GaussianRBF
     from modelforge.potential.utils import _distance_to_radial_basis
+    from openmm import unit
 
     embedding = nn.Embedding(nr_embeddings, nr_atom_basis, padding_idx=0)
     batch = return_single_batch(QM9Dataset, "fit")
     r = prepare_pairlist_for_single_batch(batch)
     radial_basis = _GaussianRBF(
-        n_rbf=nr_rbf, cutoff=5.0, dtype=batch["positions"].dtype
+        n_rbf=nr_rbf,
+        cutoff=unit.Quantity(5.0, unit.angstrom),
+        dtype=batch["positions"].dtype,
     )
 
     d_ij = r["d_ij"]

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -43,7 +43,9 @@ def setup_simple_model(
     embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
     assert embedding.embedding_dim == nr_atom_basis
     rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
-    cutoff = CosineCutoff(cutoff)
+    from openmm import unit
+
+    cutoff = CosineCutoff(unit.Quantity(cutoff, unit.angstrom))
 
     if model_class is SchNET:
         if lightning:

--- a/modelforge/tests/test_curation.py
+++ b/modelforge/tests/test_curation.py
@@ -1450,118 +1450,118 @@ def test_spice114_process_download_conversion(prep_temp_dir):
     )
 
 
-def test_spice12_openff_test_fetching(prep_temp_dir):
-    from tqdm import tqdm
-    from sqlitedict import SqliteDict
+# def test_spice12_openff_test_fetching(prep_temp_dir):
+#     from tqdm import tqdm
+#     from sqlitedict import SqliteDict
 
-    local_path_dir = str(prep_temp_dir)
-    local_database_name = "test.sqlite"
-    specification_name = "entry"
+#     local_path_dir = str(prep_temp_dir)
+#     local_database_name = "test.sqlite"
+#     specification_name = "entry"
 
-    spice_openff_data = SPICE12PubChemOpenFFCuration(
-        hdf5_file_name="test_dataset.hdf5",
-        output_file_dir=local_path_dir,
-        local_cache_dir=local_path_dir,
-        convert_units=True,
-    )
+#     spice_openff_data = SPICE12PubChemOpenFFCuration(
+#         hdf5_file_name="test_dataset.hdf5",
+#         output_file_dir=local_path_dir,
+#         local_cache_dir=local_path_dir,
+#         convert_units=True,
+#     )
 
-    # test downloading two new records and saving to the sqlite db
-    spice_openff_data._fetch_singlepoint_from_qcarchive(
-        dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
-        specification_name=specification_name,
-        local_database_name=local_database_name,
-        local_path_dir=local_path_dir,
-        force_download=True,
-        unit_testing_max_records=2,
-    )
+#     # test downloading two new records and saving to the sqlite db
+#     spice_openff_data._fetch_singlepoint_from_qcarchive(
+#         dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
+#         specification_name=specification_name,
+#         local_database_name=local_database_name,
+#         local_path_dir=local_path_dir,
+#         force_download=True,
+#         unit_testing_max_records=2,
+#     )
 
-    with SqliteDict(
-        f"{local_path_dir}/{local_database_name}",
-        tablename=specification_name,
-        autocommit=True,
-    ) as spice_db:
-        keys = list(spice_db.keys())
+#     with SqliteDict(
+#         f"{local_path_dir}/{local_database_name}",
+#         tablename=specification_name,
+#         autocommit=True,
+#     ) as spice_db:
+#         keys = list(spice_db.keys())
 
-        assert len(keys) == 2
+#         assert len(keys) == 2
 
-    # same test as above, but we will pass pbar
-    # pbar.total gets updated by the number of records
-    # we need to fetch. Since force_download=True
-    # we should fetch the 2 records again
-    pbar = tqdm()
-    pbar.total = 0
+#     # same test as above, but we will pass pbar
+#     # pbar.total gets updated by the number of records
+#     # we need to fetch. Since force_download=True
+#     # we should fetch the 2 records again
+#     pbar = tqdm()
+#     pbar.total = 0
 
-    spice_openff_data._fetch_singlepoint_from_qcarchive(
-        dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
-        specification_name=specification_name,
-        local_database_name=local_database_name,
-        local_path_dir=local_path_dir,
-        force_download=True,
-        unit_testing_max_records=2,
-        pbar=pbar,
-    )
+#     spice_openff_data._fetch_singlepoint_from_qcarchive(
+#         dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
+#         specification_name=specification_name,
+#         local_database_name=local_database_name,
+#         local_path_dir=local_path_dir,
+#         force_download=True,
+#         unit_testing_max_records=2,
+#         pbar=pbar,
+#     )
 
-    assert pbar.total == 2
+#     assert pbar.total == 2
 
-    with SqliteDict(
-        f"{local_path_dir}/{local_database_name}",
-        tablename=specification_name,
-        autocommit=True,
-    ) as spice_db:
-        keys = list(spice_db.keys())
+#     with SqliteDict(
+#         f"{local_path_dir}/{local_database_name}",
+#         tablename=specification_name,
+#         autocommit=True,
+#     ) as spice_db:
+#         keys = list(spice_db.keys())
 
-        assert len(keys) == 2
+#         assert len(keys) == 2
 
-    # test using sqlite db, by setting force_download=False
-    pbar = tqdm()
-    pbar.total = 0
+#     # test using sqlite db, by setting force_download=False
+#     pbar = tqdm()
+#     pbar.total = 0
 
-    spice_openff_data._fetch_singlepoint_from_qcarchive(
-        dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
-        specification_name=specification_name,
-        local_database_name=local_database_name,
-        local_path_dir=local_path_dir,
-        force_download=False,
-        unit_testing_max_records=2,
-    )
+#     spice_openff_data._fetch_singlepoint_from_qcarchive(
+#         dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
+#         specification_name=specification_name,
+#         local_database_name=local_database_name,
+#         local_path_dir=local_path_dir,
+#         force_download=False,
+#         unit_testing_max_records=2,
+#     )
 
-    assert pbar.total == 0
+#     assert pbar.total == 0
 
-    with SqliteDict(
-        f"{local_path_dir}/{local_database_name}",
-        tablename=specification_name,
-        autocommit=True,
-    ) as spice_db:
-        keys = list(spice_db.keys())
+#     with SqliteDict(
+#         f"{local_path_dir}/{local_database_name}",
+#         tablename=specification_name,
+#         autocommit=True,
+#     ) as spice_db:
+#         keys = list(spice_db.keys())
 
-        assert len(keys) == 2
+#         assert len(keys) == 2
 
-    # test fetching additional records
-    # we already have 2 and thus should only need to
-    # fetch 8
+#     # test fetching additional records
+#     # we already have 2 and thus should only need to
+#     # fetch 8
 
-    pbar = tqdm()
-    pbar.total = 0
+#     pbar = tqdm()
+#     pbar.total = 0
 
-    spice_openff_data._fetch_singlepoint_from_qcarchive(
-        dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
-        specification_name=specification_name,
-        local_database_name=local_database_name,
-        local_path_dir=local_path_dir,
-        force_download=False,
-        unit_testing_max_records=10,
-        pbar=pbar,
-    )
+#     spice_openff_data._fetch_singlepoint_from_qcarchive(
+#         dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
+#         specification_name=specification_name,
+#         local_database_name=local_database_name,
+#         local_path_dir=local_path_dir,
+#         force_download=False,
+#         unit_testing_max_records=10,
+#         pbar=pbar,
+#     )
 
-    assert pbar.total == 8
-    with SqliteDict(
-        f"{local_path_dir}/{local_database_name}",
-        tablename=specification_name,
-        autocommit=True,
-    ) as spice_db:
-        keys = list(spice_db.keys())
+#     assert pbar.total == 8
+#     with SqliteDict(
+#         f"{local_path_dir}/{local_database_name}",
+#         tablename=specification_name,
+#         autocommit=True,
+#     ) as spice_db:
+#         keys = list(spice_db.keys())
 
-        assert len(keys) == 10
+#         assert len(keys) == 10
 
 
 # def test_spice12_openff_test_process_downloaded(prep_temp_dir):

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -245,7 +245,7 @@ def test_pairlist():
 @pytest.mark.parametrize("dataset", DATASETS)
 def test_pairlist_on_dataset(dataset):
     from modelforge.dataset.dataset import TorchDataModule
-    from modelforge.potential.models import _PairList, _NeighbourList
+    from modelforge.potential.models import _NeighbourList
 
     data = dataset(for_unit_testing=True)
     data_module = TorchDataModule(data)
@@ -279,6 +279,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
 
     for lightning in [True, False]:
         # increase precision to 64 bit
+        torch.manual_seed(1234)
         model = setup_simple_model(model_class, lightning).double()
         input_data["positions"] = input_data["positions"]
         # reference values
@@ -342,7 +343,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
         assert torch.allclose(
             rotation_forces,
             rotate_reference,
-            atol=1e-3,
+            atol=1e-4,
         )
 
         # reflection test
@@ -367,7 +368,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
         assert torch.allclose(
             reflection_forces,
             reflection(reference_forces.to(torch.float32)).double(),
-            atol=1e-3,
+            atol=1e-4,
         )
 
 

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -342,7 +342,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
         assert torch.allclose(
             rotation_forces,
             rotate_reference,
-            atol=1e-4,
+            atol=1e-3,
         )
 
         # reflection test

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -367,7 +367,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
         assert torch.allclose(
             reflection_forces,
             reflection(reference_forces.to(torch.float32)).double(),
-            atol=1e-4,
+            atol=1e-3,
         )
 
 

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -127,7 +127,7 @@ def test_pairlist_logic():
 
 
 def test_pairlist():
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import _PairList, _NeighbourList
     import torch
 
     atomic_subsystem_indices = torch.tensor([80, 80, 80, 11, 11, 11])
@@ -142,7 +142,7 @@ def test_pairlist():
         ]
     )
     cutoff = 5.0  # no relevant cutoff
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -172,7 +172,7 @@ def test_pairlist():
 
     # test with cutoff
     cutoff = 2.0  #
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -196,7 +196,7 @@ def test_pairlist():
 
     # test with complete pairlist
     cutoff = 2.0  #
-    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=False)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -208,8 +208,8 @@ def test_pairlist():
     # make sure that Pairlist and Neighborlist behave the same for large cutoffs
     cutoff = 10.0  #
     only_unique_pairs = False
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
-    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    neighborlist = _NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = _PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
     r = neighborlist(positions, atomic_subsystem_indices)
@@ -220,8 +220,8 @@ def test_pairlist():
     # make sure that they are the same also for non-redundant pairs
     cutoff = 10.0  #
     only_unique_pairs = True
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
-    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    neighborlist = _NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = _PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
     r = neighborlist(positions, atomic_subsystem_indices)
@@ -232,8 +232,8 @@ def test_pairlist():
     # this should fail
     cutoff = 2.0  #
     only_unique_pairs = True
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
-    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    neighborlist = _NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = _PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
     r = neighborlist(positions, atomic_subsystem_indices)
@@ -245,7 +245,7 @@ def test_pairlist():
 @pytest.mark.parametrize("dataset", DATASETS)
 def test_pairlist_on_dataset(dataset):
     from modelforge.dataset.dataset import TorchDataModule
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import _PairList, _NeighbourList
 
     data = dataset(for_unit_testing=True)
     data_module = TorchDataModule(data)
@@ -255,7 +255,7 @@ def test_pairlist_on_dataset(dataset):
         positions = data["positions"]
         atomic_subsystem_indices = data["atomic_subsystem_indices"]
         print(atomic_subsystem_indices)
-        pairlist = NeighbourList(cutoff=5.0)
+        pairlist = _NeighbourList(cutoff=5.0)
         r = pairlist(positions, atomic_subsystem_indices)
         print(r)
         shape_pairlist = r["pair_indices"].shape
@@ -373,7 +373,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
 
 def test_pairlist_calculate_r_ij_and_d_ij():
     # Define inputs
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import _PairList, _NeighbourList
     import torch
 
     positions = torch.tensor(
@@ -385,14 +385,14 @@ def test_pairlist_calculate_r_ij_and_d_ij():
     # Create Pairlist instance
     # --------------------------- #
     # Only unique pairs
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=True)
     pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=True
     )
 
     # Calculate r_ij and d_ij
-    r_ij = pairlist.calculate_r_ij(pair_indices, positions)
-    d_ij = pairlist.calculate_d_ij(r_ij)
+    r_ij = pairlist._calculate_r_ij(pair_indices, positions)
+    d_ij = pairlist._calculate_d_ij(r_ij)
 
     # Check if the calculated r_ij and d_ij are correct
     expected_r_ij = torch.tensor([[2.0, 0.0, 0.0], [0.0, 2.0, 1.0]])
@@ -409,14 +409,14 @@ def test_pairlist_calculate_r_ij_and_d_ij():
 
     # --------------------------- #
     # ALL pairs
-    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=False)
     pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=False
     )
 
     # Calculate r_ij and d_ij
-    r_ij = pairlist.calculate_r_ij(pair_indices, positions)
-    d_ij = pairlist.calculate_d_ij(r_ij)
+    r_ij = pairlist._calculate_r_ij(pair_indices, positions)
+    d_ij = pairlist._calculate_d_ij(r_ij)
 
     # Check if the calculated r_ij and d_ij are correct
     expected_r_ij = torch.tensor(

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -94,7 +94,7 @@ def test_pairlist_logic():
     # Concatenate to form final (2, n_pairs) tensor
     final_pair_indices = torch.stack((i_final_pairs, j_final_pairs))
 
-    torch.allclose(
+    assert torch.allclose(
         final_pair_indices,
         torch.tensor([[0, 0, 1, 3, 5, 5, 6, 8], [1, 2, 2, 4, 6, 7, 7, 9]]),
     )
@@ -127,7 +127,7 @@ def test_pairlist_logic():
 
 
 def test_pairlist():
-    from modelforge.potential.models import PairList
+    from modelforge.potential.models import PairList, NeighbourList
     import torch
 
     atomic_subsystem_indices = torch.tensor([80, 80, 80, 11, 11, 11])
@@ -142,7 +142,7 @@ def test_pairlist():
         ]
     )
     cutoff = 5.0  # no relevant cutoff
-    pairlist = PairList(cutoff, only_unique_pairs=True)
+    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -172,13 +172,13 @@ def test_pairlist():
 
     # test with cutoff
     cutoff = 2.0  #
-    pairlist = PairList(cutoff, only_unique_pairs=True)
+    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
-    torch.allclose(pair_indices, torch.tensor([[0, 1, 3, 4], [1, 2, 4, 5]]))
+    assert torch.equal(pair_indices, torch.tensor([[0, 1, 3, 4], [1, 2, 4, 5]]))
     # pairs that are excluded through cutoff: (0,2) and (3,5)
-    torch.allclose(
+    assert torch.equal(
         r["r_ij"],
         torch.tensor(
             [
@@ -190,24 +190,62 @@ def test_pairlist():
         ),
     )
 
-    torch.allclose(r["d_ij"], torch.tensor([1.7321, 1.7321, 1.7321, 1.7321]))
+    assert torch.allclose(
+        r["d_ij"], torch.tensor([1.7321, 1.7321, 1.7321, 1.7321]), atol=1e-3
+    )
 
     # test with complete pairlist
     cutoff = 2.0  #
-    pairlist = PairList(cutoff, only_unique_pairs=False)
+    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
     print(pair_indices, flush=True)
-    torch.allclose(
+    assert torch.equal(
         pair_indices, torch.tensor([[0, 1, 1, 2, 3, 4, 4, 5], [1, 0, 2, 1, 4, 3, 5, 4]])
     )
+
+    # make sure that Pairlist and Neighborlist behave the same for large cutoffs
+    cutoff = 10.0  #
+    only_unique_pairs = False
+    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    r = pairlist(positions, atomic_subsystem_indices)
+    pair_indices = r["pair_indices"]
+    r = neighborlist(positions, atomic_subsystem_indices)
+    neighbor_indices = r["pair_indices"]
+
+    assert torch.equal(pair_indices, neighbor_indices)
+
+    # make sure that they are the same also for non-redundant pairs
+    cutoff = 10.0  #
+    only_unique_pairs = True
+    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    r = pairlist(positions, atomic_subsystem_indices)
+    pair_indices = r["pair_indices"]
+    r = neighborlist(positions, atomic_subsystem_indices)
+    neighbor_indices = r["pair_indices"]
+
+    assert torch.equal(pair_indices, neighbor_indices)
+
+    # this should fail
+    cutoff = 2.0  #
+    only_unique_pairs = True
+    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    r = pairlist(positions, atomic_subsystem_indices)
+    pair_indices = r["pair_indices"]
+    r = neighborlist(positions, atomic_subsystem_indices)
+    neighbor_indices = r["pair_indices"]
+
+    assert not pair_indices.shape == neighbor_indices.shape
 
 
 @pytest.mark.parametrize("dataset", DATASETS)
 def test_pairlist_on_dataset(dataset):
     from modelforge.dataset.dataset import TorchDataModule
-    from modelforge.potential.models import PairList
+    from modelforge.potential.models import PairList, NeighbourList
 
     data = dataset(for_unit_testing=True)
     data_module = TorchDataModule(data)
@@ -217,7 +255,7 @@ def test_pairlist_on_dataset(dataset):
         positions = data["positions"]
         atomic_subsystem_indices = data["atomic_subsystem_indices"]
         print(atomic_subsystem_indices)
-        pairlist = PairList(cutoff=5.0)
+        pairlist = NeighbourList(cutoff=5.0)
         r = pairlist(positions, atomic_subsystem_indices)
         print(r)
         shape_pairlist = r["pair_indices"].shape
@@ -335,7 +373,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
 
 def test_pairlist_calculate_r_ij_and_d_ij():
     # Define inputs
-    from modelforge.potential.models import PairList
+    from modelforge.potential.models import PairList, NeighbourList
     import torch
 
     positions = torch.tensor(
@@ -347,8 +385,8 @@ def test_pairlist_calculate_r_ij_and_d_ij():
     # Create Pairlist instance
     # --------------------------- #
     # Only unique pairs
-    pairlist = PairList(cutoff, only_unique_pairs=True)
-    pair_indices = pairlist.calculate_neighbors(
+    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=True
     )
 
@@ -371,8 +409,8 @@ def test_pairlist_calculate_r_ij_and_d_ij():
 
     # --------------------------- #
     # ALL pairs
-    pairlist = PairList(cutoff, only_unique_pairs=False)
-    pair_indices = pairlist.calculate_neighbors(
+    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
+    pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=False
     )
 

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -1,23 +1,23 @@
-from modelforge.potential import GaussianRBF
+from modelforge.potential import _GaussianRBF
 import torch
 
 
 def test_gaussian_rbf_1D():
     dist = torch.tensor([[[1.0]]])
 
-    rbf_expension = GaussianRBF(n_rbf=6, cutoff=5.0)
+    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=5.0)
     expt = torch.exp(-0.5 * torch.tensor([[[1.0, 0.0, 1.0, 4.0, 9.0, 16.0]]]))
     assert torch.allclose(expt, rbf_expension(dist), atol=0.0, rtol=1.0e-7)
     assert list(rbf_expension.parameters()) == []
 
-    rbf_expension = GaussianRBF(n_rbf=6, cutoff=5.0, trainable=True)
+    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=5.0, trainable=True)
     assert list(rbf_expension.parameters()) != []
 
 
 def test_gaussian_rbf_3D():
     dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]])
     # smear using 4 Gaussian functions with 1. spacing
-    smear = GaussianRBF(start=1.0, cutoff=4.0, n_rbf=4)
+    smear = _GaussianRBF(start=1.0, cutoff=4.0, n_rbf=4)
     # absolute value of centered distances
     expt = torch.tensor(
         [

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -3,21 +3,28 @@ import torch
 
 
 def test_gaussian_rbf_1D():
-    dist = torch.tensor([[[1.0]]])
+    dist = (
+        torch.tensor([[[1.0]]]) / 10
+    )  # NOTE: converting to nanometer, NOTE: invariant as long as consisten units are used
+    from openmm import unit
 
-    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=5.0)
+    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom))
     expt = torch.exp(-0.5 * torch.tensor([[[1.0, 0.0, 1.0, 4.0, 9.0, 16.0]]]))
-    assert torch.allclose(expt, rbf_expension(dist), atol=0.0, rtol=1.0e-7)
+    assert torch.allclose(expt, rbf_expension(dist), atol=1e-4)
     assert list(rbf_expension.parameters()) == []
 
-    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=5.0, trainable=True)
+    rbf_expension = _GaussianRBF(
+        n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom), trainable=True
+    )
     assert list(rbf_expension.parameters()) != []
 
 
 def test_gaussian_rbf_3D():
-    dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]])
+    from openmm import unit
+
+    dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]]) / 10
     # smear using 4 Gaussian functions with 1. spacing
-    smear = _GaussianRBF(start=1.0, cutoff=4.0, n_rbf=4)
+    smear = _GaussianRBF(start=.1, cutoff=unit.Quantity(4.0, unit.angstrom), n_rbf=4)
     # absolute value of centered distances
     expt = torch.tensor(
         [
@@ -28,5 +35,5 @@ def test_gaussian_rbf_3D():
         ]
     )
     expt = torch.exp(-0.5 * expt**2)
-    assert torch.allclose(expt, smear(dist), atol=0.0, rtol=1.0e-7)
+    assert torch.allclose(expt, smear(dist), atol=1e-5)
     assert list(smear.parameters()) == []

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -6,7 +6,7 @@ def test_gaussian_rbf_1D():
     dist = (
         torch.tensor([[[1.0]]]) / 10
     )  # NOTE: converting to nanometer, NOTE: invariant as long as consisten units are used
-    from openmm import unit
+    from openff.units import unit
 
     rbf_expension = _GaussianRBF(n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom))
     expt = torch.exp(-0.5 * torch.tensor([[[1.0, 0.0, 1.0, 4.0, 9.0, 16.0]]]))
@@ -14,17 +14,17 @@ def test_gaussian_rbf_1D():
     assert list(rbf_expension.parameters()) == []
 
     rbf_expension = _GaussianRBF(
-        n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom), trainable=True
+        n_rbf=6, cutoff=5.0*unit.angstrom, trainable=True
     )
     assert list(rbf_expension.parameters()) != []
 
 
 def test_gaussian_rbf_3D():
-    from openmm import unit
+    from openff.units import unit
 
     dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]]) / 10
     # smear using 4 Gaussian functions with 1. spacing
-    smear = _GaussianRBF(start=.1, cutoff=unit.Quantity(4.0, unit.angstrom), n_rbf=4)
+    smear = _GaussianRBF(start=.1, cutoff=4.0*unit.angstrom, n_rbf=4)
     # absolute value of centered distances
     expt = torch.tensor(
         [

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -20,7 +20,7 @@ def test_PaiNN_init(lightning):
     assert painn is not None, "PaiNN model should be initialized."
 
 
-from openmm import unit
+from openff.units import unit
 
 
 @pytest.mark.parametrize("lightning", [True, False])

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -20,11 +20,18 @@ def test_PaiNN_init(lightning):
     assert painn is not None, "PaiNN model should be initialized."
 
 
+from openmm import unit
+
+
 @pytest.mark.parametrize("lightning", [True, False])
 @pytest.mark.parametrize("input_data", SIMPLIFIED_INPUT_DATA)
 @pytest.mark.parametrize(
     "model_parameter",
-    ([64, 50, 2, 5.0, 2], [32, 60, 10, 7.0, 1], [128, 120, 5, 5.0, 3]),
+    (
+        [64, 50, 2, unit.Quantity(5.0, unit.angstrom), 2],
+        [32, 60, 10, unit.Quantity(7.0, unit.angstrom), 1],
+        [128, 120, 5, unit.Quantity(5.0, unit.angstrom), 3],
+    ),
 )
 def test_painn_forward(lightning, input_data, model_parameter):
     """

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -15,11 +15,18 @@ def test_Schnet_init(lightning):
     assert schnet is not None, "Schnet model should be initialized."
 
 
+from openmm import unit
+
+
 @pytest.mark.parametrize("lightning", [True, False])
 @pytest.mark.parametrize("input_data", SIMPLIFIED_INPUT_DATA)
 @pytest.mark.parametrize(
     "model_parameter",
-    ([64, 50, 20, 5.0, 2], [32, 60, 10, 7.0, 1], [128, 120, 64, 5.0, 3]),
+    (
+        [64, 50, 20, unit.Quantity(5.0, unit.angstrom), 2],
+        [32, 60, 10, unit.Quantity(7.0, unit.angstrom), 1],
+        [128, 120, 64, unit.Quantity(5.0, unit.angstrom), 3],
+    ),
 )
 def test_schnet_forward(lightning, input_data, model_parameter):
     """
@@ -73,7 +80,7 @@ def test_schnet_interaction_layer():
     interaction = SchNETInteractionBlock(
         nr_atom_basis=nr_atom_basis, nr_filters=3, nr_rbf=nr_rbf
     )
-    
+
     v = interaction(
         interaction_data["x"],
         interaction_data["pair_indices"],

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -15,7 +15,7 @@ def test_Schnet_init(lightning):
     assert schnet is not None, "Schnet model should be initialized."
 
 
-from openmm import unit
+from openff.units import unit
 
 
 @pytest.mark.parametrize("lightning", [True, False])

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -5,12 +5,12 @@ def test_gaussian_rbf_implementation():
     # compare schnetpack GaussianRBF with modelforge GaussianRBF
     from modelforge.potential.utils import _GaussianRBF
     from schnetpack.nn import GaussianRBF as schnetpack_GaussianRBF
-    from openmm import unit
+    from openff.units import unit
 
     n_rbf = 2
     cutoff = unit.Quantity(5.0, unit.angstrom)
     schnetpack_rbf = schnetpack_GaussianRBF(
-        n_rbf=n_rbf, cutoff=cutoff.value_in_unit(unit.angstrom)
+        n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom)
     )
     rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
 
@@ -145,14 +145,14 @@ def setup_spk_painn_representation(cutoff, nr_atom_basis, n_rbf):
     # set up the schnetpack Painn representation model
     from schnetpack.nn import GaussianRBF, CosineCutoff
     from schnetpack.representation import PaiNN as schnetpack_PaiNN
-    from openmm import unit
+    from openff.units import unit
 
-    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff.value_in_unit(unit.angstrom))
+    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom))
     return schnetpack_PaiNN(
         n_atom_basis=nr_atom_basis,
         n_interactions=3,
         radial_basis=radial_basis,
-        cutoff_fn=CosineCutoff(cutoff.value_in_unit(unit.angstrom)),
+        cutoff_fn=CosineCutoff(cutoff.to(unit.angstrom)),
     )
 
 
@@ -164,7 +164,7 @@ def setup_modelforge_painn_representation(cutoff, nr_atom_basis, n_rbf):
     from modelforge.potential import _CosineCutoff, _GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
     from modelforge.potential.painn import PaiNN
-    from openmm import unit
+    from openff.units import unit
 
     embedding = SlicedEmbedding(max_Z=100, embedding_dim=nr_atom_basis, sliced_dim=0)
     radial_basis = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
@@ -182,7 +182,7 @@ def test_painn_representation_implementation():
     # ---------------------------------------- #
     # test the implementation of the representation part of the PaiNN model
     # ---------------------------------------- #
-    from openmm import unit
+    from openff.units import unit
 
     cutoff = unit.Quantity(5.0, unit.angstrom)
     nr_atom_basis = 8

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -152,7 +152,7 @@ def setup_spk_painn_representation(cutoff, nr_atom_basis, n_rbf):
         n_atom_basis=nr_atom_basis,
         n_interactions=3,
         radial_basis=radial_basis,
-        cutoff_fn=CosineCutoff(cutoff.to(unit.angstrom)),
+        cutoff_fn=CosineCutoff(cutoff.to(unit.angstrom).m),
     )
 
 

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -147,7 +147,7 @@ def setup_spk_painn_representation(cutoff, nr_atom_basis, n_rbf):
     from schnetpack.representation import PaiNN as schnetpack_PaiNN
     from openff.units import unit
 
-    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom))
+    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom).m)
     return schnetpack_PaiNN(
         n_atom_basis=nr_atom_basis,
         n_interactions=3,

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -10,7 +10,7 @@ def test_gaussian_rbf_implementation():
     n_rbf = 2
     cutoff = unit.Quantity(5.0, unit.angstrom)
     schnetpack_rbf = schnetpack_GaussianRBF(
-        n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom)
+        n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom).m
     )
     rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
 

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -3,13 +3,13 @@ import torch
 
 def test_gaussian_rbf_implementation():
     # compare schnetpack GaussianRBF with modelforge GaussianRBF
-    from modelforge.potential.utils import GaussianRBF
+    from modelforge.potential.utils import _GaussianRBF
     from schnetpack.nn import GaussianRBF as schnetpack_GaussianRBF
 
     n_rbf = 2
     cutoff = 5.0
     schnetpack_rbf = schnetpack_GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
-    rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
 
     r = torch.rand(5, 3)
     schnetpack_rbf(r)
@@ -155,12 +155,12 @@ def setup_modelforge_painn_representation(cutoff, nr_atom_basis, n_rbf):
     # set up the modelforge Painn representation model
     # which means that we only want to call the
     # _transform_input() method
-    from modelforge.potential import CosineCutoff, GaussianRBF
+    from modelforge.potential import CosineCutoff, _GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
     from modelforge.potential.painn import PaiNN
 
     embedding = SlicedEmbedding(max_Z=100, embedding_dim=nr_atom_basis, sliced_dim=0)
-    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    radial_basis = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
     cutoff = CosineCutoff(cutoff)
 
     return PaiNN(

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -5,16 +5,19 @@ def test_gaussian_rbf_implementation():
     # compare schnetpack GaussianRBF with modelforge GaussianRBF
     from modelforge.potential.utils import _GaussianRBF
     from schnetpack.nn import GaussianRBF as schnetpack_GaussianRBF
+    from openmm import unit
 
     n_rbf = 2
-    cutoff = 5.0
-    schnetpack_rbf = schnetpack_GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    cutoff = unit.Quantity(5.0, unit.angstrom)
+    schnetpack_rbf = schnetpack_GaussianRBF(
+        n_rbf=n_rbf, cutoff=cutoff.value_in_unit(unit.angstrom)
+    )
     rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
 
     r = torch.rand(5, 3)
-    schnetpack_rbf(r)
-    rbf(r)
-    assert torch.allclose(schnetpack_rbf(r), rbf(r))
+    print(schnetpack_rbf(r))
+    print(rbf(r / 10))
+    assert torch.allclose(schnetpack_rbf(r), rbf(r / 10), atol=1e-8)
     assert schnetpack_rbf.n_rbf == rbf.n_rbf
 
 

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 import pytest
 
-from modelforge.potential.utils import CosineCutoff, cosine_cutoff, GaussianRBF
+from modelforge.potential.utils import CosineCutoff, _cosine_cutoff, _GaussianRBF
 
 
 def test_cosine_cutoff():
@@ -19,7 +19,7 @@ def test_cosine_cutoff():
     expected_output = 0.5 * (np.cos(np.pi * d_ij / cutoff) + 1) if d_ij <= cutoff else 0
 
     # Calculate actual output
-    actual_output = cosine_cutoff(d_ij, cutoff)
+    actual_output = _cosine_cutoff(d_ij, cutoff)
 
     # Check if the results are equal
     assert np.isclose(actual_output, expected_output)
@@ -27,7 +27,7 @@ def test_cosine_cutoff():
     d_ij = torch.tensor([1.0, 2.0, 3.0])
     cutoff = 2.0
     expected_output = torch.tensor([0.5, 0.0, 0.0])
-    output = cosine_cutoff(d_ij, cutoff)
+    output = _cosine_cutoff(d_ij, cutoff)
     assert torch.allclose(output, expected_output, rtol=1e-3)
 
 
@@ -41,7 +41,7 @@ def test_cosine_cutoff_module():
     assert torch.allclose(output, expected_output, rtol=1e-3)
 
 
-@pytest.mark.parametrize("RBF", [GaussianRBF])
+@pytest.mark.parametrize("RBF", [_GaussianRBF])
 def test_rbf(RBF):
     """
     Test the Gaussian Radial Basis Function (RBF) implementation.
@@ -59,7 +59,7 @@ def test_rbf(RBF):
     assert output.shape[2] == 20  # n_rbf dimension
 
 
-@pytest.mark.parametrize("RBF", [GaussianRBF])
+@pytest.mark.parametrize("RBF", [_GaussianRBF])
 def test_gaussian_rbf(RBF):
     # Check dimensions of output and output
     n_rbf = 5
@@ -89,7 +89,7 @@ def test_gaussian_rbf(RBF):
     assert expected_output.shape == (3, n_rbf)
 
 
-@pytest.mark.parametrize("RBF", [GaussianRBF])
+@pytest.mark.parametrize("RBF", [_GaussianRBF])
 def test_rbf_invariance(RBF):
     # Define a set of coordinates
     coordinates = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
@@ -141,11 +141,11 @@ def test_GaussianRBF():
     Test the GaussianRBF layer.
     """
 
-    from modelforge.potential import GaussianRBF
+    from modelforge.potential import _GaussianRBF
 
     n_rbf = 10
     dim_of_x = 3
-    layer = GaussianRBF(10, 5.0)
+    layer = _GaussianRBF(10, 5.0)
     x = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
     y = layer(x)  # Shape: [dim_of_x, n_rbf]
 

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -79,7 +79,7 @@ def test_gaussian_rbf(RBF):
     assert gaussian_rbf.n_rbf == n_rbf
 
     # Test that the cutoff distance is correct
-    assert gaussian_rbf.cutoff == cutoff.value_in_unit_system(unit.md_unit_system)
+    assert gaussian_rbf.cutoff == cutoff.to(unit.nanometer).m
 
     # Test that the widths and offsets are correct
     expected_offsets = torch.linspace(

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -28,7 +28,7 @@ def test_cosine_cutoff():
 
 def test_cosine_cutoff_module():
     # Test CosineCutoff module
-    from openmm import unit
+    from openff.units import unit
 
     # test the cutoff on this distance vector (NOTE: it is in angstrom)
     d_ij_angstrom = torch.tensor([1.0, 2.0, 3.0])
@@ -55,7 +55,7 @@ def test_rbf(RBF):
 
     batch = return_single_batch(QM9Dataset, mode="fit")
     pairlist = prepare_pairlist_for_single_batch(batch)
-    from openmm import unit
+    from openff.units import unit
 
     radial_basis = RBF(n_rbf=20, cutoff=unit.Quantity(5.0, unit.angstrom))
     output = radial_basis(pairlist["d_ij"])  # Shape: [n_pairs, n_rbf]
@@ -66,7 +66,7 @@ def test_rbf(RBF):
 @pytest.mark.parametrize("RBF", [_GaussianRBF])
 def test_gaussian_rbf(RBF):
     # Check dimensions of output and output
-    from openmm import unit
+    from openff.units import unit
 
     n_rbf = 5
     cutoff = unit.Quantity(10.0, unit.angstrom)
@@ -83,7 +83,7 @@ def test_gaussian_rbf(RBF):
 
     # Test that the widths and offsets are correct
     expected_offsets = torch.linspace(
-        start, cutoff.value_in_unit(unit.nanometer), n_rbf
+        start, cutoff.to(unit.nanometer), n_rbf
     )
     expected_widths = torch.abs(
         expected_offsets[1] - expected_offsets[0]
@@ -100,7 +100,7 @@ def test_gaussian_rbf(RBF):
 @pytest.mark.parametrize("RBF", [_GaussianRBF])
 def test_rbf_invariance(RBF):
     # Define a set of coordinates
-    from openmm import unit
+    from openff.units import unit
 
     coordinates = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]) / 10
 
@@ -152,7 +152,7 @@ def test_GaussianRBF():
     """
 
     from modelforge.potential import _GaussianRBF
-    from openmm import unit
+    from openff.units import unit
 
     n_rbf = 10
     dim_of_x = 3

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -83,7 +83,7 @@ def test_gaussian_rbf(RBF):
 
     # Test that the widths and offsets are correct
     expected_offsets = torch.linspace(
-        start, cutoff.to(unit.nanometer), n_rbf
+        start, cutoff.to(unit.nanometer).m, n_rbf
     )
     expected_widths = torch.abs(
         expected_offsets[1] - expected_offsets[0]

--- a/modelforge/utils/remote.py
+++ b/modelforge/utils/remote.py
@@ -1,3 +1,5 @@
+
+
 """Module for querying and fetching datafiles from remote sources"""
 
 from typing import Optional, List, Dict

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -6,7 +6,7 @@ from modelforge.potential.painn import LighningPaiNN
 from modelforge.potential import _CosineCutoff, _GaussianRBF
 from modelforge.potential.utils import SlicedEmbedding
 
-from openmm import unit
+from openff.units import unit
 
 max_atomic_number = 100
 nr_atom_basis = 128

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -1,0 +1,50 @@
+# This is an example script that trains the PaiNN model on the .
+from lightning import Trainer
+import torch
+from modelforge.potential.painn import LighningPaiNN
+
+from modelforge.potential import _CosineCutoff, _GaussianRBF
+from modelforge.potential.utils import SlicedEmbedding
+
+from openmm import unit
+
+max_atomic_number = 100
+nr_atom_basis = 128
+nr_rbf = 20
+nr_interaction_blocks = 4
+
+cutoff = unit.Quantity(5, unit.angstrom)
+embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
+assert embedding.embedding_dim == nr_atom_basis
+rbf = _GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)
+
+cutoff = _CosineCutoff(cutoff=cutoff)
+
+model = LighningPaiNN(
+    embedding=embedding,
+    nr_interaction_blocks=nr_interaction_blocks,
+    radial_basis=rbf,
+    cutoff=cutoff,
+)
+
+from modelforge.dataset.qm9 import QM9Dataset
+from modelforge.dataset.dataset import TorchDataModule
+
+data = QM9Dataset(for_unit_testing=False)
+dataset = TorchDataModule(data, batch_size=512)
+dataset.prepare_data()
+dataset.setup(stage="fit")
+from lightning.pytorch.callbacks.early_stopping import EarlyStopping
+
+trainer = Trainer(
+    max_epochs=10,
+    num_nodes=1,
+    callbacks=[
+        EarlyStopping(monitor="val_loss", mode="min", patience=3, min_delta=0.001)
+    ],
+)
+
+# Move model to the appropriate dtype and device
+model = model.to(torch.float32)
+# Run training loop and validate
+trainer.fit(model, dataset.train_dataloader(), dataset.val_dataloader())


### PR DESCRIPTION
## Description
Currently, we are not enforcing units at several public interfaces. This PR aims to fix this and enforces the internal use of the openmm unit system. This PR will close issues #54 and #32.
The `forward` call of the models will check for units attached to `positions` and convert them to nanometers if possible. If no units are attached, it will assume that the units are in nanometers and print a warning to stderr.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Refactor all public APIs to ensure that we check and validate units
  - [x] Conversion to openmm unit system

## Status
- [x] Ready to go