### PR TITLE
Pre-processing dataset energies

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,6 +10,7 @@ dependencies:
   - h5py
   - requests
   - tqdm
+  - openmm
   - qcelemental=0.25.1
   - qcportal>=0.50
   - pytorch>=2.1

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,7 +10,6 @@ dependencies:
   - h5py
   - requests
   - tqdm
-  - openmm
   - qcelemental=0.25.1
   - qcportal>=0.50
   - pytorch>=2.1
@@ -24,7 +23,6 @@ dependencies:
   - rdkit
   - retry
   - sqlitedict
-  #- schnetpack>=2.0.0
 
   # Testing
   - pytest>=2.1

--- a/modelforge/curation/curation_baseclass.py
+++ b/modelforge/curation/curation_baseclass.py
@@ -146,6 +146,8 @@ class DatasetCuration(ABC):
         Converts the units of properties in self.data to desired output values.
 
         """
+        import pint
+
         for datapoint in self.data:
             for key, val in datapoint.items():
                 if isinstance(val, pint.Quantity):

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -584,9 +584,9 @@ class TorchDataModule(pl.LightningDataModule):
         from torch.utils.data import Subset
 
         # Adjust atomic properties by subtracting the global mean
-
         if self.offset or self.normalize:
-            modified_dataset = TorchDataModule.preprocess_dataset(
+            log.info("Removing offset and/or normalizing energies")
+            TorchDataModule.preprocess_dataset(
                 self.dataset,
                 self.normalize,
                 self.dataset_mean,

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -756,10 +756,10 @@ class TorchDataModule(pl.LightningDataModule):
         from torch.utils.data import Subset
 
         # Create subsets for training, validation, and testing
-        if self.split_idxs:
-            self.train_dataset = Subset(self.dataset, self.split_idxs["train"])
-            self.val_dataset = Subset(self.dataset, self.split_idxs["val"])
-            self.test_dataset = Subset(self.dataset, self.split_idxs["test"])
+        if self.split_idxs and os.path.exists(self.split_file):
+            self.train_dataset = Subset(self.dataset, self.split_idxs["train_idx"])
+            self.val_dataset = Subset(self.dataset, self.split_idxs["val_idx"])
+            self.test_dataset = Subset(self.dataset, self.split_idxs["test_idx"])
         else:
             # Fallback to manual splitting if split_idxs is not available
             self.train_dataset, self.val_dataset, self.test_dataset = self.split.split(

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -505,6 +505,23 @@ class TorchDataModule(pl.LightningDataModule):
 
         factory = DatasetFactory()
         self.dataset = factory.create_dataset(self.data)
+        # Initialize variables to store the sum of batch averages and the total count of elements
+        weighted_sum_of_averages = 0
+        total_count = 0
+
+        # DataLoader for iterating over batches
+        for batch in DataLoader(
+            self.dataset, batch_size=self.batch_size, collate_fn=collate_conformers
+        ):
+            # Compute the average for the current batch and count the number of elements
+            batch_sum = torch.sum(batch["E_label"])
+            atoms_in_batch = batch["atomic_numbers"].size(
+                0
+            )  # This is the number of elements in the current batch
+            batch_mean_per_atom = batch_sum / atoms_in_batch
+
+        # Compute the overall average by dividing the weighted sum of batch averages by the total count
+        self.mean_value = weighted_sum_of_averages / total_count
 
     def setup(self, stage: str) -> None:
         """

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -507,7 +507,6 @@ class TorchDataModule(pl.LightningDataModule):
     >>> data = QM9Dataset()
     >>> data_module = TorchDataModule(data)
     >>> data_module.prepare_data()
-    >>> data_module.setup()
     >>> train_loader = data_module.train_dataloader()
     """
 
@@ -665,8 +664,10 @@ class TorchDataModule(pl.LightningDataModule):
         # calculate average and variance
         if normalize:
             stats = TorchDataModule.calculate_mean_and_variance(self.dataset)
-            self.stats = stats
             self.dataset = TorchDataModule.normalize_energies(self.dataset, stats)
+            self.stats = stats
+
+        self.setup()
 
     @classmethod
     def normalize_energies(cls, dataset, stats: Dict[str, float]) -> None:

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -484,7 +484,7 @@ class TorchDataModule(pl.LightningDataModule):
     >>> data = QM9Dataset()
     >>> data_module = TorchDataModule(data)
     >>> data_module.prepare_data()
-    >>> data_module.setup("")
+    >>> data_module.setup()
     >>> train_loader = data_module.train_dataloader()
     """
 
@@ -562,7 +562,10 @@ class TorchDataModule(pl.LightningDataModule):
         self.dataset = factory.create_dataset(self.data)
         stats = TorchDataModule.compute_statistics(self.dataset)
         self.dataset_mean = stats["mean"]
-        self.dataset_std = stats["stddev"]
+        if self.normalize:
+            self.dataset_std = stats["stddev"]
+            # NOTE: oterwise it is 1, so that it does not have an impact in
+            # the inverse normalization operation
 
     @classmethod
     def preprocess_dataset(

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -56,17 +56,15 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
         if len(single_atom_start_idxs_by_rec) != len(self.series_mol_start_idxs_by_rec):
             raise ValueError(
                 "Number of records in `atomic_subsystem_counts` and `n_confs` do not match."
-                )
-
+            )
 
         self.single_atom_start_idxs_by_conf = np.repeat(
-            single_atom_start_idxs_by_rec[:self.n_records], dataset["n_confs"]
+            single_atom_start_idxs_by_rec[: self.n_records], dataset["n_confs"]
         )
         self.single_atom_end_idxs_by_conf = np.repeat(
             single_atom_start_idxs_by_rec[1 : self.n_records + 1], dataset["n_confs"]
         )
         # length: n_conformers
-
 
         self.series_atom_start_idxs_by_conf = np.concatenate(
             [
@@ -109,8 +107,6 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
             )
         )
 
-
-
     def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
         """
         Fetch a tuple of the values for the properties of interest for a given conformer index.
@@ -138,20 +134,25 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
         series_atom_end_idx = self.series_atom_start_idxs_by_conf[idx + 1]
         single_atom_start_idx = self.single_atom_start_idxs_by_conf[idx]
         single_atom_end_idx = self.single_atom_end_idxs_by_conf[idx]
-        atomic_numbers = torch.tensor(
+        atomic_numbers = (
             self.properties_of_interest["atomic_numbers"][
                 single_atom_start_idx:single_atom_end_idx
-            ],
-            dtype=torch.int64,
-        )
-        positions = torch.tensor(
+            ]
+            .clone()
+            .detach()
+        ).to(torch.int64)
+        positions = (
             self.properties_of_interest["positions"][
                 series_atom_start_idx:series_atom_end_idx
-            ],
-            dtype=torch.float32,
-        )
-        E_label = torch.tensor(
-            self.properties_of_interest["E_label"][idx], dtype=torch.float32
+            ]
+            .clone()
+            .detach()
+        ).to(torch.float32)
+        E_label = (
+            self.properties_of_interest["E_label"][idx]
+            .clone()
+            .detach()
+            .to(torch.float32)
         )
 
         return {
@@ -476,8 +477,6 @@ class TorchDataModule(pl.LightningDataModule):
         batch_size: int = 64,
         split_file: Optional[str] = None,
     ):
-        from torch.utils.data import Subset
-
         super().__init__()
         self.data = data
         self.batch_size = batch_size
@@ -552,6 +551,7 @@ class TorchDataModule(pl.LightningDataModule):
             self.train_dataset,
             batch_size=self.batch_size,
             collate_fn=collate_conformers,
+            num_workers=4,
         )
 
     def val_dataloader(self) -> DataLoader:

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -260,9 +260,9 @@ class HDF5Dataset:
 
                 if all(property_found):
                     # we want to exclude conformers with NaN values for any property of interest
-                    configs_nan_by_prop: Dict[
-                        str, np.ndarray
-                    ] = OrderedDict()  # ndarray.size (n_configs, )
+                    configs_nan_by_prop: Dict[str, np.ndarray] = (
+                        OrderedDict()
+                    )  # ndarray.size (n_configs, )
                     for value in list(series_mol_data.keys()) + list(
                         series_atom_data.keys()
                     ):
@@ -447,6 +447,9 @@ class DatasetFactory:
         return TorchDataset(data.numpy_data, data._property_names)
 
 
+from torch import nn
+
+
 class TorchDataModule(pl.LightningDataModule):
     """
     A custom data module class to handle data loading and preparation for PyTorch Lightning training.
@@ -476,6 +479,7 @@ class TorchDataModule(pl.LightningDataModule):
         split: SplittingStrategy = RandomRecordSplittingStrategy(),
         batch_size: int = 64,
         split_file: Optional[str] = None,
+        transform: nn.Module = None,
     ):
         super().__init__()
         self.data = data

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -564,7 +564,10 @@ class TorchDataModule(pl.LightningDataModule):
             DataLoader containing the validation dataset.
         """
         return DataLoader(
-            self.val_dataset, batch_size=self.batch_size, collate_fn=collate_conformers
+            self.val_dataset,
+            batch_size=self.batch_size,
+            collate_fn=collate_conformers,
+            num_workers=4,
         )
 
     def test_dataloader(self) -> DataLoader:

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -522,10 +522,7 @@ class TorchDataModule(pl.LightningDataModule):
         self.split_file = split_file
         self.dataset_statistics = {}
 
-    @classmethod
-    def calculate_self_energies(
-        cls, dataset: TorchDataset, collate: bool = True
-    ) -> Dict[str, float]:
+    def calculate_self_energies(self, collate: bool = True) -> Dict[str, float]:
         """
         Calculates the self energies for each atomic number in the dataset by performing a least squares regression.
 
@@ -542,74 +539,11 @@ class TorchDataModule(pl.LightningDataModule):
             A dictionary mapping atomic numbers to their calculated self energies.
         """
         log.info("Computing self energies for elements in the dataset.")
+        from modelforge.dataset.utils import calculate_self_energies
 
         # Define the collate function based on the `collate` parameter
         collate_fn = collate_conformers if collate else None
-
-        # Initialize variables to hold data for regression
-        batch_size = 64
-        # Determine the size of the counts tensor
-        num_molecules = dataset.n_records
-        # Determine up to which Z we detect elements
-        max_atomic_number = 100
-        # Initialize the counts tensor
-        counts = torch.zeros(num_molecules, max_atomic_number + 1, dtype=torch.int16)
-        # save energies in list
-        energy_array = torch.zeros(dataset.n_records, dtype=torch.float64)
-        # for filling in the element count matrix
-        molecule_counter = 0
-        # counter for saving energy values
-        current_index = 0
-        # save unique atomic numbers in list
-        unique_atomic_numbers = set()
-
-        for batch in DataLoader(dataset, batch_size=batch_size, collate_fn=collate_fn):
-            energies, atomic_numbers, molecules_id = (
-                batch["E_label"].squeeze(),
-                batch["atomic_numbers"].squeeze(-1),
-                batch["atomic_subsystem_indices"].to(torch.int64),
-            )
-
-            # Update the energy array and unique atomic numbers set
-            batch_size = energies.size(0)
-            energy_array[current_index : current_index + batch_size] = (
-                energies.squeeze()
-            )
-            current_index += batch_size
-            unique_atomic_numbers |= set(atomic_numbers.tolist())
-            atomic_numbers_ = atomic_numbers - 1
-
-            # Count the occurrence of each atomic number in molecules
-            for molecule_id in molecules_id.unique():
-                mask = molecules_id == molecule_id
-                counts[molecule_counter].scatter_add_(
-                    0, atomic_numbers_[mask], torch.ones_like(atomic_numbers_[mask])
-                )
-                molecule_counter += 1
-
-        # Prepare the data for lineare regression
-        valid_elements_mask = counts.sum(dim=0) > 0
-        filtered_counts = counts[:, valid_elements_mask]
-
-        Xs = [
-            filtered_counts[:, i].unsqueeze(1).detach().numpy()
-            for i in range(filtered_counts.shape[1])
-        ]
-
-        A = np.hstack(Xs)
-        y = energy_array.numpy()
-
-        # Perform least squares regression
-        least_squares_fit, _, _, _ = np.linalg.lstsq(A, y, rcond=None)
-        self_energies = {
-            idx: energy for idx, energy in zip(unique_atomic_numbers, least_squares_fit)
-        }
-
-        log.info("Calculated self energies for elements.")
-
-        log.info("Coefficients for each element:", self_energies)
-        print(self_energies)
-        return self_energies
+        return calculate_self_energies(self.dataset, collate_fn)
 
     # print information about the unit system used in the dataset
     def print_unit_system(self) -> None:
@@ -652,55 +586,38 @@ class TorchDataModule(pl.LightningDataModule):
         self.dataset = factory.create_dataset(self.data)
         dataset_statistics = {}
         # calculate self energies
+        import toml
+
         if remove_self_energies:
+            log.debug("Self energies are removed ...")
             if not self_energies:
-                self_energies = TorchDataModule.calculate_self_energies(self.dataset)
-            self.dataset = TorchDataModule.remove_self_energies(
-                self.dataset, self_energies
-            )
+                log.debug("No self energies are provided, calculating them ...")
+                self_energies = self.calculate_self_energies()
+            self.dataset = self.remove_self_energies(self.dataset, self_energies)
+            # save the self energies that are removed from the dataset
             dataset_statistics["self_energies"] = self_energies
+            with open("ase.toml", "w") as f:
+                self_energies_ = {
+                    str(idx): energy for idx, energy in self_energies.items()
+                }
+                toml.dump(self_energies_, f)
 
         # calculate average and variance
         if normalize:
-            stats = TorchDataModule.calculate_mean_and_variance(self.dataset)
-            self.dataset = TorchDataModule.normalize_energies(self.dataset, stats)
+            from modelforge.dataset.utils import (
+                calculate_mean_and_variance,
+                normalize_energies,
+            )
+
+            stats = calculate_mean_and_variance(self.dataset)
+            self.dataset = normalize_energies(self.dataset, stats)
             dataset_statistics["stddev"] = stats["stddev"]
             dataset_statistics["mean"] = stats["mean"]
 
         self.dataset_statistics = dataset_statistics
         self.setup()
 
-    @classmethod
-    def normalize_energies(cls, dataset, stats: Dict[str, float]) -> None:
-        """
-        Normalizes the energies in the dataset.
-        """
-        from tqdm import tqdm
-
-        for i in tqdm(range(len(dataset)), desc="Adjusting Energies"):
-            energy = dataset[i]["E_label"]
-            # Normalize using the computed mean and std
-            modified_energy = (energy - stats["mean"]) / stats["stddev"]
-            dataset[i] = {"E_label": modified_energy}
-
-        return dataset
-
-    @classmethod
-    def calculate_mean_and_variance(cls, dataset) -> Dict[str, float]:
-        """
-        Calculates the mean and variance of the dataset.
-
-        """
-        import numpy as np
-
-        log.info("Calculating mean and variance for normalization")
-        energies = np.array([dataset[i]["E_label"] for i in range(len(dataset))])
-        stats = {"mean": energies.mean(), "stddev": energies.std()}
-        log.info(f"Mean and standard deviation of the dataset:{stats}")
-        return stats
-
-    @classmethod
-    def remove_self_energies(cls, dataset, self_energies: Dict[str, float]) -> None:
+    def remove_self_energies(self, dataset, self_energies: Dict[str, float]) -> None:
         """
         Removes the self energies from the dataset.
 
@@ -711,12 +628,15 @@ class TorchDataModule(pl.LightningDataModule):
         """
         from tqdm import tqdm
 
+        print(self_energies)
+        print(self_energies[1])
+
         log.info("Removing self energies from the dataset")
         for i in tqdm(range(len(dataset)), desc="Removing Self Energies"):
             atomic_numbers = dataset[i]["atomic_numbers"]
             E_label = dataset[i]["E_label"]
             for idx, Z in enumerate(atomic_numbers):
-                E_label -= self_energies[Z.item()]
+                E_label -= self_energies[int(Z.item())]
             dataset[i] = {"E_label": E_label}
         return dataset
 

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -559,7 +559,7 @@ class TorchDataModule(pl.LightningDataModule):
         self,
         remove_self_energies: bool = True,
         normalize: bool = False,
-        self_energies: Dict[str, float] = {},
+        self_energies: Dict[str, float] = None,
         regression_ase: bool = False,
     ) -> None:
         """
@@ -572,13 +572,13 @@ class TorchDataModule(pl.LightningDataModule):
         normalize : bool, optional
             Whether to normalize the dataset. Defaults to True.
         self_energies : Dict[str, float], optional
-            A dictionary mapping atomic numbers to their calculated self energies. Defaults to {}.
+            A dictionary mapping atomic numbers to their calculated self energies. Defaults to None.
         regression_ase : bool, optional
             If regression_ase is True, atomic self energies are calculated using linear regression
 
         if remove_self_energies is True and
             - self_energies are passed as dictionary, these will be used
-            - self_energies are {}, self._ase will be used
+            - self_energies are None, self._ase will be used
             - regression_ase is True, self_energies will be calculated
         """
 

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -149,10 +149,11 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
             .detach()
         ).to(torch.float32)
         E_label = (
-            self.properties_of_interest["E_label"][idx]
+            (self.properties_of_interest["E_label"][idx])
             .clone()
             .detach()
-            .to(torch.float64)  # NOTE: upgrading to float64 to avoid precision issues
+            .to(torch.float64)
+        )  # NOTE: upgrading to float64 to avoid precision issues
 
         return {
             "atomic_numbers": atomic_numbers,
@@ -468,7 +469,7 @@ class TorchDataModule(pl.LightningDataModule):
     >>> data = QM9Dataset()
     >>> data_module = TorchDataModule(data)
     >>> data_module.prepare_data()
-    >>> data_module.setup("fit")
+    >>> data_module.setup("")
     >>> train_loader = data_module.train_dataloader()
     """
 

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -553,7 +553,7 @@ class TorchDataModule(pl.LightningDataModule):
         # Determine up to which Z we detect elements
         max_atomic_number = 100
         # Initialize the counts tensor
-        counts = torch.zeros(num_molecules, max_atomic_number + 1, dtype=torch.int64)
+        counts = torch.zeros(num_molecules, max_atomic_number + 1, dtype=torch.int16)
         # save energies in list
         energy_array = torch.zeros(dataset.n_records, dtype=torch.float64)
         # for filling in the element count matrix

--- a/modelforge/dataset/qm9.py
+++ b/modelforge/dataset/qm9.py
@@ -95,8 +95,10 @@ class QM9Dataset(HDF5Dataset):
         )
         self.dataset_name = dataset_name
         self.for_unit_testing = for_unit_testing
-        self.test_id = "18C9Iq_7VZLx0gZbJYje8X6tybZb5m3JY"
-        self.full_id = "1damjPgjKviTogDJ2UJvhYjyBZxGvRPP-"
+        self.test_url = (
+            "https://github.com/wiederm/gm9/raw/main/qm9_dataset_n100.hdf5.gz"
+        )
+        self.full_url = "https://github.com/wiederm/gm9/raw/main/qm9.hdf5.gz"
 
     @property
     def properties_of_interest(self) -> List[str]:
@@ -164,7 +166,9 @@ class QM9Dataset(HDF5Dataset):
         >>> data.download()  # Downloads the dataset from Google Drive
 
         """
-        from modelforge.dataset.utils import _download_from_gdrive
+        from modelforge.dataset.utils import _download_from_gh
+        import requests
 
-        id = self.test_id if self.for_unit_testing else self.full_id
-        _download_from_gdrive(id, self.raw_data_file)
+        url = self.test_url if self.for_unit_testing else self.full_url
+        _download_from_gh(url, self.raw_data_file)
+        # _download_from_gdrive(id, self.raw_data_file)

--- a/modelforge/dataset/qm9.py
+++ b/modelforge/dataset/qm9.py
@@ -99,6 +99,18 @@ class QM9Dataset(HDF5Dataset):
             "https://github.com/wiederm/gm9/raw/main/qm9_dataset_n100.hdf5.gz"
         )
         self.full_url = "https://github.com/wiederm/gm9/raw/main/qm9.hdf5.gz"
+        self._ase = {
+            "H": -1313.4668615546,
+            "C": -99366.70745535441,
+            "N": -143309.9379722722,
+            "O": -197082.0671774158,
+            "F": -261811.54555874597,
+        }
+
+    @property
+    def atomic_self_energies(self):
+        from modelforge.potential.utils import AtomicSelfEnergies
+        return AtomicSelfEnergies(energies=self._ase)
 
     @property
     def properties_of_interest(self) -> List[str]:

--- a/modelforge/dataset/qm9.py
+++ b/modelforge/dataset/qm9.py
@@ -166,9 +166,9 @@ class QM9Dataset(HDF5Dataset):
         >>> data.download()  # Downloads the dataset from Google Drive
 
         """
-        from modelforge.dataset.utils import _download_from_gh
+        from modelforge.dataset.utils import _download_from_url
         import requests
 
         url = self.test_url if self.for_unit_testing else self.full_url
-        _download_from_gh(url, self.raw_data_file)
+        _download_from_url(url, self.raw_data_file)
         # _download_from_gdrive(id, self.raw_data_file)

--- a/modelforge/dataset/qm9.py
+++ b/modelforge/dataset/qm9.py
@@ -95,9 +95,6 @@ class QM9Dataset(HDF5Dataset):
         )
         self.dataset_name = dataset_name
         self.for_unit_testing = for_unit_testing
-        # self.test_id = "17oZ07UOxv2fkEmu-d5mLk6aGIuhV0mJ7"
-        # self.full_id = "1_bSdQjEvI67Tk_LKYbW0j8nmggnb5MoU"
-        # updated tests.
         self.test_id = "18C9Iq_7VZLx0gZbJYje8X6tybZb5m3JY"
         self.full_id = "1damjPgjKviTogDJ2UJvhYjyBZxGvRPP-"
 

--- a/modelforge/dataset/transformation.py
+++ b/modelforge/dataset/transformation.py
@@ -1,9 +1,0 @@
-import numpy as np
-
-from modelforge.dataset.utils import pad_molecules, pad_to_max_length
-
-default_transformation = {
-    "geometry": pad_molecules,
-    "atomic_numbers": pad_to_max_length,
-    "all": np.array,
-}

--- a/modelforge/dataset/utils.py
+++ b/modelforge/dataset/utils.py
@@ -347,20 +347,20 @@ def _download_from_gdrive(id: str, raw_dataset_file: str):
     gdown.download(url, raw_dataset_file, quiet=False)
 
 
-def _download_from_gh(url: str, raw_dataset_file: str):
+def _download_from_url(url: str, raw_dataset_file: str):
     """
-    Downloads a dataset from github lfs.
+    Downloads a dataset from a specified URLS.
 
     Parameters
     ----------
     url : str
-        gh raw link.
+        raw link address.
     raw_dataset_file : str
         Path to save the downloaded dataset.
 
     Examples
     --------
-    >>> _download_from_gh(url, "data_file.hdf5.gz")
+    >>> _download_from_url(url, "data_file.hdf5.gz")
     """
     import requests
 

--- a/modelforge/dataset/utils.py
+++ b/modelforge/dataset/utils.py
@@ -14,6 +14,106 @@ if TYPE_CHECKING:
     from modelforge.dataset.dataset import TorchDataset
 
 
+def normalize_energies(dataset, stats: Dict[str, float]) -> None:
+    """
+    Normalizes the energies in the dataset.
+    """
+    from tqdm import tqdm
+
+    for i in tqdm(range(len(dataset)), desc="Adjusting Energies"):
+        energy = dataset[i]["E_label"]
+        # Normalize using the computed mean and std
+        modified_energy = (energy - stats["mean"]) / stats["stddev"]
+        dataset[i] = {"E_label": modified_energy}
+
+    return dataset
+
+
+def calculate_mean_and_variance(dataset) -> Dict[str, float]:
+    """
+    Calculates the mean and variance of the dataset.
+
+    """
+    import numpy as np
+    from loguru import logger as log
+
+    log.info("Calculating mean and variance for normalization")
+    energies = np.array([dataset[i]["E_label"] for i in range(len(dataset))])
+    stats = {"mean": energies.mean(), "stddev": energies.std()}
+    log.info(f"Mean and standard deviation of the dataset:{stats}")
+    return stats
+
+
+def calculate_self_energies(dataset, collate_fn) -> Dict[int, float]:
+    from torch.utils.data import DataLoader
+    import torch
+    from loguru import logger as log
+
+    # Initialize variables to hold data for regression
+    batch_size = 64
+    # Determine the size of the counts tensor
+    num_molecules = dataset.n_records
+    # Determine up to which Z we detect elements
+    max_atomic_number = 100
+    # Initialize the counts tensor
+    counts = torch.zeros(num_molecules, max_atomic_number + 1, dtype=torch.int16)
+    # save energies in list
+    energy_array = torch.zeros(dataset.n_records, dtype=torch.float64)
+    # for filling in the element count matrix
+    molecule_counter = 0
+    # counter for saving energy values
+    current_index = 0
+    # save unique atomic numbers in list
+    unique_atomic_numbers = set()
+
+    for batch in DataLoader(dataset, batch_size=batch_size, collate_fn=collate_fn):
+        energies, atomic_numbers, molecules_id = (
+            batch["E_label"].squeeze(),
+            batch["atomic_numbers"].squeeze(-1).to(torch.int64),
+            batch["atomic_subsystem_indices"].to(torch.int16),
+        )
+
+        # Update the energy array and unique atomic numbers set
+        batch_size = energies.size(0)
+        energy_array[current_index : current_index + batch_size] = energies.squeeze()
+        current_index += batch_size
+        unique_atomic_numbers |= set(atomic_numbers.tolist())
+        atomic_numbers_ = atomic_numbers - 1
+
+        # Count the occurrence of each atomic number in molecules
+        for molecule_id in molecules_id.unique():
+            mask = molecules_id == molecule_id
+            counts[molecule_counter].scatter_add_(
+                0,
+                atomic_numbers_[mask],
+                torch.ones_like(atomic_numbers_[mask], dtype=torch.int16),
+            )
+            molecule_counter += 1
+
+    # Prepare the data for lineare regression
+    valid_elements_mask = counts.sum(dim=0) > 0
+    filtered_counts = counts[:, valid_elements_mask]
+
+    Xs = [
+        filtered_counts[:, i].unsqueeze(1).detach().numpy()
+        for i in range(filtered_counts.shape[1])
+    ]
+
+    A = np.hstack(Xs)
+    y = energy_array.numpy()
+
+    # Perform least squares regression
+    least_squares_fit, _, _, _ = np.linalg.lstsq(A, y, rcond=None)
+    self_energies = {
+        idx: energy for idx, energy in zip(unique_atomic_numbers, least_squares_fit)
+    }
+
+    log.debug("Calculated self energies for elements.")
+
+    log.info("Atomic self energies for each element:", self_energies)
+    return self_energies
+
+
 class SplittingStrategy(ABC):
     """
     Base class for dataset splitting strategies.

--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -1,3 +1,3 @@
 from .schnet import SchNET
 from .painn import PaiNN
-from .utils import _GaussianRBF, CosineCutoff, _shifted_softplus
+from .utils import _GaussianRBF, _CosineCutoff, _shifted_softplus

--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -1,3 +1,3 @@
 from .schnet import SchNET
 from .painn import PaiNN
-from .utils import GaussianRBF, CosineCutoff, _shifted_softplus
+from .utils import GaussianRBF, CosineCutoff, ShiftedSoftplus

--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -1,3 +1,3 @@
 from .schnet import SchNET
 from .painn import PaiNN
-from .utils import GaussianRBF, CosineCutoff, shifted_softplus
+from .utils import _GaussianRBF, CosineCutoff, _shifted_softplus

--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -1,3 +1,3 @@
 from .schnet import SchNET
 from .painn import PaiNN
-from .utils import _GaussianRBF, _CosineCutoff, _shifted_softplus
+from .utils import GaussianRBF, CosineCutoff, _shifted_softplus

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -190,32 +190,11 @@ class LightningModuleMixin(pl.LightningModule):
             "train_loss",
             loss,
             on_epoch=True,
-            on_step=False,
+            on_step=True,
             prog_bar=True,
             batch_size=batch_size,
         )
         return loss
-
-    def test_step(self, batch, batch_idx):
-        from torch.nn import functional as F
-
-        batch_size = self._log_batch_size(batch)
-
-        predictions = self.forward(batch).flatten()
-        targets = batch["E_label"].flatten()
-        test_loss = F.mse_loss(predictions, targets)
-        self.log("test_loss", test_loss, batch_size=batch_size)
-
-    def validation_step(self, batch: Dict[str, torch.Tensor], batch_idx):
-        from torch.nn import functional as F
-
-        batch_size = self._log_batch_size(batch)
-        predictions = self.forward(batch)
-        targets = batch["E_label"]
-        val_loss = F.mse_loss(predictions, targets)
-        self.log(
-            "val_loss", val_loss, batch_size=batch_size, on_epoch=True, prog_bar=True
-        )
 
     def test_step(self, batch, batch_idx):
         from torch.nn import functional as F

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -183,7 +183,7 @@ class LightningModuleMixin(pl.LightningModule):
         """
         batch_size = self._log_batch_size(batch)
         predictions = self.forward(batch).flatten()
-        targets = batch["E_label"].flatten()
+        targets = batch["E_label"].flatten().to(torch.float32)
         loss = self.loss_function(predictions, targets)
         # Specify the batch size explicitly using self.log
         self.log(
@@ -195,7 +195,6 @@ class LightningModuleMixin(pl.LightningModule):
             batch_size=batch_size,
         )
         return loss
-
 
     def test_step(self, batch, batch_idx):
         from torch.nn import functional as F

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -194,7 +194,6 @@ class LightningModuleMixin(pl.LightningModule):
             prog_bar=True,
             batch_size=batch_size,
         )
-        return loss
 
     def test_step(self, batch, batch_idx):
         from torch.nn import functional as F
@@ -213,7 +212,9 @@ class LightningModuleMixin(pl.LightningModule):
         predictions = self.forward(batch)
         targets = batch["E_label"]
         val_loss = F.mse_loss(predictions, targets)
-        self.log("val_loss", val_loss, batch_size=batch_size, on_epoch=True)
+        self.log(
+            "val_loss", val_loss, batch_size=batch_size, on_epoch=True, prog_bar=True
+        )
 
     def configure_optimizers(self) -> AdamW:
         """

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -236,7 +236,9 @@ class LightningModuleMixin(pl.LightningModule):
         predictions = self.forward(batch)
         targets = batch["E_label"]
         val_loss = F.mse_loss(predictions, targets)
-        self.log("val_loss", val_loss, batch_size=batch_size, on_epoch=True)
+        self.log(
+            "val_loss", val_loss, batch_size=batch_size, on_epoch=True, prog_bar=True
+        )
 
     def configure_optimizers(self) -> AdamW:
         """

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -214,10 +214,7 @@ class LightningModuleMixin(pl.LightningModule):
         targets = batch["E_label"]
         val_loss = F.mse_loss(predictions, targets)
         self.log(
-            "val_loss",
-            val_loss,
-            batch_size=batch_size,
-            on_epoch=True,  # prog_bar=True
+            "val_loss", val_loss, batch_size=batch_size, on_epoch=True, prog_bar=True
         )
 
     def test_step(self, batch, batch_idx):
@@ -228,7 +225,9 @@ class LightningModuleMixin(pl.LightningModule):
         predictions = self.forward(batch).flatten()
         targets = batch["E_label"].flatten()
         test_loss = F.mse_loss(predictions, targets)
-        self.log("test_loss", test_loss, batch_size=batch_size)
+        self.log(
+            "test_loss", test_loss, batch_size=batch_size, on_epoch=True, prog_bar=True
+        )
 
     def validation_step(self, batch: Dict[str, torch.Tensor], batch_idx):
         from torch.nn import functional as F

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -197,8 +197,6 @@ class LightningModuleMixin(pl.LightningModule):
         return self.optimizer(self.parameters(), lr=self.learning_rate)
 
 
-from openmm import unit
-
 
 class BaseNNP(nn.Module):
     """

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -214,7 +214,10 @@ class LightningModuleMixin(pl.LightningModule):
         targets = batch["E_label"]
         val_loss = F.mse_loss(predictions, targets)
         self.log(
-            "val_loss", val_loss, batch_size=batch_size, on_epoch=True, prog_bar=True
+            "val_loss",
+            val_loss,
+            batch_size=batch_size,
+            on_epoch=True,  # prog_bar=True
         )
 
     def test_step(self, batch, batch_idx):

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -246,9 +246,7 @@ class BaseNNP(nn.Module):
     def __init__(
         self,
         cutoff: float,
-        postprocessing: PostprocessingPipeline = PostprocessingPipeline(
-            [NoPostprocess({})]
-        ),
+        postprocessing: PostprocessingPipeline,
     ):
         """
         Initialize the NNP class.

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -205,19 +205,19 @@ class BaseNNP(nn.Module):
     Base class for neural network potentials.
     """
 
-    def __init__(self, cutoff: unit.Quantity = unit.Quantity(0.5, unit.nanometer)):
+    def __init__(self, cutoff: float):
         """
         Initialize the NNP class.
 
         Parameters
         ----------
-        cutoff : unit.Quantity, optional
-            Cutoff distance for atom centered interactions, default is 0.5 nanometer.
+        cutoff : float
+            Cutoff distance for atom centered interactions, in nanometer.
         """
         from .models import _PairList
 
         super().__init__()
-        self._cutoff = cutoff.value_in_unit_system(unit.md_unit_system)
+        self._cutoff = cutoff
         self.calculate_distances_and_pairlist = _PairList()
         self._dtype = None  # set at runtime
 

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -135,7 +135,7 @@ class PaiNN(BaseNNP):
         dir_ij = r_ij / d_ij
         f_ij, _ = _distance_to_radial_basis(d_ij, self.radial_basis_module)
 
-        fcut = self.cutoff_module(d_ij) 
+        fcut = self.cutoff_module(d_ij)
 
         filters = self.filter_net(f_ij) * fcut[..., None]
         if self.share_filters:
@@ -176,13 +176,15 @@ class PaiNN(BaseNNP):
 
         # extract properties from pairlist
         transformed_input = self._generate_representation(inputs)
+        q = transformed_input["q"]
+        mu = transformed_input["mu"]
 
         for i, (interaction_mod, mixing_mod) in enumerate(
             zip(self.interaction_modules, self.mixing_modules)
         ):
             q, mu = interaction_mod(
-                transformed_input["q"],
-                transformed_input["mu"],
+                q,
+                mu,
                 self.filter_list[i],
                 transformed_input["dir_ij"],
                 inputs["pair_indices"],
@@ -296,7 +298,7 @@ class PaiNNInteraction(nn.Module):
         expanded_idx_i_dmu = idx_i.view(-1, 1, 1).expand_as(dmu)
         dmu = zeros.scatter_add(0, expanded_idx_i_dmu, dmu)
 
-        q = q + dq 
+        q = q + dq
         mu = mu + dmu
 
         return q, mu

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -135,7 +135,7 @@ class PaiNN(BaseNNP):
         dir_ij = r_ij / d_ij
         f_ij, _ = _distance_to_radial_basis(d_ij, self.radial_basis_module)
 
-        fcut = self.cutoff_module(d_ij)  # n_pairs, 1
+        fcut = self.cutoff_module(d_ij) 
 
         filters = self.filter_net(f_ij) * fcut[..., None]
         if self.share_filters:
@@ -151,7 +151,7 @@ class PaiNN(BaseNNP):
         qs = q.shape
         mu = torch.zeros(
             (qs[0], 3, qs[2]), device=q.device
-        )  # nr_of_systems * nr_of_atoms, 3, nr_atom_basis
+        )  # total_number_of_atoms_in_the_batch, 3, nr_atom_basis
         return {"mu": mu, "dir_ij": dir_ij, "q": q}
 
     def _forward(
@@ -296,7 +296,7 @@ class PaiNNInteraction(nn.Module):
         expanded_idx_i_dmu = idx_i.view(-1, 1, 1).expand_as(dmu)
         dmu = zeros.scatter_add(0, expanded_idx_i_dmu, dmu)
 
-        q = q + dq  # .view(nr_of_atoms_in_all_systems)
+        q = q + dq 
         mu = mu + dmu
 
         return q, mu

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -73,17 +73,14 @@ class PaiNN(BaseNNP):
 
         # initialize the filter network
         if shared_filters:
-            self.filter_net = nn.Sequential(
-                nn.Linear(self.radial_basis_module.n_rbf, 3 * self.nr_atom_basis),
-                nn.Identity(),
+            self.filter_net = Dense(
+                self.radial_basis_module.n_rbf, 3 * self.nr_atom_basis
             )
         else:
-            self.filter_net = nn.Sequential(
-                nn.Linear(
-                    self.radial_basis_module.n_rbf,
-                    self.nr_interaction_blocks * 3 * self.nr_atom_basis,
-                ),
-                nn.Identity(),
+            self.filter_net = Dense(
+                self.radial_basis_module.n_rbf,
+                self.nr_interaction_blocks * self.nr_atom_basis * 3,
+                activation=None,
             )
 
         # initialize the interaction and mixing networks
@@ -223,14 +220,14 @@ class PaiNNInteraction(nn.Module):
         ----------
         nr_atom_basis : int
             Number of features to describe atomic environments.
-        intra_atomic_net : nn.Sequential
-            Neural network for intra-atomic interactions.
+        interatomic_net : nn.Sequential
+            Neural network for interatomic interactions.
         """
         super().__init__()
         self.nr_atom_basis = nr_atom_basis
 
         # Initialize the intra-atomic neural network
-        self.intra_atomic_net = nn.Sequential(
+        self.interatomic_net = nn.Sequential(
             Dense(nr_atom_basis, nr_atom_basis, activation=activation),
             Dense(nr_atom_basis, 3 * nr_atom_basis, activation=None),
         )
@@ -265,7 +262,7 @@ class PaiNNInteraction(nn.Module):
         # inter-atomic
         idx_i, idx_j = pairlist[0], pairlist[1]
 
-        x = self.intra_atomic_net(q)
+        x = self.interatomic_net(q)
         nr_of_atoms_in_all_systems, _, _ = q.shape  # [nr_systems,n_atoms,96]
         x = x.reshape(nr_of_atoms_in_all_systems, 1, 3 * self.nr_atom_basis)
 

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -7,6 +7,7 @@ from .models import BaseNNP, LightningModuleMixin
 from .utils import Dense
 import torch
 import torch.nn.functional as F
+from .postprocessing import PostprocessingPipeline, NoPostprocess
 
 
 class PaiNN(BaseNNP):
@@ -28,6 +29,9 @@ class PaiNN(BaseNNP):
         shared_interactions: bool = False,
         shared_filters: bool = False,
         epsilon: float = 1e-8,
+        postprocessing: PostprocessingPipeline = PostprocessingPipeline(
+            [NoPostprocess({})]
+        ),
     ):
         """
         Parameters
@@ -52,7 +56,7 @@ class PaiNN(BaseNNP):
         from .utils import EnergyReadout
 
         log.debug("Initializing PaiNN model.")
-        super().__init__(cutoff=cutoff_module.cutoff)
+        super().__init__(cutoff=cutoff_module.cutoff, postprocessing=postprocessing)
         self.nr_interaction_blocks = nr_interaction_blocks
         self.cutoff_module = cutoff_module
         self.share_filters = shared_filters
@@ -386,6 +390,9 @@ class LighningPaiNN(PaiNN, LightningModuleMixin):
         epsilon: float = 1e-8,
         loss: Type[nn.Module] = nn.MSELoss(),
         optimizer: Type[torch.optim.Optimizer] = torch.optim.Adam,
+        postprocessing: PostprocessingPipeline = PostprocessingPipeline(
+            [NoPostprocess({})]
+        ),
         lr: float = 1e-3,
     ) -> None:
         """PyTorch Lightning version of the PaiNN model."""
@@ -399,6 +406,7 @@ class LighningPaiNN(PaiNN, LightningModuleMixin):
             shared_interactions=shared_interactions,
             shared_filters=shared_filters,
             epsilon=epsilon,
+            postprocessing=postprocessing,
         )
         self.loss_function = loss
         self.optimizer = optimizer

--- a/modelforge/potential/postprocessing.py
+++ b/modelforge/potential/postprocessing.py
@@ -96,7 +96,7 @@ class AddSelfEnergies(Postprocess):
         molecule_indices = postprocessing_data["atomic_subsystem_indices"]
         max_atomic_number = torch.max(atomic_numbers).item()
         self_energies_tensor = torch.zeros(max_atomic_number + 1)
-        for atomic_number, energy in self.dataset_statistics["self_energies"].items():
+        for atomic_number, energy in self.dataset_statistics["self_energies"]:
             self_energies_tensor[atomic_number] = energy
 
         # Calculate self energies for each atom and then aggregate them per molecule

--- a/modelforge/potential/postprocessing.py
+++ b/modelforge/potential/postprocessing.py
@@ -1,0 +1,146 @@
+from typing import Dict
+
+import lightning as pl
+import torch
+import torch.nn as nn
+from torch.optim import AdamW
+
+from loguru import logger as log
+
+from abc import ABC, abstractmethod
+import torch
+
+
+class Postprocess(nn.Module, ABC):
+    def __init__(self, stats: dict):
+        """
+        Initializes the postprocessing operation with dataset statistics.
+
+        Parameters
+        ----------
+        stats : dict
+            A dictionary containing dataset statistics such as self energies, mean, and stddev.
+        """
+        super().__init__()
+        self.stats = stats
+
+    @abstractmethod
+    def forward(
+        self, postprocessing_data: Dict[str, torch.Tensor]
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Abstract method to be implemented by subclasses for applying specific postprocessing operations.
+
+        Parameters
+        ----------
+        postprocessing_data : Dict[str, torch.Tensor]
+            energy_readout: torch.Tensor, shape (nr_of_molecuels_in_batch)
+            atomic_numbers: torch.Tensor, shape (nr_of_atoms_in_batch)
+            atomic_subsystem_indices: torch.Tensor, shape (nr_of_atoms_in_batch)
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            The postprocessed data with updated energy_readout
+        """
+        pass
+
+
+class NoPostprocess(Postprocess):
+
+    def __init__(self, stats: Dict = {}):
+        super().__init__(stats)
+
+    def forward(
+        self,
+        postprocessing_data: Dict[str, torch.Tensor],
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Simply returns the input energies without any modification.
+        """
+        return postprocessing_data
+
+
+class UndoNormalization(Postprocess):
+    def forward(
+        self,
+        energies: torch.Tensor,
+        atomic_numbers: torch.Tensor,
+        molecule_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Undoes the normalization of the energies using the mean and stddev from the statistics.
+        """
+        mean = self.stats.get("mean", 0.0)
+        stddev = self.stats.get("stddev", 1.0)
+        return (energies * stddev) + mean
+
+
+class AddSelfEnergies(Postprocess):
+    def forward(
+        self,
+        energies: torch.Tensor,
+        atomic_numbers: torch.Tensor,
+        molecule_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Adds self energies to each molecule based on its constituent atomic numbers in a vectorized manner.
+        """
+        # Convert self_energies to a tensor for efficient lookup
+        max_atomic_number = max(self.stats["self_energies"].keys())
+        self_energies_tensor = torch.zeros(max_atomic_number + 1)
+        for atomic_number, energy in self.stats["self_energies"].items():
+            self_energies_tensor[atomic_number] = energy
+
+        # Calculate self energies for each atom and then aggregate them per molecule
+        atom_self_energies = self_energies_tensor[atomic_numbers]
+        molecule_self_energies = torch.zeros_like(energies)
+
+        for i, energy in enumerate(energies):
+            # Find atoms belonging to the current molecule
+            mask = molecule_indices == i
+            # Sum self energies for these atoms
+            molecule_self_energies[i] = atom_self_energies[mask].sum()
+
+        # Adjust energies by adding aggregated self energies for each molecule
+        adjusted_energies = energies + molecule_self_energies
+
+        return adjusted_energies
+
+
+import torch.nn as nn
+
+
+class PostprocessingPipeline(nn.Module):
+    def __init__(self, modules):
+        """
+        Initializes the postprocessing pipeline with a list of postprocessing modules.
+
+        Parameters
+        ----------
+        modules : list
+            A list of postprocessing modules (instances of classes inheriting from Postprocess).
+        """
+        super().__init__()
+        self.postprocess = nn.ModuleList(modules)
+
+    def forward(self, postprocessing_data: Dict[str, torch.Tensor]) -> torch.Tensor:
+        """
+        Abstract method to be implemented by subclasses for applying specific postprocessing operations.
+
+        Parameters
+        ----------
+        postprocessing_data : Dict[str, torch.Tensor]
+            energy_readout: torch.Tensor, shape (nr_of_molecuels_in_batch)
+            atomic_numbers: torch.Tensor, shape (nr_of_atoms_in_batch)
+            atomic_subsystem_indices: torch.Tensor, shape (nr_of_atoms_in_batch)
+
+
+        Returns
+        -------
+        torch.Tensor
+            The postprocessed energies.
+        """
+        for module in self.postprocess:
+            postprocessing_data = module.forward(postprocessing_data)
+        return postprocessing_data

--- a/modelforge/potential/postprocessing.py
+++ b/modelforge/potential/postprocessing.py
@@ -64,25 +64,24 @@ class NoPostprocess(Postprocess):
 class UndoNormalization(Postprocess):
     def forward(
         self,
-        energies: torch.Tensor,
-        atomic_numbers: torch.Tensor,
-        molecule_indices: torch.Tensor,
-    ) -> torch.Tensor:
+        postprocessing_data: Dict[str, torch.Tensor],
+    ) -> Dict[str, torch.Tensor]:
         """
         Undoes the normalization of the energies using the mean and stddev from the statistics.
         """
         mean = self.stats.get("mean", 0.0)
         stddev = self.stats.get("stddev", 1.0)
-        return (energies * stddev) + mean
+        postprocessing_data["energy_readout"] = (
+            postprocessing_data["energy_readout"] * stddev
+        ) + mean
+        return postprocessing_data
 
 
 class AddSelfEnergies(Postprocess):
     def forward(
         self,
-        energies: torch.Tensor,
-        atomic_numbers: torch.Tensor,
-        molecule_indices: torch.Tensor,
-    ) -> torch.Tensor:
+        postprocessing_data: Dict[str, torch.Tensor],
+    ) -> Dict[str, torch.Tensor]:
         """
         Adds self energies to each molecule based on its constituent atomic numbers in a vectorized manner.
         """

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -34,7 +34,7 @@ class SchNET(BaseNNP):
         """
 
         log.debug("Initializing SchNet model.")
-        super().__init__(cutoff=cutoff_module.cutoff)
+        super().__init__(cutoff=float(cutoff_module.cutoff))
         self.radial_basis_module = radial_basis_module
         self.cutoff_module = cutoff_module
 

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -5,7 +5,7 @@ from loguru import logger as log
 import torch.nn as nn
 
 from .models import BaseNNP, LightningModuleMixin
-from .utils import _distance_to_radial_basis, shifted_softplus
+from .utils import _distance_to_radial_basis, _shifted_softplus
 
 
 class SchNET(BaseNNP):
@@ -17,7 +17,7 @@ class SchNET(BaseNNP):
         cutoff_module: nn.Module,
         nr_filters: int = 2,
         shared_interactions: bool = False,
-        activation: nn.Module = shifted_softplus,
+        activation: nn.Module = _shifted_softplus,
     ) -> None:
         """
         Initialize the SchNet class.
@@ -139,7 +139,7 @@ class SchNETInteractionBlock(nn.Module):
             Number of radial basis functions.
         """
         super().__init__()
-        from .utils import shifted_softplus, Dense
+        from .utils import _shifted_softplus, Dense
 
         assert nr_rbf > 4, "Number of radial basis functions must be larger than 10."
         assert nr_filters > 1, "Number of filters must be larger than 1."
@@ -148,11 +148,11 @@ class SchNETInteractionBlock(nn.Module):
         self.nr_atom_basis = nr_atom_basis  # Initialize parameters
         self.intput_to_feature = nn.Linear(nr_atom_basis, nr_filters)
         self.feature_to_output = nn.Sequential(
-            Dense(nr_filters, nr_atom_basis, activation=shifted_softplus),
+            Dense(nr_filters, nr_atom_basis, activation=_shifted_softplus),
             Dense(nr_atom_basis, nr_atom_basis, activation=None),
         )
         self.filter_network = nn.Sequential(
-            Dense(nr_rbf, nr_filters, activation=shifted_softplus),
+            Dense(nr_rbf, nr_filters, activation=_shifted_softplus),
             Dense(nr_filters, nr_filters, activation=None),
         )
 
@@ -263,7 +263,7 @@ class LightningSchNET(SchNET, LightningModuleMixin):
         cutoff: nn.Module,
         nr_filters: int = 2,
         shared_interactions: bool = False,
-        activation: nn.Module = shifted_softplus,
+        activation: nn.Module = _shifted_softplus,
         loss: Type[nn.Module] = nn.MSELoss(),
         optimizer: Type[torch.optim.Optimizer] = torch.optim.Adam,
         lr: float = 1e-3,

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -5,7 +5,7 @@ from loguru import logger as log
 import torch.nn as nn
 
 from .models import BaseNNP, LightningModuleMixin
-from .utils import _distance_to_radial_basis, _shifted_softplus
+from .utils import _distance_to_radial_basis, ShiftedSoftplus
 from .postprocessing import PostprocessingPipeline, NoPostprocess
 
 
@@ -16,9 +16,9 @@ class SchNET(BaseNNP):
         nr_interaction_blocks: int,
         radial_basis_module: nn.Module,
         cutoff_module: nn.Module,
-        nr_filters: int = 2,
+        nr_filters: int = None,
         shared_interactions: bool = False,
-        activation: nn.Module = _shifted_softplus,
+        activation: nn.Module = ShiftedSoftplus(),
         postprocessing: PostprocessingPipeline = PostprocessingPipeline(
             [NoPostprocess({})]
         ),
@@ -34,7 +34,7 @@ class SchNET(BaseNNP):
         radial_basis : nn.Module
         cutoff : nn.Module
         nr_filters : int, optional
-            Number of filters; defines the dimensionality of the intermediate features (default is 2).
+            Number of filters; defines the dimensionality of the intermediate features.
         """
 
         log.debug("Initializing SchNet model.")
@@ -49,9 +49,10 @@ class SchNET(BaseNNP):
 
         self.nr_atom_basis = embedding_module.embedding_dim
         self.readout_module = EnergyReadout(self.nr_atom_basis)
+        self.nr_filters = nr_filters or self.nr_atom_basis
 
         log.debug(
-            f"Passed parameters to constructor: {self.nr_atom_basis=}, {nr_interaction_blocks=}, {nr_filters=}, {cutoff_module=}"
+            f"Passed parameters to constructor: {self.nr_atom_basis=}, {nr_interaction_blocks=}, {self.nr_filters=}, {cutoff_module=}"
         )
 
         # Initialize representation block
@@ -62,7 +63,7 @@ class SchNET(BaseNNP):
         self.interaction_modules = nn.ModuleList(
             [
                 SchNETInteractionBlock(
-                    self.nr_atom_basis, nr_filters, self.radial_basis_module.n_rbf
+                    self.nr_atom_basis, self.nr_filters, self.radial_basis_module.n_rbf
                 )
                 for _ in range(nr_interaction_blocks)
             ]
@@ -145,20 +146,22 @@ class SchNETInteractionBlock(nn.Module):
             Number of radial basis functions.
         """
         super().__init__()
-        from .utils import _shifted_softplus, Dense
+        from .utils import ShiftedSoftplus, Dense
 
         assert nr_rbf > 4, "Number of radial basis functions must be larger than 10."
         assert nr_filters > 1, "Number of filters must be larger than 1."
         assert nr_atom_basis > 10, "Number of atom basis must be larger than 10."
 
         self.nr_atom_basis = nr_atom_basis  # Initialize parameters
-        self.intput_to_feature = nn.Linear(nr_atom_basis, nr_filters)
+        self.intput_to_feature = Dense(
+            nr_atom_basis, nr_filters, bias=False, activation=None
+        )
         self.feature_to_output = nn.Sequential(
-            Dense(nr_filters, nr_atom_basis, activation=_shifted_softplus),
+            Dense(nr_filters, nr_atom_basis, activation=ShiftedSoftplus()),
             Dense(nr_atom_basis, nr_atom_basis, activation=None),
         )
         self.filter_network = nn.Sequential(
-            Dense(nr_rbf, nr_filters, activation=_shifted_softplus),
+            Dense(nr_rbf, nr_filters, activation=ShiftedSoftplus()),
             Dense(nr_filters, nr_filters, activation=None),
         )
 
@@ -209,7 +212,7 @@ class SchNETInteractionBlock(nn.Module):
 
         # Initialize a tensor to gather the results
         shape = list(x.shape)  # note that we're using x.shape, not x_ij.shape
-        x_native = torch.zeros(shape, dtype=x.dtype)
+        x_native = torch.zeros(shape, dtype=x.dtype, device=x.device)
 
         idx_i_expanded = idx_i.unsqueeze(1).expand_as(x_ij)
 
@@ -269,7 +272,7 @@ class LightningSchNET(SchNET, LightningModuleMixin):
         cutoff: nn.Module,
         nr_filters: int = 2,
         shared_interactions: bool = False,
-        activation: nn.Module = _shifted_softplus,
+        activation: nn.Module = ShiftedSoftplus(),
         postprocessing: PostprocessingPipeline = PostprocessingPipeline(
             [NoPostprocess({})]
         ),

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -335,7 +335,7 @@ def _shifted_softplus(x: torch.Tensor):
 from typing import Optional
 
 
-class _GaussianRBF(nn.Module):
+class GaussianRBF(nn.Module):
     """
     Gaussian Radial Basis Function module.
 
@@ -468,6 +468,7 @@ def _pair_list(
 
 from openff.units import unit
 
+
 def _neighbor_list_with_cutoff(
     coordinates: torch.Tensor,  # in nanometer
     atomic_subsystem_indices: torch.Tensor,
@@ -499,7 +500,7 @@ def _neighbor_list_with_cutoff(
     )
 
     # Find pairs within the cutoff
-    #cutoff = cutoff.to(unit.nanometer).m
+    # cutoff = cutoff.to(unit.nanometer).m
     in_cutoff = (distances <= cutoff).nonzero(as_tuple=False).squeeze()
 
     # Get the atom indices within the cutoff

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -172,19 +172,22 @@ def gaussian_rbf(
     return y
 
 
+from openmm import unit
+
+
 class CosineCutoff(nn.Module):
-    def __init__(self, cutoff: float):
-        r"""
+    def __init__(self, cutoff: unit.Quantity):
+        """
         Behler-style cosine cutoff module.
 
-        Args:
-            cutoff (float): The cutoff distance.
-
-        Attributes:
-            cutoff (torch.Tensor): The cutoff distance as a tensor.
+        Parameters:
+        ----------
+        cutoff: unit.Quantity
+            The cutoff distance.
 
         """
         super().__init__()
+        cutoff = cutoff.value_in_unit_system(unit.md_unit_system)
         self.register_buffer("cutoff", torch.FloatTensor([cutoff]))
 
     def forward(self, input: torch.Tensor):

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -310,7 +310,6 @@ class EnergyReadout(nn.Module):
 
         # Sum across feature dimension to get final tensor of shape (num_molecules, 1)
         total_energy_per_molecule = result.sum(dim=1, keepdim=True)
-
         return total_energy_per_molecule
 
 

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -175,7 +175,7 @@ def gaussian_rbf(
 from openmm import unit
 
 
-class _CosineCutoff(nn.Module):
+class CosineCutoff(nn.Module):
     def __init__(self, cutoff: unit.Quantity):
         """
         Behler-style cosine cutoff module.
@@ -335,7 +335,7 @@ def _shifted_softplus(x: torch.Tensor):
 from typing import Optional
 
 
-class _GaussianRBF(nn.Module):
+class GaussianRBF(nn.Module):
     """
     Gaussian Radial Basis Function module.
 

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -319,6 +319,16 @@ from typing import Dict, Iterator
 
 @dataclass
 class AtomicSelfEnergies:
+    """
+    AtomicSelfEnergies stores a mapping of atomic elements to their self energies.
+
+    Provides lookup by atomic number or symbol, iteration over the mapping,
+    and utilities to convert between atomic number and symbol.
+
+    Intended as a base class to be extended with specific element-energy values.
+    """    
+    # We provide a dictionary with {str:float} of element name to atomic self-energy,
+    # which can then be accessed by atomic index or element name
     energies: Dict[str, float] = field(default_factory=dict)
     # Example mapping, replace or extend as necessary
     atomic_number_to_element: Dict[int, str] = field(
@@ -387,7 +397,7 @@ class AtomicSelfEnergies:
         elif isinstance(key, str):
             # Directly access by element symbol
             if key not in self.energies:
-                raise KeyError(f"Element '{key}' not found.")
+                raise KeyError(f"Element {key} not found.")
             return self.energies[key]
         else:
             raise TypeError(
@@ -397,11 +407,19 @@ class AtomicSelfEnergies:
     def __iter__(self) -> Iterator[Dict[str, float]]:
         """Iterate over the energies dictionary."""
         for element, energy in self.energies.items():
-            yield (self.atomic_number_to_element.get(element), energy)
+            atomic_number = self.element_to_atomic_number(element)
+            yield (atomic_number, energy)
 
     def __len__(self) -> int:
         """Return the number of element-energy pairs."""
         return len(self.energies)
+
+    def element_to_atomic_number(self, element: str) -> int:
+        """Return the atomic number for a given element symbol."""
+        for atomic_number, elem_symbol in self.atomic_number_to_element.items():
+            if elem_symbol == element:
+                return atomic_number
+        raise ValueError(f"Element symbol '{element}' not found in the mapping.")
 
 
 class ShiftedSoftplus(nn.Module):

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -305,7 +305,7 @@ class EnergyReadout(nn.Module):
         # Perform scatter add operation
         indices = atomic_subsystem_indices.unsqueeze(1).to(torch.int64)
         result = torch.zeros(
-            len(atomic_subsystem_indices.unique()), 1, dtype=x.dtype
+            len(atomic_subsystem_indices.unique()), 1, dtype=x.dtype, device=x.device
         ).scatter_add(0, indices, x)
 
         # Sum across feature dimension to get final tensor of shape (num_molecules, 1)

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -397,7 +397,11 @@ class AtomicSelfEnergies:
     def __iter__(self) -> Iterator[Dict[str, float]]:
         """Iterate over the energies dictionary."""
         for element, energy in self.energies.items():
-            yield (element, energy)
+            yield (self.atomic_number_to_element.get(element), energy)
+
+    def __len__(self) -> int:
+        """Return the number of element-energy pairs."""
+        return len(self.energies)
 
 
 class ShiftedSoftplus(nn.Module):

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -313,23 +313,30 @@ class EnergyReadout(nn.Module):
         return total_energy_per_molecule
 
 
-def _shifted_softplus(x: torch.Tensor):
-    r"""Compute shifted soft-plus activation function.
+class ShiftedSoftplus(nn.Module):
+    def __init__(self):
+        super().__init__()
+        import math
+        self.log_2 = math.log(2.0)
 
-    .. math::
-       y = \ln\left(1 + e^{-x}\right) - \ln(2)
+    def forward(self, x: torch.Tensor):
+        """Compute shifted soft-plus activation function.
 
-    Args:
-        x (torch.Tensor): input tensor.
+        y = \ln\left(1 + e^{-x}\right) - \ln(2)
 
-    Returns:
+        Parameters:
+        -----------
+        x:torch.Tensor
+            input tensor
+
+        Returns:
+        -----------
         torch.Tensor: shifted soft-plus of input.
 
-    """
-    from torch.nn import functional
-    import math
+        """
+        from torch.nn import functional
 
-    return functional.softplus(x) - math.log(0.2)
+        return functional.softplus(x) - self.log_2
 
 
 from typing import Optional

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -313,10 +313,98 @@ class EnergyReadout(nn.Module):
         return total_energy_per_molecule
 
 
+from dataclasses import dataclass, field
+from typing import Dict, Iterator
+
+
+@dataclass
+class AtomicSelfEnergies:
+    energies: Dict[str, float] = field(default_factory=dict)
+    # Example mapping, replace or extend as necessary
+    atomic_number_to_element: Dict[int, str] = field(
+        default_factory=lambda: {
+            1: "H",
+            2: "He",
+            3: "Li",
+            4: "Be",
+            5: "B",
+            6: "C",
+            7: "N",
+            8: "O",
+            9: "F",
+            10: "Ne",
+            11: "Na",
+            12: "Mg",
+            13: "Al",
+            14: "Si",
+            15: "P",
+            16: "S",
+            17: "Cl",
+            18: "Ar",
+            19: "K",
+            20: "Ca",
+            21: "Sc",
+            22: "Ti",
+            23: "V",
+            24: "Cr",
+            25: "Mn",
+            26: "Fe",
+            27: "Co",
+            28: "Ni",
+            29: "Cu",
+            30: "Zn",
+            31: "Ga",
+            32: "Ge",
+            33: "As",
+            34: "Se",
+            35: "Br",
+            36: "Kr",
+            37: "Rb",
+            38: "Sr",
+            39: "Y",
+            40: "Zr",
+            41: "Nb",
+            42: "Mo",
+            43: "Tc",
+            44: "Ru",
+            45: "Rh",
+            46: "Pd",
+            47: "Ag",
+            48: "Cd",
+            49: "In",
+            50: "Sn",
+            # Add more elements as needed
+        }
+    )
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            # Convert atomic number to element symbol
+            element = self.atomic_number_to_element.get(key)
+            if element is None:
+                raise KeyError(f"Atomic number {key} not found.")
+            return self.energies.get(element)
+        elif isinstance(key, str):
+            # Directly access by element symbol
+            if key not in self.energies:
+                raise KeyError(f"Element '{key}' not found.")
+            return self.energies[key]
+        else:
+            raise TypeError(
+                "Key must be an integer (atomic number) or string (element name)."
+            )
+
+    def __iter__(self) -> Iterator[Dict[str, float]]:
+        """Iterate over the energies dictionary."""
+        for element, energy in self.energies.items():
+            yield (element, energy)
+
+
 class ShiftedSoftplus(nn.Module):
     def __init__(self):
         super().__init__()
         import math
+
         self.log_2 = math.log(2.0)
 
     def forward(self, x: torch.Tensor):

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -123,7 +123,6 @@ def initialize_dataset(
     data = dataset(for_unit_testing=for_unit_testing)
     data_module = TorchDataModule(data, split_file=split_file)
     data_module.prepare_data()
-    data_module.setup()
     return data_module
 
 

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -13,13 +13,14 @@ DATASETS = [QM9Dataset]
 
 from openff.units import unit
 
+
 def setup_simple_model(
     model_class,
     lightning: bool = False,
     nr_atom_basis: int = 128,
     max_atomic_number: int = 100,
     n_rbf: int = 20,
-    cutoff: unit.Quantity = 5.0*unit.angstrom,
+    cutoff: unit.Quantity = 5.0 * unit.angstrom,
     nr_interaction_blocks: int = 2,
     nr_filters: int = 2,
 ) -> Optional[BaseNNP]:
@@ -38,7 +39,7 @@ def setup_simple_model(
     Optional[BaseNNP]
         Initialized model.
     """
-    from modelforge.potential import _CosineCutoff, _GaussianRBF
+    from modelforge.potential import CosineCutoff, GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
 
     embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
@@ -83,7 +84,7 @@ def setup_simple_model(
 
 
 def return_single_batch(
-    dataset, mode: str, split_file: Optional[str] = None, for_unit_testing: bool = True
+    dataset, split_file: Optional[str] = None, for_unit_testing: bool = True
 ) -> Dict[str, torch.Tensor]:
     """
     Return a single batch from a dataset.
@@ -197,7 +198,7 @@ def generate_mock_data():
 
 
 def generate_batch_data():
-    return return_single_batch(QM9Dataset, mode="fit")
+    return return_single_batch(QM9Dataset)
 
 
 def generate_interaction_block_data(
@@ -222,12 +223,12 @@ def generate_interaction_block_data(
     import torch.nn as nn
 
     from modelforge.dataset.qm9 import QM9Dataset
-    from modelforge.potential import _GaussianRBF
+    from modelforge.potential import GaussianRBF
     from modelforge.potential.utils import _distance_to_radial_basis
     from openff.units import unit
 
     embedding = nn.Embedding(nr_embeddings, nr_atom_basis, padding_idx=0)
-    batch = return_single_batch(QM9Dataset, "fit")
+    batch = return_single_batch(QM9Dataset)
     r = prepare_pairlist_for_single_batch(batch)
     radial_basis = GaussianRBF(
         n_rbf=nr_rbf,

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -39,14 +39,14 @@ def setup_simple_model(
     Optional[BaseNNP]
         Initialized model.
     """
-    from modelforge.potential import _CosineCutoff, _GaussianRBF
+    from modelforge.potential import CosineCutoff, GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
 
     embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
     assert embedding.embedding_dim == nr_atom_basis
-    rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
 
-    cutoff = _CosineCutoff(cutoff=cutoff)
+    cutoff = CosineCutoff(cutoff=cutoff)
 
     if model_class is SchNET:
         if lightning:
@@ -230,14 +230,14 @@ def generate_interaction_block_data(
     import torch.nn as nn
 
     from modelforge.dataset.qm9 import QM9Dataset
-    from modelforge.potential import _GaussianRBF
+    from modelforge.potential import GaussianRBF
     from modelforge.potential.utils import _distance_to_radial_basis
     from openmm import unit
 
     embedding = nn.Embedding(nr_embeddings, nr_atom_basis, padding_idx=0)
     batch = return_single_batch(QM9Dataset, "fit")
     r = prepare_pairlist_for_single_batch(batch)
-    radial_basis = _GaussianRBF(
+    radial_basis = GaussianRBF(
         n_rbf=nr_rbf,
         cutoff=unit.Quantity(5.0, unit.angstrom),
         dtype=batch["positions"].dtype,

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -37,12 +37,12 @@ def setup_simple_model(
     Optional[BaseNNP]
         Initialized model.
     """
-    from modelforge.potential import CosineCutoff, GaussianRBF
+    from modelforge.potential import CosineCutoff, _GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
 
     embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
     assert embedding.embedding_dim == nr_atom_basis
-    rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
     cutoff = CosineCutoff(cutoff)
 
     if model_class is SchNET:
@@ -148,11 +148,11 @@ def prepare_pairlist_for_single_batch(
         Pairlist with keys 'atom_index12', 'd_ij', 'r_ij'.
     """
 
-    from modelforge.potential.models import PairList
+    from modelforge.potential.models import _PairList
 
     positions = batch["positions"]
     atomic_subsystem_indices = batch["atomic_subsystem_indices"]
-    pairlist = PairList()
+    pairlist = _PairList()
     return pairlist(positions, atomic_subsystem_indices)
 
 
@@ -224,13 +224,15 @@ def generate_interaction_block_data(
     import torch.nn as nn
 
     from modelforge.dataset.qm9 import QM9Dataset
-    from modelforge.potential import GaussianRBF
+    from modelforge.potential import _GaussianRBF
     from modelforge.potential.utils import _distance_to_radial_basis
 
     embedding = nn.Embedding(nr_embeddings, nr_atom_basis, padding_idx=0)
     batch = return_single_batch(QM9Dataset, "fit")
     r = prepare_pairlist_for_single_batch(batch)
-    radial_basis = GaussianRBF(n_rbf=nr_rbf, cutoff=5.0, dtype=batch["positions"].dtype)
+    radial_basis = _GaussianRBF(
+        n_rbf=nr_rbf, cutoff=5.0, dtype=batch["positions"].dtype
+    )
 
     d_ij = r["d_ij"]
     f_ij, rcut_ij = _distance_to_radial_basis(d_ij, radial_basis)

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -232,12 +232,15 @@ def generate_interaction_block_data(
     from modelforge.dataset.qm9 import QM9Dataset
     from modelforge.potential import _GaussianRBF
     from modelforge.potential.utils import _distance_to_radial_basis
+    from openmm import unit
 
     embedding = nn.Embedding(nr_embeddings, nr_atom_basis, padding_idx=0)
     batch = return_single_batch(QM9Dataset, "fit")
     r = prepare_pairlist_for_single_batch(batch)
     radial_basis = _GaussianRBF(
-        n_rbf=nr_rbf, cutoff=5.0, dtype=batch["positions"].dtype
+        n_rbf=nr_rbf,
+        cutoff=unit.Quantity(5.0, unit.angstrom),
+        dtype=batch["positions"].dtype,
     )
 
     d_ij = r["d_ij"]

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -126,7 +126,7 @@ def initialize_dataset(
     return data_module
 
 
-def preparePairlist_for_single_batch(
+def prepare_pairlist_for_single_batch(
     batch: Dict[str, torch.Tensor]
 ) -> Dict[str, torch.Tensor]:
     """

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -43,7 +43,9 @@ def setup_simple_model(
     embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
     assert embedding.embedding_dim == nr_atom_basis
     rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
-    cutoff = CosineCutoff(cutoff)
+    from openmm import unit
+
+    cutoff = CosineCutoff(unit.Quantity(cutoff, unit.angstrom))
 
     if model_class is SchNET:
         if lightning:

--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -93,22 +93,19 @@ def return_single_batch(
     ----------
     dataset : class
         Dataset class.
-    mode : str
-        Mode to setup the dataset ('fit', or 'test').
-
     Returns
     -------
     Dict[str, Tensor]
         A single batch from the dataset.
     """
 
-    train_loader = initialize_dataset(dataset, mode, split_file, for_unit_testing)
+    train_loader = initialize_dataset(dataset, split_file, for_unit_testing)
     for batch in train_loader.train_dataloader():
         return batch
 
 
 def initialize_dataset(
-    dataset, mode: str, split_file: Optional[str] = None, for_unit_testing: bool = True
+    dataset, split_file: Optional[str] = None, for_unit_testing: bool = True
 ) -> TorchDataModule:
     """
     Initialize a dataset for a given mode.
@@ -117,10 +114,6 @@ def initialize_dataset(
     ----------
     dataset : class
         Dataset class.
-    mode : str
-        Mode to setup the dataset. Either "fit" for training/validation split
-        or "test" for test split.
-
     Returns
     -------
     TorchDataModule
@@ -130,7 +123,7 @@ def initialize_dataset(
     data = dataset(for_unit_testing=for_unit_testing)
     data_module = TorchDataModule(data, split_file=split_file)
     data_module.prepare_data()
-    data_module.setup(stage=mode)
+    data_module.setup()
     return data_module
 
 

--- a/modelforge/tests/test_curation.py
+++ b/modelforge/tests/test_curation.py
@@ -1450,118 +1450,118 @@ def test_spice114_process_download_conversion(prep_temp_dir):
     )
 
 
-def test_spice12_openff_test_fetching(prep_temp_dir):
-    from tqdm import tqdm
-    from sqlitedict import SqliteDict
+# def test_spice12_openff_test_fetching(prep_temp_dir):
+#     from tqdm import tqdm
+#     from sqlitedict import SqliteDict
 
-    local_path_dir = str(prep_temp_dir)
-    local_database_name = "test.sqlite"
-    specification_name = "entry"
+#     local_path_dir = str(prep_temp_dir)
+#     local_database_name = "test.sqlite"
+#     specification_name = "entry"
 
-    spice_openff_data = SPICE12PubChemOpenFFCuration(
-        hdf5_file_name="test_dataset.hdf5",
-        output_file_dir=local_path_dir,
-        local_cache_dir=local_path_dir,
-        convert_units=True,
-    )
+#     spice_openff_data = SPICE12PubChemOpenFFCuration(
+#         hdf5_file_name="test_dataset.hdf5",
+#         output_file_dir=local_path_dir,
+#         local_cache_dir=local_path_dir,
+#         convert_units=True,
+#     )
 
-    # test downloading two new records and saving to the sqlite db
-    spice_openff_data._fetch_singlepoint_from_qcarchive(
-        dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
-        specification_name=specification_name,
-        local_database_name=local_database_name,
-        local_path_dir=local_path_dir,
-        force_download=True,
-        unit_testing_max_records=2,
-    )
+#     # test downloading two new records and saving to the sqlite db
+#     spice_openff_data._fetch_singlepoint_from_qcarchive(
+#         dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
+#         specification_name=specification_name,
+#         local_database_name=local_database_name,
+#         local_path_dir=local_path_dir,
+#         force_download=True,
+#         unit_testing_max_records=2,
+#     )
 
-    with SqliteDict(
-        f"{local_path_dir}/{local_database_name}",
-        tablename=specification_name,
-        autocommit=True,
-    ) as spice_db:
-        keys = list(spice_db.keys())
+#     with SqliteDict(
+#         f"{local_path_dir}/{local_database_name}",
+#         tablename=specification_name,
+#         autocommit=True,
+#     ) as spice_db:
+#         keys = list(spice_db.keys())
 
-        assert len(keys) == 2
+#         assert len(keys) == 2
 
-    # same test as above, but we will pass pbar
-    # pbar.total gets updated by the number of records
-    # we need to fetch. Since force_download=True
-    # we should fetch the 2 records again
-    pbar = tqdm()
-    pbar.total = 0
+#     # same test as above, but we will pass pbar
+#     # pbar.total gets updated by the number of records
+#     # we need to fetch. Since force_download=True
+#     # we should fetch the 2 records again
+#     pbar = tqdm()
+#     pbar.total = 0
 
-    spice_openff_data._fetch_singlepoint_from_qcarchive(
-        dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
-        specification_name=specification_name,
-        local_database_name=local_database_name,
-        local_path_dir=local_path_dir,
-        force_download=True,
-        unit_testing_max_records=2,
-        pbar=pbar,
-    )
+#     spice_openff_data._fetch_singlepoint_from_qcarchive(
+#         dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
+#         specification_name=specification_name,
+#         local_database_name=local_database_name,
+#         local_path_dir=local_path_dir,
+#         force_download=True,
+#         unit_testing_max_records=2,
+#         pbar=pbar,
+#     )
 
-    assert pbar.total == 2
+#     assert pbar.total == 2
 
-    with SqliteDict(
-        f"{local_path_dir}/{local_database_name}",
-        tablename=specification_name,
-        autocommit=True,
-    ) as spice_db:
-        keys = list(spice_db.keys())
+#     with SqliteDict(
+#         f"{local_path_dir}/{local_database_name}",
+#         tablename=specification_name,
+#         autocommit=True,
+#     ) as spice_db:
+#         keys = list(spice_db.keys())
 
-        assert len(keys) == 2
+#         assert len(keys) == 2
 
-    # test using sqlite db, by setting force_download=False
-    pbar = tqdm()
-    pbar.total = 0
+#     # test using sqlite db, by setting force_download=False
+#     pbar = tqdm()
+#     pbar.total = 0
 
-    spice_openff_data._fetch_singlepoint_from_qcarchive(
-        dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
-        specification_name=specification_name,
-        local_database_name=local_database_name,
-        local_path_dir=local_path_dir,
-        force_download=False,
-        unit_testing_max_records=2,
-    )
+#     spice_openff_data._fetch_singlepoint_from_qcarchive(
+#         dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
+#         specification_name=specification_name,
+#         local_database_name=local_database_name,
+#         local_path_dir=local_path_dir,
+#         force_download=False,
+#         unit_testing_max_records=2,
+#     )
 
-    assert pbar.total == 0
+#     assert pbar.total == 0
 
-    with SqliteDict(
-        f"{local_path_dir}/{local_database_name}",
-        tablename=specification_name,
-        autocommit=True,
-    ) as spice_db:
-        keys = list(spice_db.keys())
+#     with SqliteDict(
+#         f"{local_path_dir}/{local_database_name}",
+#         tablename=specification_name,
+#         autocommit=True,
+#     ) as spice_db:
+#         keys = list(spice_db.keys())
 
-        assert len(keys) == 2
+#         assert len(keys) == 2
 
-    # test fetching additional records
-    # we already have 2 and thus should only need to
-    # fetch 8
+#     # test fetching additional records
+#     # we already have 2 and thus should only need to
+#     # fetch 8
 
-    pbar = tqdm()
-    pbar.total = 0
+#     pbar = tqdm()
+#     pbar.total = 0
 
-    spice_openff_data._fetch_singlepoint_from_qcarchive(
-        dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
-        specification_name=specification_name,
-        local_database_name=local_database_name,
-        local_path_dir=local_path_dir,
-        force_download=False,
-        unit_testing_max_records=10,
-        pbar=pbar,
-    )
+#     spice_openff_data._fetch_singlepoint_from_qcarchive(
+#         dataset_name="SPICE PubChem Set 1 Single Points Dataset v1.2",
+#         specification_name=specification_name,
+#         local_database_name=local_database_name,
+#         local_path_dir=local_path_dir,
+#         force_download=False,
+#         unit_testing_max_records=10,
+#         pbar=pbar,
+#     )
 
-    assert pbar.total == 8
-    with SqliteDict(
-        f"{local_path_dir}/{local_database_name}",
-        tablename=specification_name,
-        autocommit=True,
-    ) as spice_db:
-        keys = list(spice_db.keys())
+#     assert pbar.total == 8
+#     with SqliteDict(
+#         f"{local_path_dir}/{local_database_name}",
+#         tablename=specification_name,
+#         autocommit=True,
+#     ) as spice_db:
+#         keys = list(spice_db.keys())
 
-        assert len(keys) == 10
+#         assert len(keys) == 10
 
 
 # def test_spice12_openff_test_process_downloaded(prep_temp_dir):

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -331,6 +331,9 @@ def test_offset_and_normalization():
             item = self.data[idx]
             return item
 
+        def __setitem__(self, idx, value):
+            self.data[idx] = value
+
     # add the mock datapoints
     dataset = [
         {"E_label": torch.tensor([2], dtype=torch.float)},
@@ -407,4 +410,5 @@ def test_offset_and_normalization():
     for batch in dataset.train_dataloader():
         labels = batch["E_label"]
         # no datapoint should be outside the a normal distribution with stddev of 1
-        assert torch.all(labels < 2.0 + 1e-4)
+        # test that all labels are within [-2,2]
+        assert torch.all(labels > -2.0) or torch.all(labels < 2.0)

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -327,13 +327,20 @@ def test_self_energy():
     )
 
     # self energy is calculated and removed in prepare_data if `remove_self_energies` is True
-    dataset.prepare_data(remove_self_energies=True, normalize=True)
+    dataset.prepare_data(remove_self_energies=True, normalize=False)
 
     assert dataset.dataset_statistics
     self_energies = dataset.dataset_statistics["self_energies"]
     # only 4 elements present in the reduced QM9 dataset
     assert len(self_energies) == 4
+    # H: -1313.4668615546
     assert np.isclose(self_energies[1], -1584.5087457646348)
+    # C: -99366.70745535441
     assert np.isclose(self_energies[6], -99960.88941782094)
+    # N: -143309.9379722722
     assert np.isclose(self_energies[7], -143754.0263865598)
+    # O: -197082.0671774158
     assert np.isclose(self_energies[8], -197495.00132926644)
+
+
+

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -395,3 +395,16 @@ def test_offset_and_normalization():
     assert torch.isclose(
         mod_dataset[2]["E_label"], torch.tensor([1.2247], dtype=torch.float), atol=1e-4
     )
+
+    # test offset and normalization with QM9
+    from modelforge.dataset.qm9 import QM9Dataset
+
+    data = QM9Dataset(for_unit_testing=True)
+    dataset = TorchDataModule(data, batch_size=64)
+    dataset.prepare_data(offset=True, normalize=True)
+    dataset.setup()
+
+    for batch in dataset.train_dataloader():
+        labels = batch["E_label"]
+        # no datapoint should be outside the a normal distribution with stddev of 1
+        assert torch.all(labels < 2.0 + 1e-4)

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -331,16 +331,16 @@ def test_self_energy():
 
     assert dataset.dataset_statistics
     self_energies = dataset.dataset_statistics["self_energies"]
-    # only 4 elements present in the reduced QM9 dataset
-    assert len(self_energies) == 4
+    # 5 elements present in the QM9 dataset
+    assert len(self_energies) == 5
     # H: -1313.4668615546
-    assert np.isclose(self_energies[1], -1584.5087457646348)
+    assert np.isclose(self_energies[1], -1313.4668615546)
     # C: -99366.70745535441
-    assert np.isclose(self_energies[6], -99960.88941782094)
+    assert np.isclose(self_energies[6], -99366.70745535441)
     # N: -143309.9379722722
-    assert np.isclose(self_energies[7], -143754.0263865598)
+    assert np.isclose(self_energies[7], -143309.9379722722)
     # O: -197082.0671774158
-    assert np.isclose(self_energies[8], -197495.00132926644)
+    assert np.isclose(self_energies[8], -197082.0671774158)
 
 
 

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -330,10 +330,11 @@ def test_self_energy():
     # self energy is calculated and removed in prepare_data if `remove_self_energies` is True
     dataset.prepare_data(remove_self_energies=True, normalize=True)
 
-    assert dataset.self_energies
+    assert dataset.dataset_statistics
+    self_energies = dataset.dataset_statistics["self_energies"]
     # only 4 elements present in the reduced QM9 dataset
-    assert len(dataset.self_energies) == 4
-    assert np.isclose(dataset.self_energies[1], -1584.5087457646348)
-    assert np.isclose(dataset.self_energies[6], -99960.88941782094)
-    assert np.isclose(dataset.self_energies[7], -143754.0263865598)
-    assert np.isclose(dataset.self_energies[8], -197495.00132926644)
+    assert len(self_energies) == 4
+    assert np.isclose(self_energies[1], -1584.5087457646348)
+    assert np.isclose(self_energies[6], -99960.88941782094)
+    assert np.isclose(self_energies[7], -143754.0263865598)
+    assert np.isclose(self_energies[8], -197495.00132926644)

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -64,11 +64,17 @@ def test_dataset_basic_operations():
     geom_shape = (total_atoms_series, 3)
     atomic_numbers_shape = (total_atoms_single, 1)
     internal_energy_shape = (total_confs, 1)
-    input_data = {"geometry": np.arange(geom_shape[0] * geom_shape[1]).reshape(geom_shape),
-                  "atomic_numbers": np.arange(atomic_numbers_shape[0]).reshape(atomic_numbers_shape),
-                  "internal_energy_at_0K": np.arange(internal_energy_shape[0]).reshape(internal_energy_shape),
-                  "atomic_subsystem_counts": atomic_subsystem_counts,
-                  "n_confs": n_confs}
+    input_data = {
+        "geometry": np.arange(geom_shape[0] * geom_shape[1]).reshape(geom_shape),
+        "atomic_numbers": np.arange(atomic_numbers_shape[0]).reshape(
+            atomic_numbers_shape
+        ),
+        "internal_energy_at_0K": np.arange(internal_energy_shape[0]).reshape(
+            internal_energy_shape
+        ),
+        "atomic_subsystem_counts": atomic_subsystem_counts,
+        "n_confs": n_confs,
+    }
 
     property_names = PropertyNames(
         "atomic_numbers",
@@ -77,7 +83,7 @@ def test_dataset_basic_operations():
     )
     dataset = TorchDataset(input_data, property_names)
     assert len(dataset) == total_confs
-    assert (dataset.record_len() == total_records)
+    assert dataset.record_len() == total_records
 
     atomic_numbers_true = []
     geom_true = []
@@ -92,8 +98,12 @@ def test_dataset_basic_operations():
         for conf in range(n_confs[rec]):
             atom_end_idx_series = atom_start_idx_series + atomic_subsystem_counts[rec]
             energy_true.append(input_data["internal_energy_at_0K"][conf_idx])
-            geom_true.append(input_data["geometry"][atom_start_idx_series:atom_end_idx_series])
-            atomic_numbers_true.append(input_data["atomic_numbers"][atom_start_idx_single:atom_end_idx_single])
+            geom_true.append(
+                input_data["geometry"][atom_start_idx_series:atom_end_idx_series]
+            )
+            atomic_numbers_true.append(
+                input_data["atomic_numbers"][atom_start_idx_single:atom_end_idx_single]
+            )
             series_mol_idxs_for_rec.append(conf_idx)
             atom_start_idx_series = atom_end_idx_series
             conf_idx += 1
@@ -102,12 +112,16 @@ def test_dataset_basic_operations():
 
     for conf_idx in range(len(dataset)):
         conf_data = dataset[conf_idx]
-        assert(np.array_equal(conf_data["positions"], geom_true[conf_idx]))
-        assert(np.array_equal(conf_data["atomic_numbers"], atomic_numbers_true[conf_idx]))
-        assert(np.array_equal(conf_data["E_label"], energy_true[conf_idx]))
+        assert np.array_equal(conf_data["positions"], geom_true[conf_idx])
+        assert np.array_equal(
+            conf_data["atomic_numbers"], atomic_numbers_true[conf_idx]
+        )
+        assert np.array_equal(conf_data["E_label"], energy_true[conf_idx])
 
     for rec_idx in range(dataset.record_len()):
-        assert(np.array_equal(dataset.get_series_mol_idxs(rec_idx), series_mol_idxs[rec_idx]))
+        assert np.array_equal(
+            dataset.get_series_mol_idxs(rec_idx), series_mol_idxs[rec_idx]
+        )
 
 
 @pytest.mark.parametrize("dataset", DATASETS)
@@ -175,7 +189,7 @@ def test_data_item_format(dataset):
     from typing import Dict
 
     dataset = initialize_dataset(
-        dataset, mode="fit", split_file="modelforge/tests/qm9tut/split.npz"
+        dataset, split_file="modelforge/tests/qm9tut/split.npz"
     )
 
     raw_data_item = dataset.dataset[0]
@@ -186,7 +200,7 @@ def test_data_item_format(dataset):
     print(raw_data_item)
 
     assert (
-            raw_data_item["atomic_numbers"].shape[0] == raw_data_item["positions"].shape[0]
+        raw_data_item["atomic_numbers"].shape[0] == raw_data_item["positions"].shape[0]
     )
 
 
@@ -210,7 +224,7 @@ def test_padding():
 def test_dataset_generation(dataset):
     """Test the splitting of the dataset."""
 
-    dataset = initialize_dataset(dataset, mode="fit")
+    dataset = initialize_dataset(dataset)
     train_dataloader = dataset.train_dataloader()
     val_dataloader = dataset.val_dataloader()
 
@@ -235,7 +249,9 @@ def test_dataset_splitting(dataset):
     from modelforge.dataset.utils import RandomRecordSplittingStrategy
 
     dataset = generate_torch_dataset(dataset)
-    train_dataset, val_dataset, test_dataset = RandomRecordSplittingStrategy().split(dataset)
+    train_dataset, val_dataset, test_dataset = RandomRecordSplittingStrategy().split(
+        dataset
+    )
 
     energy = train_dataset[0]["E_label"].item()
     assert np.isclose(energy, -412509.9375)
@@ -244,9 +260,9 @@ def test_dataset_splitting(dataset):
     try:
         RandomRecordSplittingStrategy(split=[0.2, 0.1, 0.1])
     except AssertionError as e:
-        print(f'AssertionError raised: {e}')
+        print(f"AssertionError raised: {e}")
         logger.debug(e)
-    
+
     train_dataset, val_dataset, test_dataset = RandomRecordSplittingStrategy(
         split=[0.6, 0.3, 0.1]
     ).split(dataset)
@@ -262,7 +278,7 @@ def test_file_cache_methods(dataset):
 
     # generate files to test _from_hdf5()
 
-    _ = initialize_dataset(dataset, mode="fit")
+    _ = initialize_dataset(dataset)
 
     data = dataset(for_unit_testing=True)
 
@@ -296,3 +312,86 @@ def test_numpy_dataset_assignment(dataset):
 
     assert hasattr(data, "numpy_data")
     assert isinstance(data.numpy_data, np.lib.npyio.NpzFile)
+
+
+def test_offset_and_normalization():
+
+    from modelforge.dataset.dataset import TorchDataModule
+    from torch.utils.data import Dataset
+
+    # create a small mock dataset
+    class SimpleDataset(Dataset):
+        def __init__(self, data):
+            self.data = data
+
+        def __len__(self):
+            return len(self.data)
+
+        def __getitem__(self, idx):
+            item = self.data[idx]
+            return item
+
+    # add the mock datapoints
+    dataset = [
+        {"E_label": torch.tensor([2], dtype=torch.float)},
+        {"E_label": torch.tensor([4], dtype=torch.float)},
+        {"E_label": torch.tensor([6], dtype=torch.float)},
+    ]
+
+    # Create an instance of the SimpleDataset with your data
+    simple_dataset = SimpleDataset(dataset)
+
+    # compute statistics for this dataset
+    stats = TorchDataModule.compute_statistics(simple_dataset, collate=False)
+
+    # make sure that mean and stddev are correct
+    assert torch.isclose(stats["mean"], torch.tensor([4.0]))
+    assert torch.isclose(stats["stddev"], torch.tensor([1.6330]))
+    # NOTE: since we are using a single batch ddof = 0 and the above
+    # represents the population stddev, if multiple batches are provided
+    # the sample stddev is calculates with ddof=1
+
+    # only offset the dataset by global mean
+    mod_dataset = TorchDataModule.preprocess_dataset(
+        simple_dataset,
+        normalize=False,
+        dataset_mean=stats["mean"],
+        dataset_std=stats["stddev"],
+    )
+
+    # new datapoints are -2,0,2 --> offset is 4
+    assert torch.isclose(
+        mod_dataset[0]["E_label"], torch.tensor([-2], dtype=torch.float)
+    )
+    assert torch.isclose(
+        mod_dataset[1]["E_label"], torch.tensor([0], dtype=torch.float)
+    )
+    assert torch.isclose(
+        mod_dataset[2]["E_label"], torch.tensor([2], dtype=torch.float)
+    )
+
+    # normalize the dataset using global mean and stddev
+    # NOTE: Since the dataset was modified in place we need to reinitialize the dataloader
+    # # add the mock datapoints
+    dataset = [
+        {"E_label": torch.tensor([2], dtype=torch.float)},
+        {"E_label": torch.tensor([4], dtype=torch.float)},
+        {"E_label": torch.tensor([6], dtype=torch.float)},
+    ]
+    simple_dataset = SimpleDataset(dataset)
+    mod_dataset = TorchDataModule.preprocess_dataset(
+        simple_dataset,
+        normalize=True,
+        dataset_mean=stats["mean"],
+        dataset_std=stats["stddev"],
+    )
+
+    assert torch.isclose(
+        mod_dataset[0]["E_label"], torch.tensor([-1.2247], dtype=torch.float), atol=1e-4
+    )
+    assert torch.isclose(
+        mod_dataset[1]["E_label"], torch.tensor([0], dtype=torch.float), atol=1e-4
+    )
+    assert torch.isclose(
+        mod_dataset[2]["E_label"], torch.tensor([1.2247], dtype=torch.float), atol=1e-4
+    )

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -304,11 +304,10 @@ def test_numpy_dataset_assignment(dataset):
     """
     Test if the numpy_dataset attribute is correctly assigned after processing or loading.
     """
-    from modelforge.dataset.transformation import default_transformation
 
     factory = DatasetFactory()
     data = dataset(for_unit_testing=True)
-    factory._load_or_process_data(data, None, default_transformation)
+    factory._load_or_process_data(data)
 
     assert hasattr(data, "numpy_data")
     assert isinstance(data.numpy_data, np.lib.npyio.NpzFile)

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -245,7 +245,7 @@ def test_pairlist():
 @pytest.mark.parametrize("dataset", DATASETS)
 def test_pairlist_on_dataset(dataset):
     from modelforge.dataset.dataset import TorchDataModule
-    from modelforge.potential.models import _PairList, _NeighbourList
+    from modelforge.potential.models import _NeighbourList
 
     data = dataset(for_unit_testing=True)
     data_module = TorchDataModule(data)
@@ -279,6 +279,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
 
     for lightning in [True, False]:
         # increase precision to 64 bit
+        torch.manual_seed(1234)
         model = setup_simple_model(model_class, lightning).double()
         input_data["positions"] = input_data["positions"]
         # reference values
@@ -342,7 +343,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
         assert torch.allclose(
             rotation_forces,
             rotate_reference,
-            atol=1e-3,
+            atol=1e-4,
         )
 
         # reflection test
@@ -367,7 +368,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
         assert torch.allclose(
             reflection_forces,
             reflection(reference_forces.to(torch.float32)).double(),
-            atol=1e-3,
+            atol=1e-4,
         )
 
 

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -342,7 +342,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
         assert torch.allclose(
             rotation_forces,
             rotate_reference,
-            atol=1e-4,
+            atol=1e-3,
         )
 
         # reflection test

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -367,7 +367,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
         assert torch.allclose(
             reflection_forces,
             reflection(reference_forces.to(torch.float32)).double(),
-            atol=1e-4,
+            atol=1e-3,
         )
 
 

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -446,8 +446,8 @@ def test_postprocessing():
     # self energy is calculated and removed in prepare_data if `remove_self_energies` is True
     dataset.prepare_data(remove_self_energies=True, normalize=False)
     assert dataset.dataset_statistics
-    # only 4 elements present in the reduced QM9 dataset
-    assert len(dataset.dataset_statistics["self_energies"]) == 4
+    # 5 elements present in the QM9 dataset
+    assert len(dataset.dataset_statistics["self_energies"]) == 5
 
     from modelforge.potential.schnet import SchNET
     from modelforge.potential import CosineCutoff, GaussianRBF
@@ -479,7 +479,6 @@ def test_postprocessing():
     )
 
     for batch in dataset.train_dataloader():
-        print(batch)
         result = model(batch)
         break
 
@@ -518,9 +517,11 @@ def test_postprocessing():
         result_with_offset = model(batch)
         break
 
+    print(f"{offset=}")
+    print(f"{e=}")
     r1 = result_with_offset[0].item()
     r2 = (e + offset).item()
 
-    # make sure that the prediction between the two 
+    # make sure that the prediction between the two
     # SchNET models differ only by the offset
     assert np.isclose(r1, r2)

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -127,7 +127,7 @@ def test_pairlist_logic():
 
 
 def test_pairlist():
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import _PairList, _NeighbourList
     import torch
 
     atomic_subsystem_indices = torch.tensor([80, 80, 80, 11, 11, 11])
@@ -142,7 +142,7 @@ def test_pairlist():
         ]
     )
     cutoff = 5.0  # no relevant cutoff
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -172,7 +172,7 @@ def test_pairlist():
 
     # test with cutoff
     cutoff = 2.0  #
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=True)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -196,7 +196,7 @@ def test_pairlist():
 
     # test with complete pairlist
     cutoff = 2.0  #
-    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=False)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
 
@@ -208,8 +208,8 @@ def test_pairlist():
     # make sure that Pairlist and Neighborlist behave the same for large cutoffs
     cutoff = 10.0  #
     only_unique_pairs = False
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
-    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    neighborlist = _NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = _PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
     r = neighborlist(positions, atomic_subsystem_indices)
@@ -220,8 +220,8 @@ def test_pairlist():
     # make sure that they are the same also for non-redundant pairs
     cutoff = 10.0  #
     only_unique_pairs = True
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
-    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    neighborlist = _NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = _PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
     r = neighborlist(positions, atomic_subsystem_indices)
@@ -232,8 +232,8 @@ def test_pairlist():
     # this should fail
     cutoff = 2.0  #
     only_unique_pairs = True
-    neighborlist = NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
-    pairlist = PairList(only_unique_pairs=only_unique_pairs)
+    neighborlist = _NeighbourList(cutoff, only_unique_pairs=only_unique_pairs)
+    pairlist = _PairList(only_unique_pairs=only_unique_pairs)
     r = pairlist(positions, atomic_subsystem_indices)
     pair_indices = r["pair_indices"]
     r = neighborlist(positions, atomic_subsystem_indices)
@@ -245,7 +245,7 @@ def test_pairlist():
 @pytest.mark.parametrize("dataset", DATASETS)
 def test_pairlist_on_dataset(dataset):
     from modelforge.dataset.dataset import TorchDataModule
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import _PairList, _NeighbourList
 
     data = dataset(for_unit_testing=True)
     data_module = TorchDataModule(data)
@@ -255,7 +255,7 @@ def test_pairlist_on_dataset(dataset):
         positions = data["positions"]
         atomic_subsystem_indices = data["atomic_subsystem_indices"]
         print(atomic_subsystem_indices)
-        pairlist = NeighbourList(cutoff=5.0)
+        pairlist = _NeighbourList(cutoff=5.0)
         r = pairlist(positions, atomic_subsystem_indices)
         print(r)
         shape_pairlist = r["pair_indices"].shape
@@ -373,7 +373,7 @@ def test_equivariant_energies_and_forces(input_data, model_class):
 
 def test_pairlist_calculate_r_ij_and_d_ij():
     # Define inputs
-    from modelforge.potential.models import PairList, NeighbourList
+    from modelforge.potential.models import _PairList, _NeighbourList
     import torch
 
     positions = torch.tensor(
@@ -385,14 +385,14 @@ def test_pairlist_calculate_r_ij_and_d_ij():
     # Create Pairlist instance
     # --------------------------- #
     # Only unique pairs
-    pairlist = NeighbourList(cutoff, only_unique_pairs=True)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=True)
     pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=True
     )
 
     # Calculate r_ij and d_ij
-    r_ij = pairlist.calculate_r_ij(pair_indices, positions)
-    d_ij = pairlist.calculate_d_ij(r_ij)
+    r_ij = pairlist._calculate_r_ij(pair_indices, positions)
+    d_ij = pairlist._calculate_d_ij(r_ij)
 
     # Check if the calculated r_ij and d_ij are correct
     expected_r_ij = torch.tensor([[2.0, 0.0, 0.0], [0.0, 2.0, 1.0]])
@@ -409,14 +409,14 @@ def test_pairlist_calculate_r_ij_and_d_ij():
 
     # --------------------------- #
     # ALL pairs
-    pairlist = NeighbourList(cutoff, only_unique_pairs=False)
+    pairlist = _NeighbourList(cutoff, only_unique_pairs=False)
     pair_indices = pairlist.calculate_pairs(
         positions, atomic_subsystem_indices, pairlist.cutoff, only_unique_pairs=False
     )
 
     # Calculate r_ij and d_ij
-    r_ij = pairlist.calculate_r_ij(pair_indices, positions)
-    d_ij = pairlist.calculate_d_ij(r_ij)
+    r_ij = pairlist._calculate_r_ij(pair_indices, positions)
+    d_ij = pairlist._calculate_d_ij(r_ij)
 
     # Check if the calculated r_ij and d_ij are correct
     expected_r_ij = torch.tensor(

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -19,7 +19,6 @@ def test_forward_pass(model_class, dataset):
         initialized_model = setup_simple_model(model_class, lightning)
         inputs = return_single_batch(
             dataset,
-            mode="fit",
         )  # split_file="modelforge/tests/qm9tut/split.npz")
         nr_of_mols = inputs["atomic_subsystem_indices"].unique().shape[0]
         nr_of_atoms_per_batch = inputs["atomic_subsystem_indices"].shape[0]
@@ -250,7 +249,7 @@ def test_pairlist_on_dataset(dataset):
     data = dataset(for_unit_testing=True)
     data_module = TorchDataModule(data)
     data_module.prepare_data()
-    data_module.setup("fit")
+    data_module.setup()
     for data in data_module.train_dataloader():
         positions = data["positions"]
         atomic_subsystem_indices = data["atomic_subsystem_indices"]

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -1,23 +1,23 @@
-from modelforge.potential import GaussianRBF
+from modelforge.potential import _GaussianRBF
 import torch
 
 
 def test_gaussian_rbf_1D():
     dist = torch.tensor([[[1.0]]])
 
-    rbf_expension = GaussianRBF(n_rbf=6, cutoff=5.0)
+    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=5.0)
     expt = torch.exp(-0.5 * torch.tensor([[[1.0, 0.0, 1.0, 4.0, 9.0, 16.0]]]))
     assert torch.allclose(expt, rbf_expension(dist), atol=0.0, rtol=1.0e-7)
     assert list(rbf_expension.parameters()) == []
 
-    rbf_expension = GaussianRBF(n_rbf=6, cutoff=5.0, trainable=True)
+    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=5.0, trainable=True)
     assert list(rbf_expension.parameters()) != []
 
 
 def test_gaussian_rbf_3D():
     dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]])
     # smear using 4 Gaussian functions with 1. spacing
-    smear = GaussianRBF(start=1.0, cutoff=4.0, n_rbf=4)
+    smear = _GaussianRBF(start=1.0, cutoff=4.0, n_rbf=4)
     # absolute value of centered distances
     expt = torch.tensor(
         [

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -1,4 +1,4 @@
-from modelforge.potential import _GaussianRBF
+from modelforge.potential import GaussianRBF
 import torch
 
 
@@ -8,15 +8,14 @@ def test_gaussian_rbf_1D():
     )  # NOTE: converting to nanometer, NOTE: invariant as long as consisten units are used
 
     from openff.units import unit
+
     rbf_expension = GaussianRBF(n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom))
 
     expt = torch.exp(-0.5 * torch.tensor([[[1.0, 0.0, 1.0, 4.0, 9.0, 16.0]]]))
     assert torch.allclose(expt, rbf_expension(dist), atol=1e-4)
     assert list(rbf_expension.parameters()) == []
 
-    rbf_expension = GaussianRBF(
-        n_rbf=6, cutoff=5.0*unit.angstrom, trainable=True
-    )
+    rbf_expension = GaussianRBF(n_rbf=6, cutoff=5.0 * unit.angstrom, trainable=True)
     assert list(rbf_expension.parameters()) != []
 
 
@@ -25,7 +24,7 @@ def test_gaussian_rbf_3D():
 
     dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]]) / 10
     # smear using 4 Gaussian functions with 1. spacing
-    smear = GaussianRBF(start=.1, cutoff=4.0*unit.angstrom, n_rbf=4)
+    smear = GaussianRBF(start=0.1, cutoff=4.0 * unit.angstrom, n_rbf=4)
     # absolute value of centered distances
     expt = torch.tensor(
         [

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -3,21 +3,28 @@ import torch
 
 
 def test_gaussian_rbf_1D():
-    dist = torch.tensor([[[1.0]]])
+    dist = (
+        torch.tensor([[[1.0]]]) / 10
+    )  # NOTE: converting to nanometer, NOTE: invariant as long as consisten units are used
+    from openmm import unit
 
-    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=5.0)
+    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom))
     expt = torch.exp(-0.5 * torch.tensor([[[1.0, 0.0, 1.0, 4.0, 9.0, 16.0]]]))
-    assert torch.allclose(expt, rbf_expension(dist), atol=0.0, rtol=1.0e-7)
+    assert torch.allclose(expt, rbf_expension(dist), atol=1e-4)
     assert list(rbf_expension.parameters()) == []
 
-    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=5.0, trainable=True)
+    rbf_expension = _GaussianRBF(
+        n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom), trainable=True
+    )
     assert list(rbf_expension.parameters()) != []
 
 
 def test_gaussian_rbf_3D():
-    dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]])
+    from openmm import unit
+
+    dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]]) / 10
     # smear using 4 Gaussian functions with 1. spacing
-    smear = _GaussianRBF(start=1.0, cutoff=4.0, n_rbf=4)
+    smear = _GaussianRBF(start=.1, cutoff=unit.Quantity(4.0, unit.angstrom), n_rbf=4)
     # absolute value of centered distances
     expt = torch.tensor(
         [
@@ -28,5 +35,5 @@ def test_gaussian_rbf_3D():
         ]
     )
     expt = torch.exp(-0.5 * expt**2)
-    assert torch.allclose(expt, smear(dist), atol=0.0, rtol=1.0e-7)
+    assert torch.allclose(expt, smear(dist), atol=1e-5)
     assert list(smear.parameters()) == []

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -1,4 +1,4 @@
-from modelforge.potential import _GaussianRBF
+from modelforge.potential import GaussianRBF
 import torch
 
 
@@ -8,12 +8,12 @@ def test_gaussian_rbf_1D():
     )  # NOTE: converting to nanometer, NOTE: invariant as long as consisten units are used
     from openmm import unit
 
-    rbf_expension = _GaussianRBF(n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom))
+    rbf_expension = GaussianRBF(n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom))
     expt = torch.exp(-0.5 * torch.tensor([[[1.0, 0.0, 1.0, 4.0, 9.0, 16.0]]]))
     assert torch.allclose(expt, rbf_expension(dist), atol=1e-4)
     assert list(rbf_expension.parameters()) == []
 
-    rbf_expension = _GaussianRBF(
+    rbf_expension = GaussianRBF(
         n_rbf=6, cutoff=unit.Quantity(5.0, unit.angstrom), trainable=True
     )
     assert list(rbf_expension.parameters()) != []
@@ -24,7 +24,7 @@ def test_gaussian_rbf_3D():
 
     dist = torch.tensor([[[0.0, 1.0, 1.5], [0.5, 1.5, 3.0]]]) / 10
     # smear using 4 Gaussian functions with 1. spacing
-    smear = _GaussianRBF(start=.1, cutoff=unit.Quantity(4.0, unit.angstrom), n_rbf=4)
+    smear = GaussianRBF(start=0.1, cutoff=unit.Quantity(4.0, unit.angstrom), n_rbf=4)
     # absolute value of centered distances
     expt = torch.tensor(
         [

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -20,11 +20,18 @@ def test_PaiNN_init(lightning):
     assert painn is not None, "PaiNN model should be initialized."
 
 
+from openmm import unit
+
+
 @pytest.mark.parametrize("lightning", [True, False])
 @pytest.mark.parametrize("input_data", SIMPLIFIED_INPUT_DATA)
 @pytest.mark.parametrize(
     "model_parameter",
-    ([64, 50, 2, 5.0, 2], [32, 60, 10, 7.0, 1], [128, 120, 5, 5.0, 3]),
+    (
+        [64, 50, 2, unit.Quantity(5.0, unit.angstrom), 2],
+        [32, 60, 10, unit.Quantity(7.0, unit.angstrom), 1],
+        [128, 120, 5, unit.Quantity(5.0, unit.angstrom), 3],
+    ),
 )
 def test_painn_forward(lightning, input_data, model_parameter):
     """

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -54,7 +54,7 @@ def test_painn_forward(lightning, input_data, model_parameter):
         cutoff=cutoff,
         nr_interaction_blocks=nr_interaction_blocks,
     )
-    energy = painn(input_data)
+    energy = painn(input_data)['energy_readout']
     nr_of_mols = input_data["atomic_subsystem_indices"].unique().shape[0]
 
     assert energy.shape == (

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -15,11 +15,18 @@ def test_Schnet_init(lightning):
     assert schnet is not None, "Schnet model should be initialized."
 
 
+from openmm import unit
+
+
 @pytest.mark.parametrize("lightning", [True, False])
 @pytest.mark.parametrize("input_data", SIMPLIFIED_INPUT_DATA)
 @pytest.mark.parametrize(
     "model_parameter",
-    ([64, 50, 20, 5.0, 2], [32, 60, 10, 7.0, 1], [128, 120, 64, 5.0, 3]),
+    (
+        [64, 50, 20, unit.Quantity(5.0, unit.angstrom), 2],
+        [32, 60, 10, unit.Quantity(7.0, unit.angstrom), 1],
+        [128, 120, 64, unit.Quantity(5.0, unit.angstrom), 3],
+    ),
 )
 def test_schnet_forward(lightning, input_data, model_parameter):
     """
@@ -73,7 +80,7 @@ def test_schnet_interaction_layer():
     interaction = SchNETInteractionBlock(
         nr_atom_basis=nr_atom_basis, nr_filters=3, nr_rbf=nr_rbf
     )
-    
+
     v = interaction(
         interaction_data["x"],
         interaction_data["pair_indices"],

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -49,7 +49,7 @@ def test_schnet_forward(lightning, input_data, model_parameter):
         cutoff=cutoff,
         nr_interaction_blocks=nr_interaction_blocks,
     )
-    energy = schnet(input_data)
+    energy = schnet(input_data)['energy_readout']
     nr_of_mols = input_data["atomic_subsystem_indices"].unique().shape[0]
 
     assert energy.shape == (

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -3,13 +3,13 @@ import torch
 
 def test_gaussian_rbf_implementation():
     # compare schnetpack GaussianRBF with modelforge GaussianRBF
-    from modelforge.potential.utils import _GaussianRBF
-    from schnetpack.nn import GaussianRBF as schnetpack_GaussianRBF
+    from modelforge.potential.utils import GaussianRBF
+    from schnetpack.nn import GaussianRBF as schnetpackGaussianRBF
     from openff.units import unit
 
     n_rbf = 2
     cutoff = unit.Quantity(5.0, unit.angstrom)
-    schnetpack_rbf = schnetpack_GaussianRBF(
+    schnetpack_rbf = schnetpackGaussianRBF(
         n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom).m
     )
     rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
@@ -161,14 +161,14 @@ def setup_modelforge_painn_representation(cutoff, nr_atom_basis, n_rbf):
     # set up the modelforge Painn representation model
     # which means that we only want to call the
     # _transform_input() method
-    from modelforge.potential import _CosineCutoff, _GaussianRBF
+    from modelforge.potential import CosineCutoff, GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
     from modelforge.potential.painn import PaiNN
     from openff.units import unit
 
     embedding = SlicedEmbedding(max_Z=100, embedding_dim=nr_atom_basis, sliced_dim=0)
-    radial_basis = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
-    cutoff = _CosineCutoff(cutoff)
+    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    cutoff = CosineCutoff(cutoff)
 
     return PaiNN(
         embedding_module=embedding,

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -140,7 +140,9 @@ def setup_input():
     }
 
 
-def setup_spk_painn_representation(cutoff, nr_atom_basis, n_rbf):
+def setup_spk_painn_representation(
+    cutoff: float, nr_atom_basis: int, n_rbf: int, nr_of_interactions: int
+):
     # ------------------------------------ #
     # set up the schnetpack Painn representation model
     from schnetpack.nn import GaussianRBF, CosineCutoff
@@ -150,29 +152,31 @@ def setup_spk_painn_representation(cutoff, nr_atom_basis, n_rbf):
     radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom).m)
     return schnetpack_PaiNN(
         n_atom_basis=nr_atom_basis,
-        n_interactions=3,
+        n_interactions=nr_of_interactions,
         radial_basis=radial_basis,
         cutoff_fn=CosineCutoff(cutoff.to(unit.angstrom).m),
     )
 
 
-def setup_modelforge_painn_representation(cutoff, nr_atom_basis, n_rbf):
+def setup_modelforge_painn_representation(
+    cutoff: float, nr_atom_basis: int, n_rbf: int, nr_of_interactions: int
+):
     # ------------------------------------ #
     # set up the modelforge Painn representation model
     # which means that we only want to call the
     # _transform_input() method
     from modelforge.potential import CosineCutoff, GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
-    from modelforge.potential.painn import PaiNN
+    from modelforge.potential.painn import PaiNN as mf_PaiNN
     from openff.units import unit
 
     embedding = SlicedEmbedding(max_Z=100, embedding_dim=nr_atom_basis, sliced_dim=0)
     radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
     cutoff = CosineCutoff(cutoff)
 
-    return PaiNN(
+    return mf_PaiNN(
         embedding_module=embedding,
-        nr_interaction_blocks=3,
+        nr_interaction_blocks=nr_of_interactions,
         radial_basis_module=radial_basis,
         cutoff_module=cutoff,
     )
@@ -187,15 +191,15 @@ def test_painn_representation_implementation():
     cutoff = unit.Quantity(5.0, unit.angstrom)
     nr_atom_basis = 8
     n_rbf = 5
+    nr_of_interactions = 3
     torch.manual_seed(1234)
     schnetpack_painn = setup_spk_painn_representation(
-        cutoff, nr_atom_basis, n_rbf
+        cutoff, nr_atom_basis, n_rbf, nr_of_interactions
     ).double()
     torch.manual_seed(1234)
     modelforge_painn = setup_modelforge_painn_representation(
-        cutoff, nr_atom_basis, n_rbf
+        cutoff, nr_atom_basis, n_rbf, nr_of_interactions
     ).double()
-
     # ------------------------------------ #
     # set up the input for the spk Painn model
     input = setup_input()
@@ -232,16 +236,16 @@ def test_painn_representation_implementation():
     # ---------------------------------------- #
     # test cutoff
     # ---------------------------------------- #
-    spk_fcut = schnetpack_painn.cutoff_fn(d_ij)
-    mf_fcut = modelforge_painn.cutoff_module(d_ij / 10)  # NOTE: converting to nm
-    assert torch.allclose(spk_fcut, mf_fcut)
+    fcut_spk = schnetpack_painn.cutoff_fn(d_ij)
+    fcut_mf = modelforge_painn.cutoff_module(d_ij / 10)  # NOTE: converting to nm
+    assert torch.allclose(fcut_spk, fcut_mf)
 
     # ---------------------------------------- #
     # test filter
     # ---------------------------------------- #
-    spk_filters = schnetpack_painn.filter_net(phi_ij) * spk_fcut[..., None]
-    mf_filters = schnetpack_painn.filter_net(phi_ij) * mf_fcut[..., None]
-    assert torch.allclose(spk_filters, mf_filters)
+    filters_spk = schnetpack_painn.filter_net(phi_ij) * fcut_spk[..., None]
+    filters_mf = schnetpack_painn.filter_net(phi_ij) * fcut_mf[..., None]
+    assert torch.allclose(filters_spk, filters_mf)
 
     # ---------------------------------------- #
     # test embedding
@@ -251,64 +255,81 @@ def test_painn_representation_implementation():
     assert torch.allclose(
         spk_input[properties.Z], modelforge_input["atomic_numbers"].squeeze()
     )
-    spk_embedding = schnetpack_painn.embedding(spk_input[properties.Z])
-    mf_embedding = modelforge_painn.embedding_module(modelforge_input["atomic_numbers"])
-    assert torch.allclose(spk_embedding, mf_embedding)
+    embedding_spk = schnetpack_painn.embedding(spk_input[properties.Z])
+    embedding_mf = modelforge_painn.embedding_module(modelforge_input["atomic_numbers"])
 
+    assert torch.allclose(embedding_spk, embedding_mf)
     # ---------------------------------------- #
     # test interaction
     # ---------------------------------------- #
     # compare dimensions of q and mu in spk and modelforge
-    spk_q = spk_embedding[:, None]
-    spk_qs = spk_q.shape
-    mf_q = mf_embedding[:, None]
-    mf_qs = mf_q.shape
+    q_spk_initial = embedding_spk[:, None]
+    spk_qs = q_spk_initial.shape
+    q_mf_initial = embedding_mf[:, None]
+    mf_qs = q_mf_initial.shape
     assert spk_qs == mf_qs
-    assert torch.allclose(spk_q, mf_q)
+    assert torch.allclose(q_spk_initial, q_mf_initial)
 
-    spk_mu = torch.zeros((spk_qs[0], 3, spk_qs[2]))
-    mf_mu = torch.zeros((mf_qs[0], 3, mf_qs[2]))
-    assert spk_mu.shape == mf_mu.shape
+    mu_spk_initial = torch.zeros((spk_qs[0], 3, spk_qs[2]))
+    mu_mf_initial = torch.zeros((mf_qs[0], 3, mf_qs[2]))
+    assert mu_spk_initial.shape == mu_mf_initial.shape
 
     # set up the filter and interaction, pass the input and compare the results
     # ---------------------------------------- #
-    mf_intra_net = modelforge_painn.interaction_modules[0].intra_atomic_net
-    spk_intra_net = schnetpack_painn.interactions[0].interatomic_context_net
-    assert torch.allclose(mf_q, spk_q)
+    assert torch.allclose(q_mf_initial, q_spk_initial)
     # reset parameters
     torch.manual_seed(1234)
-    [dense.reset_parameters() for dense in mf_intra_net]
+    [
+        dense.reset_parameters()
+        for i in range(nr_of_interactions)
+        for dense in modelforge_painn.interaction_modules[i].interatomic_net
+    ]
     torch.manual_seed(1234)
-    [dense.reset_parameters() for dense in spk_intra_net]
+    [
+        dense.reset_parameters()
+        for i in range(nr_of_interactions)
+        for dense in schnetpack_painn.interactions[i].interatomic_context_net
+    ]
+    print(modelforge_painn.interaction_modules[0].interatomic_net[0].weight)
+    print(schnetpack_painn.interactions[0].interatomic_context_net[0].weight)
 
-    intra_mf_q = mf_intra_net(mf_q)
-    intra_spk_q = spk_intra_net(spk_q)
+    assert torch.allclose(
+        modelforge_painn.interaction_modules[0].interatomic_net[0].weight,
+        schnetpack_painn.interactions[0].interatomic_context_net[0].weight,
+        atol=1e-4,
+    )
+
+    # first layer
+    mf_intra_net = modelforge_painn.interaction_modules[0].interatomic_net
+    spk_intra_net = schnetpack_painn.interactions[0].interatomic_context_net
+    intra_mf_q = mf_intra_net(q_mf_initial)
+    intra_spk_q = spk_intra_net(q_spk_initial)
 
     assert torch.allclose(intra_mf_q, intra_spk_q)
     # ---------------------------------------- #
 
-    filter_list = torch.split(spk_filters, 3 * schnetpack_painn.n_atom_basis, dim=-1)
+    filter_list = torch.split(filters_spk, 3 * schnetpack_painn.n_atom_basis, dim=-1)
     n_atoms = spk_input[properties.Z].shape[0]
-    spk_q, spk_mu = schnetpack_painn.interactions[0](
-        spk_q, spk_mu, filter_list[0], dir_ij, idx_i, idx_j, n_atoms
+    q_spk, mu_spk = schnetpack_painn.interactions[0](
+        q_spk_initial, mu_spk_initial, filter_list[0], dir_ij, idx_i, idx_j, n_atoms
     )
     torch.manual_seed(1234)
     pair_indices = modelforge_input_2["pair_indices"]
-    filter_list = torch.split(mf_filters, 3 * modelforge_painn.nr_atom_basis, dim=-1)
+    filter_list = torch.split(filters_mf, 3 * modelforge_painn.nr_atom_basis, dim=-1)
 
     # test intra-atomic NNP
-    mf_q, mf_mu = modelforge_painn.interaction_modules[0](
-        mf_q,
-        mf_mu,
+    q_mf, mu_mf = modelforge_painn.interaction_modules[0](
+        q_mf_initial,
+        mu_mf_initial,
         filter_list[0],
         dir_ij,
         pair_indices,
     )
 
-    assert spk_q.shape == mf_q.shape
-    assert spk_mu.shape == mf_mu.shape
-    assert torch.allclose(spk_q, mf_q)
-    assert torch.allclose(spk_mu, mf_mu)
+    assert q_spk.shape == q_mf.shape
+    assert mu_spk.shape == mu_mf.shape
+    assert torch.allclose(q_spk, q_mf)
+    assert torch.allclose(mu_spk, mu_mf)
 
     # ---------------------------------------- #
     # test mixing
@@ -316,34 +337,352 @@ def test_painn_representation_implementation():
     # reset parameters
     torch.manual_seed(1234)
     [
-        dense.reset_parameters()
-        for dense in modelforge_painn.mixing_modules[0].intra_atomic_net
+        (
+            modelforge_painn.mixing_modules[i].mu_channel_mix.reset_parameters(),
+            modelforge_painn.mixing_modules[i].intra_atomic_net[0].reset_parameters(),
+            modelforge_painn.mixing_modules[i].intra_atomic_net[1].reset_parameters(),
+        )
+        for i in range(nr_of_interactions)
     ]
-    modelforge_painn.mixing_modules[0].mu_channel_mix.reset_parameters()
-    torch.manual_seed(1234)
-    [
-        dense.reset_parameters()
-        for dense in schnetpack_painn.mixing[0].intraatomic_context_net
-    ]
-    schnetpack_painn.mixing[0].mu_channel_mix.reset_parameters()
 
-    mixed_spk_q, mixed_spk_mu = schnetpack_painn.mixing[0](spk_q, spk_mu)
-    mixed_mf_q, mixed_mf_mu = modelforge_painn.mixing_modules[0](mf_q, mf_mu)
+    torch.manual_seed(1234)
+
+    [
+        (
+            schnetpack_painn.mixing[i].mu_channel_mix.reset_parameters(),
+            schnetpack_painn.mixing[i].intraatomic_context_net[0].reset_parameters(),
+            schnetpack_painn.mixing[i].intraatomic_context_net[1].reset_parameters(),
+        )
+        for i in range(nr_of_interactions)
+    ]
+
+    # test painn mixing
+    for i in range(nr_of_interactions):
+        print(i, flush=True)
+        assert torch.allclose(
+            modelforge_painn.mixing_modules[i].mu_channel_mix.weight,
+            schnetpack_painn.mixing[i].mu_channel_mix.weight,
+        )
+        assert torch.allclose(
+            modelforge_painn.mixing_modules[i].intra_atomic_net[0].weight,
+            schnetpack_painn.mixing[i].intraatomic_context_net[0].weight,
+        )
+        assert torch.allclose(
+            modelforge_painn.mixing_modules[i].intra_atomic_net[1].weight,
+            schnetpack_painn.mixing[i].intraatomic_context_net[1].weight,
+        )
+
+    mixed_spk_q, mixed_spk_mu = schnetpack_painn.mixing[0](q_spk, mu_spk)
+    mixed_mf_q, mixed_mf_mu = modelforge_painn.mixing_modules[0](q_mf, mu_mf)
     assert torch.allclose(mixed_mf_q, mixed_spk_q)
     assert torch.allclose(mixed_mf_mu, mixed_spk_mu)
+
+    # -----------------------------
+    # test one interaction and mixing pass
+    # -----------------------------
+    spk_filter_list = torch.split(
+        filters_spk, 3 * schnetpack_painn.n_atom_basis, dim=-1
+    )
+    # q_spk = q_spk_initial
+    # mu_spk = mu_spk_initial
+    for i, (interaction, mixing) in enumerate(
+        zip(schnetpack_painn.interactions[0:1], schnetpack_painn.mixing[0:1])
+    ):
+        q_spk, mu_spk = interaction(
+            q_spk,
+            mu_spk,
+            spk_filter_list[i],
+            dir_ij,
+            idx_i,
+            idx_j,
+            n_atoms,
+        )
+        q_spk, mu_spk = mixing(q_spk, mu_spk)
+
+    mf_filter_list = torch.split(filters_mf, 3 * modelforge_painn.nr_atom_basis, dim=-1)
+    # q_mf = q_mf_initial
+    # mu_mf = mu_mf_initial
+
+    for i, (interaction, mixing) in enumerate(
+        zip(
+            modelforge_painn.interaction_modules[0:1],
+            modelforge_painn.mixing_modules[0:1],
+        )
+    ):
+        q_mf, mu_mf = interaction(q_mf, mu_mf, mf_filter_list[i], dir_ij, pair_indices)
+        q_mf, mu_mf = mixing(q_mf, mu_mf)
+
+    assert torch.allclose(q_mf, q_spk)
+    assert torch.allclose(mu_mf, mu_spk)
+
+    # -----------------------------
+    # test two interaction and mixing pass
+    # -----------------------------
+    spk_filter_list = torch.split(
+        filters_spk, 3 * schnetpack_painn.n_atom_basis, dim=-1
+    )
+    mf_filter_list = torch.split(filters_mf, 3 * modelforge_painn.nr_atom_basis, dim=-1)
+
+    # q_spk = q_spk_initial
+    # mu_spk = mu_spk_initial
+
+    for i, (spk_interaction, spk_mixing, mf_interaction, mf_mixing) in enumerate(
+        zip(
+            schnetpack_painn.interactions,
+            schnetpack_painn.mixing,
+            modelforge_painn.interaction_modules,
+            modelforge_painn.mixing_modules,
+        )
+    ):
+        q_spk, mu_spk = spk_interaction(
+            q_spk,
+            mu_spk,
+            spk_filter_list[i],
+            dir_ij,
+            idx_i,
+            idx_j,
+            n_atoms,
+        )
+        q_spk, mu_spk = spk_mixing(q_spk, mu_spk)
+        q_mf, mu_mf = mf_interaction(
+            q_mf, mu_mf, mf_filter_list[i], dir_ij, pair_indices
+        )
+        q_mf, mu_mf = mf_mixing(q_mf, mu_mf)
+        assert torch.allclose(q_mf, q_spk)
+        assert torch.allclose(mu_mf, mu_spk)
 
     # ---------------------------------------- #
     # test forward pass
     # ---------------------------------------- #
 
+    # reset filter parameters
+    torch.manual_seed(1234)
+    modelforge_painn.filter_net.reset_parameters()
+    torch.manual_seed(1234)
+    schnetpack_painn.filter_net.reset_parameters()
+    assert torch.allclose(
+        modelforge_painn.filter_net.weight,
+        schnetpack_painn.filter_net.weight,
+        atol=1e-4,
+    )
     modelforge_results = modelforge_painn._forward(modelforge_input_2)
-    # FIXME: NOTE: this is still not the same
-    # assert torch.allclose(
-    #     schnetpack_results["scalar_representation"],
-    #     modelforge_results["scalar_representation"],
-    # )
+    schnetpack_results = schnetpack_painn(spk_input)
 
-    # assert torch.allclose(
-    #     schnetpack_results["vector_representation"],
-    #     modelforge_results["vector_representation"],
-    # )
+    assert (
+        schnetpack_results["scalar_representation"].shape
+        == modelforge_results["scalar_representation"].shape
+    )
+
+    scalar_spk = schnetpack_results["scalar_representation"]
+    scalar_mf = modelforge_results["scalar_representation"]
+    assert torch.allclose(scalar_spk, scalar_mf, atol=1e-4)
+
+    assert torch.allclose(
+        schnetpack_results["vector_representation"],
+        modelforge_results["vector_representation"],
+        atol=1e-4,
+    )
+
+
+def setup_spk_schnet_representation(
+    cutoff: float, nr_atom_basis: int, n_rbf: int, nr_of_interactions: int
+):
+    # ------------------------------------ #
+    # set up the schnetpack Painn representation model
+    from schnetpack.nn import GaussianRBF, CosineCutoff
+    from schnetpack.representation import SchNet as schnetpack_SchNET
+    from openff.units import unit
+
+    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff.to(unit.angstrom).m)
+    return schnetpack_SchNET(
+        n_atom_basis=nr_atom_basis,
+        n_interactions=nr_of_interactions,
+        radial_basis=radial_basis,
+        cutoff_fn=CosineCutoff(cutoff.to(unit.angstrom).m),
+    )
+
+
+def setup_mf_schnet_representation(
+    cutoff: float, nr_atom_basis: int, n_rbf: int, nr_of_interactions: int
+):
+    # ------------------------------------ #
+    # set up the modelforge Painn representation model
+    # which means that we only want to call the
+    # _transform_input() method
+    from modelforge.potential import CosineCutoff, GaussianRBF
+    from modelforge.potential.utils import SlicedEmbedding
+    from modelforge.potential.schnet import SchNET as mf_SchNET
+
+    embedding = SlicedEmbedding(max_Z=100, embedding_dim=nr_atom_basis, sliced_dim=0)
+    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    cutoff = CosineCutoff(cutoff)
+
+    return mf_SchNET(
+        embedding_module=embedding,
+        nr_interaction_blocks=nr_of_interactions,
+        radial_basis_module=radial_basis,
+        cutoff_module=cutoff,
+    )
+
+
+def test_schnet_representation_implementation():
+    # ---------------------------------------- #
+    # test the implementation of the representation part of the PaiNN model
+    # ---------------------------------------- #
+    from openff.units import unit
+
+    cutoff = unit.Quantity(5.0, unit.angstrom)
+    nr_atom_basis = 12
+    n_rbf = 5
+    nr_of_interactions = 3
+    torch.manual_seed(1234)
+    schnetpack_schnet = setup_spk_schnet_representation(
+        cutoff, nr_atom_basis, n_rbf, nr_of_interactions
+    ).double()
+    torch.manual_seed(1234)
+    modelforge_schnet = setup_mf_schnet_representation(
+        cutoff, nr_atom_basis, n_rbf, nr_of_interactions
+    ).double()
+    # ------------------------------------ #
+    # set up the input for the spk Schnet model
+    input = setup_input()
+    spk_input = input["spk_methane_input"]
+    modelforge_input = input["modelforge_methane_input"]
+
+    schnetpack_results = schnetpack_schnet(spk_input)
+    modelforge_schnet._set_dtype()
+    modelforge_input_1 = modelforge_schnet._input_checks(modelforge_input)
+    modelforge_input_2 = modelforge_schnet.prepare_inputs(modelforge_input_1)
+
+    # ---------------------------------------- #
+    # test neighborlist and distance
+    # ---------------------------------------- #
+    assert torch.allclose(spk_input["_Rij"] / 10, modelforge_input_2["r_ij"], atol=1e-4)
+    assert torch.allclose(spk_input["_idx_i"], modelforge_input_2["pair_indices"][0])
+    assert torch.allclose(spk_input["_idx_j"], modelforge_input_2["pair_indices"][1])
+    idx_i = spk_input["_idx_i"]
+    idx_j = spk_input["_idx_j"]
+
+    # ---------------------------------------- #
+    # test rbf
+    # ---------------------------------------- #
+    r_ij = spk_input["_Rij"]
+    d_ij = torch.norm(r_ij, dim=1, keepdim=True)
+    dir_ij = r_ij / d_ij
+    schnetpack_phi_ij = schnetpack_schnet.radial_basis(d_ij)
+    modelforge_phi_ij = modelforge_schnet.radial_basis_module(
+        d_ij / 10
+    )  # NOTE: converting to nm
+
+    assert torch.allclose(schnetpack_phi_ij, modelforge_phi_ij)
+    phi_ij = schnetpack_phi_ij
+    # ---------------------------------------- #
+    # test cutoff
+    # ---------------------------------------- #
+    fcut_spk = schnetpack_schnet.cutoff_fn(d_ij)
+    fcut_mf = modelforge_schnet.cutoff_module(d_ij / 10)  # NOTE: converting to nm
+    assert torch.allclose(fcut_spk, fcut_mf)
+
+    # ---------------------------------------- #
+    # test embedding
+    # ---------------------------------------- #
+    import schnetpack.properties as properties
+
+    assert torch.allclose(
+        spk_input[properties.Z], modelforge_input["atomic_numbers"].squeeze()
+    )
+    embedding_spk = schnetpack_schnet.embedding(spk_input[properties.Z])
+    embedding_mf = modelforge_schnet.embedding_module(
+        modelforge_input["atomic_numbers"]
+    )
+
+    assert torch.allclose(embedding_spk, embedding_mf)
+
+    # --------------------------------------- #
+    # test representation
+    # --------------------------------------- #
+    rep_mf = modelforge_schnet.schnet_representation_module(d_ij / 10)
+
+    r_ij = spk_input["_Rij"]
+    d_ij = torch.norm(r_ij, dim=1)
+    f_ij_spk = schnetpack_schnet.radial_basis(d_ij)
+    rcut_ij_spk = schnetpack_schnet.cutoff_fn(d_ij)
+
+    assert torch.allclose(rep_mf["f_ij"], f_ij_spk)
+    assert torch.allclose(rep_mf["rcut_ij"], rcut_ij_spk)
+
+    # ---------------------------------------- #
+    # test interactions
+    # ---------------------------------------- #
+
+    # reset all parameters
+    torch.manual_seed(1234)
+    for i in range(nr_of_interactions):
+        schnetpack_schnet.interactions[i].in2f.reset_parameters()
+        for j in range(2):
+            schnetpack_schnet.interactions[i].f2out[j].reset_parameters()
+            schnetpack_schnet.interactions[i].filter_network[j].reset_parameters()
+
+    torch.manual_seed(1234)
+    for i in range(nr_of_interactions):
+        modelforge_schnet.interaction_modules[i].intput_to_feature.reset_parameters()
+        for j in range(2):
+            modelforge_schnet.interaction_modules[i].feature_to_output[
+                j
+            ].reset_parameters()
+            modelforge_schnet.interaction_modules[i].filter_network[
+                j
+            ].reset_parameters()
+
+    assert torch.allclose(
+        schnetpack_schnet.interactions[0].filter_network[0].weight,
+        modelforge_schnet.interaction_modules[0].filter_network[0].weight,
+    )
+    assert torch.allclose(
+        schnetpack_schnet.interactions[0].filter_network[0].bias,
+        modelforge_schnet.interaction_modules[0].filter_network[0].bias,
+    )
+
+    assert torch.allclose(
+        schnetpack_schnet.interactions[0].filter_network[1].weight,
+        modelforge_schnet.interaction_modules[0].filter_network[1].weight,
+    )
+    assert torch.allclose(
+        schnetpack_schnet.interactions[0].filter_network[1].bias,
+        modelforge_schnet.interaction_modules[0].filter_network[1].bias,
+    )
+
+    assert torch.allclose(embedding_spk, embedding_mf)
+
+    for mf_interaction, spk_interaction in zip(
+        modelforge_schnet.interaction_modules, schnetpack_schnet.interactions
+    ):
+        v_spk = spk_interaction(
+            embedding_spk,
+            f_ij_spk,
+            spk_input["_idx_i"],
+            spk_input["_idx_j"],
+            rcut_ij_spk,
+        )
+        v_mf = mf_interaction(
+            embedding_mf,
+            modelforge_input_2["pair_indices"],
+            rep_mf["f_ij"],
+            rep_mf["rcut_ij"],
+        )
+
+        assert torch.allclose(v_spk, v_mf)
+
+    # Check full pass
+
+    modelforge_results = modelforge_schnet._forward(modelforge_input_2)
+    schnetpack_results = schnetpack_schnet(spk_input)
+
+    assert (
+        schnetpack_results["scalar_representation"].shape
+        == modelforge_results["scalar_representation"].shape
+    )
+
+    scalar_spk = schnetpack_results["scalar_representation"]
+    scalar_mf = modelforge_results["scalar_representation"]
+    assert torch.allclose(scalar_spk, scalar_mf, atol=1e-4)

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -3,7 +3,7 @@ import torch
 
 def test_gaussian_rbf_implementation():
     # compare schnetpack GaussianRBF with modelforge GaussianRBF
-    from modelforge.potential.utils import _GaussianRBF
+    from modelforge.potential.utils import GaussianRBF
     from schnetpack.nn import GaussianRBF as schnetpack_GaussianRBF
     from openmm import unit
 
@@ -12,7 +12,7 @@ def test_gaussian_rbf_implementation():
     schnetpack_rbf = schnetpack_GaussianRBF(
         n_rbf=n_rbf, cutoff=cutoff.value_in_unit(unit.angstrom)
     )
-    rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
 
     r = torch.rand(5, 3)
     print(schnetpack_rbf(r))
@@ -161,14 +161,14 @@ def setup_modelforge_painn_representation(cutoff, nr_atom_basis, n_rbf):
     # set up the modelforge Painn representation model
     # which means that we only want to call the
     # _transform_input() method
-    from modelforge.potential import _CosineCutoff, _GaussianRBF
+    from modelforge.potential import CosineCutoff, GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
     from modelforge.potential.painn import PaiNN
     from openmm import unit
 
     embedding = SlicedEmbedding(max_Z=100, embedding_dim=nr_atom_basis, sliced_dim=0)
-    radial_basis = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
-    cutoff = _CosineCutoff(cutoff)
+    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    cutoff = CosineCutoff(cutoff)
 
     return PaiNN(
         embedding_module=embedding,

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -3,13 +3,13 @@ import torch
 
 def test_gaussian_rbf_implementation():
     # compare schnetpack GaussianRBF with modelforge GaussianRBF
-    from modelforge.potential.utils import GaussianRBF
+    from modelforge.potential.utils import _GaussianRBF
     from schnetpack.nn import GaussianRBF as schnetpack_GaussianRBF
 
     n_rbf = 2
     cutoff = 5.0
     schnetpack_rbf = schnetpack_GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
-    rbf = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
 
     r = torch.rand(5, 3)
     schnetpack_rbf(r)
@@ -155,12 +155,12 @@ def setup_modelforge_painn_representation(cutoff, nr_atom_basis, n_rbf):
     # set up the modelforge Painn representation model
     # which means that we only want to call the
     # _transform_input() method
-    from modelforge.potential import CosineCutoff, GaussianRBF
+    from modelforge.potential import CosineCutoff, _GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
     from modelforge.potential.painn import PaiNN
 
     embedding = SlicedEmbedding(max_Z=100, embedding_dim=nr_atom_basis, sliced_dim=0)
-    radial_basis = GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    radial_basis = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
     cutoff = CosineCutoff(cutoff)
 
     return PaiNN(

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -5,16 +5,19 @@ def test_gaussian_rbf_implementation():
     # compare schnetpack GaussianRBF with modelforge GaussianRBF
     from modelforge.potential.utils import _GaussianRBF
     from schnetpack.nn import GaussianRBF as schnetpack_GaussianRBF
+    from openmm import unit
 
     n_rbf = 2
-    cutoff = 5.0
-    schnetpack_rbf = schnetpack_GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
+    cutoff = unit.Quantity(5.0, unit.angstrom)
+    schnetpack_rbf = schnetpack_GaussianRBF(
+        n_rbf=n_rbf, cutoff=cutoff.value_in_unit(unit.angstrom)
+    )
     rbf = _GaussianRBF(n_rbf=n_rbf, cutoff=cutoff)
 
     r = torch.rand(5, 3)
-    schnetpack_rbf(r)
-    rbf(r)
-    assert torch.allclose(schnetpack_rbf(r), rbf(r))
+    print(schnetpack_rbf(r))
+    print(rbf(r / 10))
+    assert torch.allclose(schnetpack_rbf(r), rbf(r / 10), atol=1e-8)
     assert schnetpack_rbf.n_rbf == rbf.n_rbf
 
 

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -70,13 +70,6 @@ def test_pt_lightning():
 
     cutoff = CosineCutoff(cutoff=cutoff)
 
-    model = LighningPaiNN(
-        embedding=embedding,
-        nr_interaction_blocks=nr_interaction_blocks,
-        radial_basis=rbf,
-        cutoff=cutoff,
-    )
-
     from modelforge.dataset.qm9 import QM9Dataset
     from modelforge.dataset.dataset import TorchDataModule
 
@@ -94,6 +87,15 @@ def test_pt_lightning():
         ],
     )
 
+    model = LighningPaiNN(
+        embedding=embedding,
+        nr_interaction_blocks=nr_interaction_blocks,
+        radial_basis=rbf,
+        cutoff=cutoff,
+    )
+
+    model.energy_average = dataset.dataset_mean
+    model.energy_std = dataset.dataset_std
     # Move model to the appropriate dtype and device
     model = model.to(torch.float32)
     # Run training loop and validate

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -45,3 +45,56 @@ def test_train_with_lightning(dataset: Type[BaseNNP], model_class: Type[BaseNNP]
     model = model.to(torch.float32)
     # Run training loop and validate
     trainer.fit(model, dataset.train_dataloader(), dataset.val_dataloader())
+
+
+def test_pt_lightning():
+    # This is an example script that trains the PaiNN model on the .
+    from lightning import Trainer
+    import torch
+    from modelforge.potential.painn import LighningPaiNN
+
+    from modelforge.potential import _CosineCutoff, _GaussianRBF
+    from modelforge.potential.utils import SlicedEmbedding
+
+    from openmm import unit
+
+    max_atomic_number = 100
+    nr_atom_basis = 128
+    nr_rbf = 20
+    nr_interaction_blocks = 4
+
+    cutoff = unit.Quantity(5, unit.angstrom)
+    embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
+    assert embedding.embedding_dim == nr_atom_basis
+    rbf = _GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)
+
+    cutoff = _CosineCutoff(cutoff=cutoff)
+
+    model = LighningPaiNN(
+        embedding=embedding,
+        nr_interaction_blocks=nr_interaction_blocks,
+        radial_basis=rbf,
+        cutoff=cutoff,
+    )
+
+    from modelforge.dataset.qm9 import QM9Dataset
+    from modelforge.dataset.dataset import TorchDataModule
+
+    data = QM9Dataset(for_unit_testing=True)
+    dataset = TorchDataModule(data, batch_size=64)
+    dataset.prepare_data()
+    dataset.setup(stage="fit")
+    from lightning.pytorch.callbacks.early_stopping import EarlyStopping
+
+    trainer = Trainer(
+        max_epochs=500,
+        num_nodes=1,
+        callbacks=[
+            EarlyStopping(monitor="val_loss", mode="min", patience=3, min_delta=0.001)
+        ],
+    )
+
+    # Move model to the appropriate dtype and device
+    model = model.to(torch.float32)
+    # Run training loop and validate
+    trainer.fit(model, dataset.train_dataloader(), dataset.val_dataloader())

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -35,7 +35,7 @@ def test_train_with_lightning(dataset: Type[BaseNNP], model_class: Type[BaseNNP]
         pytest.fail("Failed to set up the model.")
 
     # Initialize dataset and data loader
-    dataset = initialize_dataset(dataset, mode="fit")
+    dataset = initialize_dataset(dataset)
     if dataset is None:
         pytest.fail("Failed to initialize the dataset.")
     # Initialize PyTorch Lightning Trainer
@@ -83,7 +83,7 @@ def test_pt_lightning():
     data = QM9Dataset(for_unit_testing=True)
     dataset = TorchDataModule(data, batch_size=64)
     dataset.prepare_data()
-    dataset.setup(stage="fit")
+    dataset.setup()
     from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 
     trainer = Trainer(

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -82,7 +82,7 @@ def test_pt_lightning():
 
     data = QM9Dataset(for_unit_testing=True)
     dataset = TorchDataModule(data, batch_size=64)
-    dataset.prepare_data()
+    dataset.prepare_data(offset=True)
     dataset.setup()
     from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -75,8 +75,7 @@ def test_pt_lightning():
 
     data = QM9Dataset(for_unit_testing=True)
     dataset = TorchDataModule(data, batch_size=64)
-    dataset.prepare_data(offset=True)
-    dataset.setup()
+    dataset.prepare_data(remove_self_energies=True)
     from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 
     trainer = Trainer(
@@ -94,8 +93,6 @@ def test_pt_lightning():
         cutoff=cutoff,
     )
 
-    model.energy_average = dataset.dataset_mean
-    model.energy_std = dataset.dataset_std
     # Move model to the appropriate dtype and device
     model = model.to(torch.float32)
     # Run training loop and validate

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -56,14 +56,14 @@ def test_pt_lightning():
     from modelforge.potential import CosineCutoff, GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
 
-    from openmm import unit
+    from openff.units import unit
 
     max_atomic_number = 100
     nr_atom_basis = 128
     nr_rbf = 20
     nr_interaction_blocks = 4
 
-    cutoff = unit.Quantity(5, unit.angstrom)
+    cutoff = 5 * unit.angstrom
     embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
     assert embedding.embedding_dim == nr_atom_basis
     rbf = GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -53,7 +53,7 @@ def test_pt_lightning():
     import torch
     from modelforge.potential.painn import LighningPaiNN
 
-    from modelforge.potential import _CosineCutoff, _GaussianRBF
+    from modelforge.potential import CosineCutoff, GaussianRBF
     from modelforge.potential.utils import SlicedEmbedding
 
     from openmm import unit
@@ -66,9 +66,9 @@ def test_pt_lightning():
     cutoff = unit.Quantity(5, unit.angstrom)
     embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
     assert embedding.embedding_dim == nr_atom_basis
-    rbf = _GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)
+    rbf = GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)
 
-    cutoff = _CosineCutoff(cutoff=cutoff)
+    cutoff = CosineCutoff(cutoff=cutoff)
 
     model = LighningPaiNN(
         embedding=embedding,

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 import pytest
 
-from modelforge.potential.utils import CosineCutoff, cosine_cutoff, GaussianRBF
+from modelforge.potential.utils import CosineCutoff, _cosine_cutoff, _GaussianRBF
 
 
 def test_cosine_cutoff():
@@ -19,7 +19,7 @@ def test_cosine_cutoff():
     expected_output = 0.5 * (np.cos(np.pi * d_ij / cutoff) + 1) if d_ij <= cutoff else 0
 
     # Calculate actual output
-    actual_output = cosine_cutoff(d_ij, cutoff)
+    actual_output = _cosine_cutoff(d_ij, cutoff)
 
     # Check if the results are equal
     assert np.isclose(actual_output, expected_output)
@@ -27,7 +27,7 @@ def test_cosine_cutoff():
     d_ij = torch.tensor([1.0, 2.0, 3.0])
     cutoff = 2.0
     expected_output = torch.tensor([0.5, 0.0, 0.0])
-    output = cosine_cutoff(d_ij, cutoff)
+    output = _cosine_cutoff(d_ij, cutoff)
     assert torch.allclose(output, expected_output, rtol=1e-3)
 
 
@@ -41,7 +41,7 @@ def test_cosine_cutoff_module():
     assert torch.allclose(output, expected_output, rtol=1e-3)
 
 
-@pytest.mark.parametrize("RBF", [GaussianRBF])
+@pytest.mark.parametrize("RBF", [_GaussianRBF])
 def test_rbf(RBF):
     """
     Test the Gaussian Radial Basis Function (RBF) implementation.
@@ -59,7 +59,7 @@ def test_rbf(RBF):
     assert output.shape[2] == 20  # n_rbf dimension
 
 
-@pytest.mark.parametrize("RBF", [GaussianRBF])
+@pytest.mark.parametrize("RBF", [_GaussianRBF])
 def test_gaussian_rbf(RBF):
     # Check dimensions of output and output
     n_rbf = 5
@@ -89,7 +89,7 @@ def test_gaussian_rbf(RBF):
     assert expected_output.shape == (3, n_rbf)
 
 
-@pytest.mark.parametrize("RBF", [GaussianRBF])
+@pytest.mark.parametrize("RBF", [_GaussianRBF])
 def test_rbf_invariance(RBF):
     # Define a set of coordinates
     coordinates = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
@@ -141,11 +141,11 @@ def test_GaussianRBF():
     Test the GaussianRBF layer.
     """
 
-    from modelforge.potential import GaussianRBF
+    from modelforge.potential import _GaussianRBF
 
     n_rbf = 10
     dim_of_x = 3
-    layer = GaussianRBF(10, 5.0)
+    layer = _GaussianRBF(10, 5.0)
     x = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
     y = layer(x)  # Shape: [dim_of_x, n_rbf]
 

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 import pytest
 
-from modelforge.potential.utils import _CosineCutoff, _cosine_cutoff, _GaussianRBF
+from modelforge.potential.utils import CosineCutoff, _cosine_cutoff, GaussianRBF
 
 
 def test_cosine_cutoff():
@@ -37,14 +37,14 @@ def test_cosine_cutoff_module():
 
     cutoff = unit.Quantity(2.0, unit.angstrom)
     expected_output = torch.tensor([0.5, 0.0, 0.0])
-    cosine_cutoff_module = _CosineCutoff(cutoff)
+    cosine_cutoff_module = CosineCutoff(cutoff)
 
     output = cosine_cutoff_module(d_ij_angstrom / 10)  # input is in nanometer
 
     assert torch.allclose(output, expected_output, rtol=1e-3)
 
 
-@pytest.mark.parametrize("RBF", [_GaussianRBF])
+@pytest.mark.parametrize("RBF", [GaussianRBF])
 def test_rbf(RBF):
     """
     Test the Gaussian Radial Basis Function (RBF) implementation.
@@ -63,7 +63,7 @@ def test_rbf(RBF):
     assert output.shape[2] == 20  # n_rbf dimension
 
 
-@pytest.mark.parametrize("RBF", [_GaussianRBF])
+@pytest.mark.parametrize("RBF", [GaussianRBF])
 def test_gaussian_rbf(RBF):
     # Check dimensions of output and output
     from openmm import unit
@@ -97,7 +97,7 @@ def test_gaussian_rbf(RBF):
     assert expected_output.shape == (3, n_rbf)
 
 
-@pytest.mark.parametrize("RBF", [_GaussianRBF])
+@pytest.mark.parametrize("RBF", [GaussianRBF])
 def test_rbf_invariance(RBF):
     # Define a set of coordinates
     from openmm import unit
@@ -151,13 +151,13 @@ def test_GaussianRBF():
     Test the GaussianRBF layer.
     """
 
-    from modelforge.potential import _GaussianRBF
+    from modelforge.potential import GaussianRBF
     from openmm import unit
 
     n_rbf = 10
     dim_of_x = 3
     cutoff = unit.Quantity(5.0, unit.angstrom)
-    layer = _GaussianRBF(10, cutoff)
+    layer = GaussianRBF(10, cutoff)
     x = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
     y = layer(x)  # Shape: [dim_of_x, n_rbf]
 

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -44,7 +44,7 @@ def test_cosine_cutoff_module():
     assert torch.allclose(output, expected_output, rtol=1e-3)
 
 
-@pytest.mark.parametrize("RBF", [_GaussianRBF])
+@pytest.mark.parametrize("RBF", [GaussianRBF])
 def test_rbf(RBF):
     """
     Test the Gaussian Radial Basis Function (RBF) implementation.
@@ -53,7 +53,7 @@ def test_rbf(RBF):
 
     from .helper_functions import prepare_pairlist_for_single_batch, return_single_batch
 
-    batch = return_single_batch(QM9Dataset, mode="fit")
+    batch = return_single_batch(QM9Dataset)
     pairlist = prepare_pairlist_for_single_batch(batch)
     from openff.units import unit
 
@@ -63,7 +63,7 @@ def test_rbf(RBF):
     assert output.shape[2] == 20  # n_rbf dimension
 
 
-@pytest.mark.parametrize("RBF", [_GaussianRBF])
+@pytest.mark.parametrize("RBF", [GaussianRBF])
 def test_gaussian_rbf(RBF):
     # Check dimensions of output and output
     from openff.units import unit
@@ -82,9 +82,7 @@ def test_gaussian_rbf(RBF):
     assert gaussian_rbf.cutoff == cutoff.to(unit.nanometer).m
 
     # Test that the widths and offsets are correct
-    expected_offsets = torch.linspace(
-        start, cutoff.to(unit.nanometer).m, n_rbf
-    )
+    expected_offsets = torch.linspace(start, cutoff.to(unit.nanometer).m, n_rbf)
     expected_widths = torch.abs(
         expected_offsets[1] - expected_offsets[0]
     ) * torch.ones_like(expected_offsets)
@@ -97,7 +95,7 @@ def test_gaussian_rbf(RBF):
     assert expected_output.shape == (3, n_rbf)
 
 
-@pytest.mark.parametrize("RBF", [_GaussianRBF])
+@pytest.mark.parametrize("RBF", [GaussianRBF])
 def test_rbf_invariance(RBF):
     # Define a set of coordinates
     from openff.units import unit
@@ -146,12 +144,12 @@ def test_scatter_add():
     native_result.scatter_add_(dim, idx_i, x)
 
 
-def test_GaussianRBF():
+def testGaussianRBF():
     """
     Test the GaussianRBF layer.
     """
 
-    from modelforge.potential import _GaussianRBF
+    from modelforge.potential import GaussianRBF
     from openff.units import unit
 
     n_rbf = 10

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -51,7 +51,7 @@ def test_rbf(RBF):
     """
     from modelforge.dataset import QM9Dataset
 
-    from .helper_functions import preparePairlist_for_single_batch, return_single_batch
+    from .helper_functions import prepare_pairlist_for_single_batch, return_single_batch
 
     batch = return_single_batch(QM9Dataset)
     pairlist = prepare_pairlist_for_single_batch(batch)
@@ -82,7 +82,9 @@ def test_gaussian_rbf(RBF):
     assert gaussian_rbf.cutoff == cutoff.to(unit.nanometer).m
 
     # Test that the widths and offsets are correct
-    expected_offsets = torch.linspace(start.to(unit.nanometer).m, cutoff.to(unit.nanometer).m, n_rbf)
+    expected_offsets = torch.linspace(
+        start.to(unit.nanometer).m, cutoff.to(unit.nanometer).m, n_rbf
+    )
     expected_widths = torch.abs(
         expected_offsets[1] - expected_offsets[0]
     ) * torch.ones_like(expected_offsets)
@@ -189,3 +191,27 @@ def test_sliced_embedding():
 
     assert sliced_output.shape == (5, embedding_dim)
     assert normal_output.shape == (5, 1, embedding_dim)
+
+
+def test_welford():
+    """
+    Test the Welford's algorithm implementation.
+    """
+    from modelforge.utils.misc import Welford
+    import torch
+    import numpy as np
+
+    torch.manual_seed(0)
+    target_mean = 1000
+    target_stddev = 50
+    target_variance = target_stddev**2
+
+    online_estimator = Welford()
+
+    for i in range(0, 5):
+        batch = torch.normal(target_mean, target_stddev, size=(1000,))
+        online_estimator.update(batch)
+
+        assert np.isclose(online_estimator.mean / target_mean, 1.0, rtol=1e-1)
+        assert np.isclose(online_estimator.variance / target_variance, 1.0, rtol=1e-1)
+        assert np.isclose(online_estimator.stddev / target_stddev, 1.0, rtol=1e-1)

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -5,6 +5,21 @@ import pytest
 from modelforge.potential.utils import CosineCutoff, _cosine_cutoff, GaussianRBF
 
 
+def test_ase_dataclass():
+    from modelforge.potential.utils import AtomicSelfEnergies
+
+    # Example usage
+    atomic_self_energies = AtomicSelfEnergies(
+        energies={"H": 13.6, "He": 24.6, "Li": 5.4}
+    )
+
+    # Access by element name
+    print(atomic_self_energies["H"])  # Output: 13.6
+
+    # Access by atomic number
+    print(atomic_self_energies[1])  # Output: 13.6
+
+
 def test_cosine_cutoff():
     """
     Test the cosine cutoff implementation.

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -14,10 +14,15 @@ def test_ase_dataclass():
     )
 
     # Access by element name
-    print(atomic_self_energies["H"])  # Output: 13.6
+    assert np.isclose(atomic_self_energies["H"], 13.6)
 
     # Access by atomic number
-    print(atomic_self_energies[1])  # Output: 13.6
+    assert np.isclose(atomic_self_energies[1], 13.6)
+
+    # Iterate over the atomic self energies
+    for idx, (atom_index, ase) in enumerate(atomic_self_energies):
+        print(atom_index, ase)
+        assert atom_index == idx + 1
 
 
 def test_cosine_cutoff():

--- a/modelforge/utils/misc.py
+++ b/modelforge/utils/misc.py
@@ -1,4 +1,60 @@
 from loguru import logger
+import torch
+
+
+class Welford:
+    def __init__(self):
+        """
+        Implements Welford's online algorithm for computing running variance
+        and standard deviation incrementally.
+
+        This class maintains the count, mean, and M2 sufficient statistics,
+        which is used to calculate variance and standard deviation on the fly
+        as new samples are added via the update() method.
+
+        The running variance/stddev can be retrieved via the variance/stddev properties.
+        """
+        self._n = 0
+        self._mean = 0
+        self._M2 = 0
+
+    def update(self, batch: torch.Tensor) -> None:
+        """
+        Updates the running mean and variance statistics with a new batch of data.
+
+        The mean and sum of squared differences from the mean (M2) are updated with the new batch of data.
+        Parameters
+        ----------
+        batch: torch.Tensor, required
+            Batch of data to be added to the running statistics.
+        """
+        # Convert batch to a numpy array to handle both scalars and arrays
+        batch_size = len(batch)
+
+        new_mean = torch.mean(batch)
+        new_M2 = torch.sum((batch - new_mean) ** 2)
+
+        delta = new_mean - self._mean
+        self._mean += delta * batch_size / (self._n + batch_size)
+        self._M2 += new_M2 + delta**2 * self._n * batch_size / (self._n + batch_size)
+        self._n += batch_size
+
+    @property
+    def variance(self) -> torch.Tensor:
+        """
+        Returns the running variance calculated from the mean and M2 statistics.
+        """
+        return self._M2 / self._n if self._n > 1 else 0
+
+    @property
+    def stddev(self) -> torch.Tensor:
+
+        return torch.sqrt(self.variance)
+
+    @property
+    def mean(self) -> torch.Tensor:
+        """Returns the current mean."""
+        return self._mean
 
 
 def list_files(directory: str, extension: str) -> list:

--- a/modelforge/utils/units.py
+++ b/modelforge/utils/units.py
@@ -40,7 +40,7 @@ c.add_transformation(
 unit.add_context(c)
 
 
-def provide_details_about_used_unitsystem():
+def print_modelforge_unit_system():
     """
     Provide details about the used unit systems.
     """

--- a/modelforge/utils/units.py
+++ b/modelforge/utils/units.py
@@ -44,7 +44,8 @@ def provide_details_about_used_unitsystem():
     """
     Provide details about the used unit systems.
     """
-    print(
-        f"Available unit systems: {unit.unit_systems}, "
-        f"used unit system: {unit.get_unit_system()}"
-    )
+    from loguru import logger as log
+
+    log.info("Distance are in nanometer.")
+    log.info("Energies are in kJ/mol")
+    log.info("Forces are in kJ/mol/nm**2")

--- a/modelforge/utils/units.py
+++ b/modelforge/utils/units.py
@@ -1,4 +1,3 @@
-import pint
 from openff.units import unit, Quantity
 
 # define new context for converting energy (e.g., hartree)
@@ -39,3 +38,13 @@ c.add_transformation(
 
 
 unit.add_context(c)
+
+
+def provide_details_about_used_unitsystem():
+    """
+    Provide details about the used unit systems.
+    """
+    print(
+        f"Available unit systems: {unit.unit_systems}, "
+        f"used unit system: {unit.get_unit_system()}"
+    )

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -26,7 +26,6 @@ from modelforge.dataset.dataset import TorchDataModule
 data = QM9Dataset(for_unit_testing=True)
 dataset = TorchDataModule(data, batch_size=512)
 dataset.prepare_data(offset=True, normalize=True)
-dataset.setup()
 from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 
 trainer = Trainer(

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -34,8 +34,15 @@ data = QM9Dataset(for_unit_testing=False)
 dataset = TorchDataModule(data, batch_size=512)
 dataset.prepare_data()
 dataset.setup(stage="fit")
+from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 
-trainer = Trainer(max_epochs=10, num_nodes=1)
+trainer = Trainer(
+    max_epochs=10,
+    num_nodes=1,
+    callbacks=[
+        EarlyStopping(monitor="val_loss", mode="min", patience=3, min_delta=0.001)
+    ],
+)
 
 # Move model to the appropriate dtype and device
 model = model.to(torch.float32)

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -30,12 +30,12 @@ model = LighningPaiNN(
 from modelforge.dataset.qm9 import QM9Dataset
 from modelforge.dataset.dataset import TorchDataModule
 
-data = QM9Dataset()
+data = QM9Dataset(for_unit_testing=False)
 dataset = TorchDataModule(data)
 dataset.prepare_data()
 dataset.setup(stage="fit")
 
-trainer = Trainer(max_epochs=2, num_nodes=8)
+trainer = Trainer(max_epochs=2, num_nodes=1)
 
 # Move model to the appropriate dtype and device
 model = model.to(torch.float32)

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -20,13 +20,6 @@ rbf = GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)
 
 cutoff = CosineCutoff(cutoff=cutoff)
 
-model = LighningPaiNN(
-    embedding=embedding,
-    nr_interaction_blocks=nr_interaction_blocks,
-    radial_basis=rbf,
-    cutoff=cutoff,
-)
-
 from modelforge.dataset.qm9 import QM9Dataset
 from modelforge.dataset.dataset import TorchDataModule
 
@@ -43,6 +36,17 @@ trainer = Trainer(
         EarlyStopping(monitor="val_loss", mode="min", patience=3, min_delta=0.001)
     ],
 )
+
+
+model = LighningPaiNN(
+    embedding=embedding,
+    nr_interaction_blocks=nr_interaction_blocks,
+    radial_basis=rbf,
+    cutoff=cutoff,
+)
+
+model.energy_average = dataset.data.energy_average
+model.energy_std = dataset.data.energy_std
 
 # Move model to the appropriate dtype and device
 model = model.to(torch.float32)

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -3,7 +3,7 @@ from lightning import Trainer
 import torch
 from modelforge.potential.painn import LighningPaiNN
 
-from modelforge.potential import _CosineCutoff, _GaussianRBF
+from modelforge.potential import CosineCutoff, GaussianRBF
 from modelforge.potential.utils import SlicedEmbedding
 
 from openmm import unit
@@ -16,9 +16,9 @@ nr_interaction_blocks = 4
 cutoff = unit.Quantity(5, unit.angstrom)
 embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
 assert embedding.embedding_dim == nr_atom_basis
-rbf = _GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)
+rbf = GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)
 
-cutoff = _CosineCutoff(cutoff=cutoff)
+cutoff = CosineCutoff(cutoff=cutoff)
 
 model = LighningPaiNN(
     embedding=embedding,

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -30,14 +30,14 @@ model = LighningPaiNN(
 from modelforge.dataset.qm9 import QM9Dataset
 from modelforge.dataset.dataset import TorchDataModule
 
-data = QM9Dataset(for_unit_testing=False)
-dataset = TorchDataModule(data, batch_size=512)
+data = QM9Dataset(for_unit_testing=True)
+dataset = TorchDataModule(data, batch_size=64)
 dataset.prepare_data()
 dataset.setup(stage="fit")
 from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 
 trainer = Trainer(
-    max_epochs=10,
+    max_epochs=1000,
     num_nodes=1,
     callbacks=[
         EarlyStopping(monitor="val_loss", mode="min", patience=3, min_delta=0.001)

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -31,11 +31,11 @@ from modelforge.dataset.qm9 import QM9Dataset
 from modelforge.dataset.dataset import TorchDataModule
 
 data = QM9Dataset(for_unit_testing=False)
-dataset = TorchDataModule(data)
+dataset = TorchDataModule(data, batch_size=512)
 dataset.prepare_data()
 dataset.setup(stage="fit")
 
-trainer = Trainer(max_epochs=2, num_nodes=1)
+trainer = Trainer(max_epochs=10, num_nodes=1)
 
 # Move model to the appropriate dtype and device
 model = model.to(torch.float32)

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -1,0 +1,43 @@
+# This is an example script that trains the PaiNN model on the .
+from lightning import Trainer
+import torch
+from modelforge.potential.painn import LighningPaiNN
+
+from modelforge.potential import _CosineCutoff, _GaussianRBF
+from modelforge.potential.utils import SlicedEmbedding
+
+from openmm import unit
+
+max_atomic_number = 100
+nr_atom_basis = 128
+nr_rbf = 20
+nr_interaction_blocks = 4
+
+cutoff = unit.Quantity(5, unit.angstrom)
+embedding = SlicedEmbedding(max_atomic_number, nr_atom_basis, sliced_dim=0)
+assert embedding.embedding_dim == nr_atom_basis
+rbf = _GaussianRBF(n_rbf=nr_rbf, cutoff=cutoff)
+
+cutoff = _CosineCutoff(cutoff=cutoff)
+
+model = LighningPaiNN(
+    embedding=embedding,
+    nr_interaction_blocks=nr_interaction_blocks,
+    radial_basis=rbf,
+    cutoff=cutoff,
+)
+
+from modelforge.dataset.qm9 import QM9Dataset
+from modelforge.dataset.dataset import TorchDataModule
+
+data = QM9Dataset()
+dataset = TorchDataModule(data)
+dataset.prepare_data()
+dataset.setup(stage="fit")
+
+trainer = Trainer(max_epochs=2, num_nodes=8)
+
+# Move model to the appropriate dtype and device
+model = model.to(torch.float32)
+# Run training loop and validate
+trainer.fit(model, dataset.train_dataloader(), dataset.val_dataloader())

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -33,7 +33,7 @@ from modelforge.dataset.dataset import TorchDataModule
 data = QM9Dataset(for_unit_testing=True)
 dataset = TorchDataModule(data, batch_size=64)
 dataset.prepare_data()
-dataset.setup(stage="fit")
+dataset.setup()
 from lightning.pytorch.callbacks.early_stopping import EarlyStopping
 
 trainer = Trainer(


### PR DESCRIPTION
## Description

It is common in training neural network potentials to perform pre-processing steps on the energies used for training. 
Two common strategies are (described in more detail here https://doi.org/10.1063/5.0160326):
- offsetting the molecular energies by the atomize energies (self energies of the free atoms in vacuum) to avoid numerical instability with the typical considerable total energies
- scaling the range of energies to a unit interval

Both pre-processing strategies require information passed from the dataset to the model, since the transformations must be reversed to obtain total energies.

This PR adds functionality to the dataset class to offset the total energies using atomic self-energies, calculated or provided for a specific level of theory and dataset, as well as the mean and variance of the total or pre-processed energies.

```python
 from modelforge.dataset.qm9 import QM9Dataset
 from modelforge.dataset.utils import FirstComeFirstServeSplittingStrategy

 data = QM9Dataset(for_unit_testing=True)
 dataset = TorchDataModule(
    data, batch_size=8, split=FirstComeFirstServeSplittingStrategy()
    )

# self energy is calculated and removed in prepare_data if `remove_self_energies` is True
dataset.prepare_data(remove_self_energies=True, normalize=False)
# alternatively, if we know the self energies for a dataset it can be provided by passing a dictionary with the atomic number as key a the self-energies as corresponding values
self_energies : {1 : -10., 6 : -1000}
dataset.prepare_data(remove_self_energies=True, normalize=False, self_energies=self_energies)
 ```

### Self-energies

The self-energies are calculated using a linear regression fit if self-energies aren't provided. 
If total energies are required, the self-energies must be passed to the corresponding postprocessing module (`AddSelfEnergies`) to reverse the transformation.

```python
model = SchNET(
    embedding_module=embedding,
    nr_interaction_blocks=nr_interaction_blocks,
    radial_basis_module=rbf,
    cutoff_module=cutoff,
    nr_filters=nr_filters,
    postprocessing=PostprocessingPipeline(
        [AddSelfEnergies(dataset.dataset_statistics)]
    ),
)
```
 
### Normalization

Energies can be normalized by removing the average and dividing by the standard deviation.
This operation can be requested by calling
```python
# self energy is calculated and removed in prepare_data if `remove_self_energies` is True
dataset.prepare_data(remove_self_energies=True, normalize=True)
```

To obtain the total energy both the substraction of the self-energies and the normalization need to be reverted. This can be done by passing both Postprocessing classes to the `ProstprocessingPipeline`:
```python
model = SchNET(
    embedding_module=embedding,
    nr_interaction_blocks=nr_interaction_blocks,
    radial_basis_module=rbf,
    cutoff_module=cutoff,
    nr_filters=nr_filters,
    postprocessing=PostprocessingPipeline(
        [AddSelfEnergies(dataset.dataset_statistics), UndoNormalization(dataset.dataset_statistics)]
    ),
)
```
All of the Postprocessing classes can also be passed without  `dataset.dataset_statistics`, in that case they will check if the dataset_statistics are already provided by the model (a trained model will provide these), and if not, raise an error.

## Todos
  - [x] self-energies infrastructure
  - [x] postprocessing classes 
  - [x] Update LightningDataset and TorchDataset to remove atomic offset/normalize
 
## Status
- [x] Ready to go