### PR TITLE
Add abstract base class and methods to BaseNNP

### DIFF
--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -228,7 +228,11 @@ class LightningModuleMixin(pl.LightningModule):
         return self.optimizer(self.parameters(), lr=self.learning_rate)
 
 
-class BaseNNP(nn.Module):
+# import abstract base class and method
+from abc import ABC, abstractmethod
+
+
+class BaseNNP(ABC, nn.Module):
     """
     Base class for neural network potentials.
     """
@@ -251,17 +255,20 @@ class BaseNNP(nn.Module):
         self._log_message_dtype = False
         self._log_message_units = False
 
-    def preate_input(self, inputs: Dict[str, torch.Tensor]):
+    @abstractmethod
+    def prepare_inputs(self, inputs: Dict[str, torch.Tensor]):
         # needs to be implemented by the subclass
         # if subclass needs any additional input preparation (e.g. embedding),
         # it should be done here
         raise NotImplementedError
 
+    @abstractmethod
     def _forward(self, inputs: Dict[str, torch.Tensor]):
         # needs to be implemented by the subclass
         # perform the forward pass implemented in the subclass
         raise NotImplementedError
 
+    @abstractmethod
     def _readout(self, input: Dict[str, torch.Tensor]):
         # needs to be implemented by the subclass
         # perform the readout operation implemented in the subclass

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -260,19 +260,19 @@ class BaseNNP(ABC, nn.Module):
         # needs to be implemented by the subclass
         # if subclass needs any additional input preparation (e.g. embedding),
         # it should be done here
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def _forward(self, inputs: Dict[str, torch.Tensor]):
         # needs to be implemented by the subclass
         # perform the forward pass implemented in the subclass
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def _readout(self, input: Dict[str, torch.Tensor]):
         # needs to be implemented by the subclass
         # perform the readout operation implemented in the subclass
-        raise NotImplementedError
+        pass
 
     def _prepare_inputs(self, inputs: Dict[str, torch.Tensor]):
         atomic_numbers = inputs["atomic_numbers"]  # shape (nr_of_atoms_in_batch, 1)


### PR DESCRIPTION
## Description
The BaseNNP is now an ABC, and the methods that previously raised a `NotImplementedError` are now `abstract methods`, enforcing at initialization that these are provided in subclasses.

- [x] Ready to go