### PR TITLE
Refactor SchNet potential module and add unit test for radial basis functions

### DIFF
--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -81,8 +81,8 @@ class Pairlist(nn.Module):
         -------
         dict : Dict[str, torch.Tensor], containing atom index pairs, distances, and displacement vectors.
             - 'pair_indices': torch.Tensor, shape (2, n_pairs)
-            - 'r_ij' : torch.Tensor, shape (3, n_pairs)
-            - 'd_ij' : torch.Tensor, shape (1, n_pairs)
+            - 'r_ij' : torch.Tensor, shape (n_pairs, 3)
+            - 'd_ij' : torch.Tensor, shape (n_pairs, 1)
 
         """
         assert positions.ndim == 2
@@ -140,8 +140,8 @@ class Neighborlist(Pairlist):
         -------
         dict : Dict[str, torch.Tensor], containing atom index pairs, distances, and displacement vectors.
             - 'pair_indices': torch.Tensor, shape (2, n_pairs)
-            - 'r_ij' : torch.Tensor, shape (3, n_pairs)
-            - 'd_ij' : torch.Tensor, shape (1, n_pairs)
+            - 'r_ij' : torch.Tensor, shape (n_pairs, 3)
+            - 'd_ij' : torch.Tensor, shape (n_pairs, 1)
 
         """
         pair_indices = self.calculate_pairs(

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -46,11 +46,6 @@ class SchNET(BaseNNP):
 
         self.embedding_module = Embedding(max_Z, embedding_dimensions)
 
-        # cutoff
-        from modelforge.potential import CosineCutoff
-
-        self.cutoff_module = CosineCutoff(cutoff, self.device)
-
         # initialize the energy readout
         from .utils import FromAtomToMoleculeReduction
 
@@ -63,7 +58,7 @@ class SchNET(BaseNNP):
         # Intialize interaction blocks
         self.interaction_modules = nn.ModuleList(
             [
-                SchNETInteractionBlock(
+                SchNETInteractionModule(
                     self.nr_atom_basis,
                     self.nr_filters,
                     number_of_gaussians_basis_functions,
@@ -104,14 +99,15 @@ class SchNET(BaseNNP):
         """
 
         # Compute the representation for each atom (transform to radial basis set, multiply by cutoff)
-        f_ij = self.schnet_representation_module(inputs["d_ij"])
+        representation = self.schnet_representation_module(inputs["d_ij"])
         x = inputs["atomic_embedding"]
         # Iterate over interaction blocks to update features
         for interaction in self.interaction_modules:
             v = interaction(
                 x,
                 inputs["pair_indices"],
-                f_ij,
+                representation["f_ij"],
+                representation["f_cutoff"],
             )
             x = x + v  # Update atomic features
 
@@ -121,7 +117,7 @@ class SchNET(BaseNNP):
         }
 
 
-class SchNETInteractionBlock(nn.Module):
+class SchNETInteractionModule(nn.Module):
     def __init__(
         self, nr_atom_basis: int, nr_filters: int, number_of_gaussians: int
     ) -> None:
@@ -163,7 +159,8 @@ class SchNETInteractionBlock(nn.Module):
         self,
         x: torch.Tensor,
         pairlist: torch.Tensor,  # shape [n_pairs, 2]
-        f_ij: torch.Tensor,
+        f_ij: torch.Tensor,  # shape [n_pairs, 1, number_of_gaussians]
+        f_ij_cutoff: torch.Tensor,  # shape [n_pairs, 1]
     ) -> torch.Tensor:
         """
         Forward pass for the interaction block.
@@ -173,8 +170,9 @@ class SchNETInteractionBlock(nn.Module):
         x : torch.Tensor, shape [nr_of_atoms_in_systems, nr_atom_basis]
             Input feature tensor for atoms.
         pairlist : torch.Tensor, shape [n_pairs, 2]
-        f_ij : torch.Tensor, shape [n_pairs, number_of_gaussians]
+        f_ij : torch.Tensor, shape [n_pairs, 1, number_of_gaussians]
             Radial basis functions for pairs of atoms.
+        f_ij_cutoff : torch.Tensor, shape [n_pairs, 1]
 
         Returns
         -------
@@ -186,13 +184,13 @@ class SchNETInteractionBlock(nn.Module):
         x = self.intput_to_feature(x)
 
         # Generate interaction filters based on radial basis functions
-        Wij = self.filter_network(f_ij).squeeze(0)
+        Wij = self.filter_network(f_ij.squeeze(1))
 
         idx_i, idx_j = pairlist[0], pairlist[1]
         x_j = x[idx_j]
 
         # Perform continuous-filter convolution
-        x_ij = x_j * Wij
+        x_ij = x_j * Wij * f_ij_cutoff
 
         # Initialize a tensor to gather the results
         x_ = torch.zeros_like(x, dtype=x.dtype, device=x.device)
@@ -227,6 +225,10 @@ class SchNETRepresentation(nn.Module):
             radial_cutoff, number_of_gaussians
         )
         self.device = device
+        # cutoff
+        from modelforge.potential import CosineCutoff
+
+        self.cutoff_module = CosineCutoff(radial_cutoff, self.device)
 
     def _setup_radial_symmetry_functions(
         self, radial_cutoff: unit.Quantity, number_of_gaussians: int
@@ -251,30 +253,14 @@ class SchNETRepresentation(nn.Module):
 
         Returns
         -------
-        Radial basis functions for pairs of atoms; shape [n_pairs, number_of_gaussians]
+        Radial basis functions for pairs of atoms; shape [n_pairs, 1, number_of_gaussians]
         """
-        from modelforge.potential.utils import CosineCutoff
 
         # Convert distances to radial basis functions
         f_ij = self.radial_symmetry_function_module(
             d_ij
         )  # shape (n_pairs, 1, number_of_gaussians)
 
-        cutoff_module = CosineCutoff(
-            self.radial_symmetry_function_module.radial_cutoff, device=d_ij.device
-        )
+        f_cutoff = self.cutoff_module(d_ij)  # shape (n_pairs, 1)
 
-        # calculate offset
-        rcut_ij = cutoff_module(d_ij)  # shape(n_pairs, 1)
-
-        # return f_ij with cutoff
-        f_ij_ = f_ij * rcut_ij.unsqueeze(-1)
-
-        # check that broadcasting dimension is correct
-        assert f_ij_.shape == (
-            d_ij.shape[0],
-            1,
-            self.radial_symmetry_function_module.number_of_gaussians,
-        )
-
-        return f_ij_.squeeze(1)  # shape (n_pairs, number_of_gaussians)
+        return {"f_ij": f_ij, "f_cutoff": f_cutoff}

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -655,7 +655,7 @@ number_of_gaussians={self.number_of_gaussians}
         (NOTE: sum is not performed)
         Parameters
         ----------
-        d_ij : torch.Tensor, size (nr_of_atoms, distance)
+        d_ij : torch.Tensor, size (nr_of_atoms, 1)
             Pairwise distances.
 
         Returns
@@ -663,6 +663,9 @@ number_of_gaussians={self.number_of_gaussians}
         torch.Tensor
             The radial basis functions. Shape: [pairs, number_of_gaussians]
         """
+        assert d_ij.ndim == 2
+        assert d_ij.shape[1] == 1
+
         diff = d_ij[..., None] - self.R_s  # d_ij - R_s
         y = self.prefactor * torch.exp((-1 * self.EtaR) * torch.pow(diff, 2))
         return y

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -108,12 +108,7 @@ def test_compare_radial_symmetry_features():
     from openff.units import unit
 
     # generate a random list of distances, all < 5
-    d_ij = (
-        torch.rand(
-            5,
-        )
-        * 5
-    )
+    d_ij = torch.rand(5, 1) * 5
 
     # ANI constants
     radial_cutoff = 5.0  # radial_cutoff
@@ -129,7 +124,7 @@ def test_compare_radial_symmetry_features():
         radial_start * unit.angstrom,
         ani_style=True,
     )
-    r_mf = rsf(d_ij / 10)  # torch.Size([5, 8]) # NOTE: nanometer
+    r_mf = rsf(d_ij / 10)  # torch.Size([5,1, 8]) # NOTE: nanometer
     cutoff_module = CosineCutoff(radial_cutoff * unit.angstrom)
     from torchani.aev import radial_terms
 
@@ -137,7 +132,7 @@ def test_compare_radial_symmetry_features():
 
     r_mf = r_mf * rcut_ij[:, None]
     r_ani = radial_terms(5, EtaR, ShfR, d_ij)  # torch.Size([5,8]) # NOTE: Angstrom
-    assert torch.allclose(r_mf, r_ani)
+    assert torch.allclose(r_mf.squeeze(1), r_ani)
 
 
 def test_radial_with_diagonal_batching(setup_two_methanes):
@@ -155,7 +150,7 @@ def test_radial_with_diagonal_batching(setup_two_methanes):
         mf_input["atomic_subsystem_indices"],
         only_unique_pairs=True,
     )
-    d_ij = pairs["d_ij"].squeeze()
+    d_ij = pairs["d_ij"]
 
     # ANI constants
     radial_cutoff = 5.1  # radial_cutoff
@@ -194,17 +189,17 @@ def test_radial_with_diagonal_batching(setup_two_methanes):
     # ------------ ANI calculation ----------#
     from torchani.aev import radial_terms
 
-    assert torch.allclose(distances, d_ij * 10)  # NOTE: unit mismatch
+    assert torch.allclose(distances, d_ij.squeeze(1) * 10)  # NOTE: unit mismatch
     radial_symmetry_feature_vector_ani = radial_terms(
         radial_cutoff, EtaR, ShfR, distances
     )
     # test that both ANI and MF obtain the same radial symmetry outpu
     assert torch.allclose(
-        radial_symmetry_feature_vector_mf, radial_symmetry_feature_vector_ani
+        radial_symmetry_feature_vector_mf.squeeze(1), radial_symmetry_feature_vector_ani
     )
 
     assert radial_symmetry_feature_vector_mf.shape == torch.Size(
-        [20, radial_dist_divisions]
+        [20, 1, radial_dist_divisions]
     )
 
 

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -2,16 +2,31 @@ from modelforge.potential import RadialSymmetryFunction
 import torch
 
 
-def test_gaussian_rbf_1D():
+def test_radial_symmetry_function():
 
-    dist = torch.tensor([[[1.0]]]) / 10  # NOTE: converting to nanometer
-
+    from modelforge.potential import RadialSymmetryFunction, CosineCutoff
+    import torch
     from openff.units import unit
 
+    # set cutoff and radial symmetry function
+    cutoff = CosineCutoff(cutoff=unit.Quantity(5.0, unit.angstrom))
     rbf_expension = RadialSymmetryFunction(
-        number_of_gaussians=6, radial_cutoff=unit.Quantity(5.0, unit.angstrom)
+        number_of_gaussians=18, radial_cutoff=unit.Quantity(5.0, unit.angstrom)
     )
 
-    expt = torch.exp(-0.5 * torch.tensor([[[1.0, 0.0, 1.0, 4.0, 9.0, 16.0]]]))
-    assert torch.allclose(expt, rbf_expension(dist), atol=1e-4)
-    assert list(rbf_expension.parameters()) == []
+    # calculate expension and cutoff
+    d = torch.tensor([[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]])
+    vs = rbf_expension(d) * cutoff(d).T
+
+    # make sure that this matches the output of SchNETRepresentation
+    from modelforge.potential.schnet import SchNETRepresentation
+
+    rep = SchNETRepresentation(
+        radial_cutoff=5 * unit.angstrom,
+        number_of_gaussians=18,
+        device=torch.device("cpu"),
+    )
+    d = torch.tensor([[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]])
+    rep_ = rep(d)
+
+    assert torch.allclose(vs, rep_)

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -32,6 +32,11 @@ def test_radial_symmetry_function():
         device=torch.device("cpu"),
     )
 
-    rep_ = rep(d_ij)
+    representation = rep(d_ij)
+    f_ij_cutoff = (
+        representation["f_ij"] * representation["f_cutoff"].unsqueeze(-1)
+    ).squeeze(1)
+    print(f_ij_cutoff.shape)
+    print(vs.shape)
 
-    assert torch.allclose(vs, rep_)
+    assert torch.allclose(vs, f_ij_cutoff)

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -15,8 +15,13 @@ def test_radial_symmetry_function():
     )
 
     # calculate expension and cutoff
-    d = torch.tensor([[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]])
-    vs = rbf_expension(d) * cutoff(d).T
+    d_ij = torch.tensor(
+        [[0.0], [0.1], [0.2], [0.3], [0.4], [0.5]]
+    )  # distances have the dimensions [nr_of_pairs, 1] (because displacement vectors have the dimensions [nr_of_pairs, 3])
+
+    f_ij_cutoff = cutoff(d_ij)
+    f_ij = rbf_expension(d_ij)
+    vs = (f_ij * f_ij_cutoff.unsqueeze(-1)).squeeze(1)
 
     # make sure that this matches the output of SchNETRepresentation
     from modelforge.potential.schnet import SchNETRepresentation
@@ -26,7 +31,7 @@ def test_radial_symmetry_function():
         number_of_gaussians=18,
         device=torch.device("cpu"),
     )
-    d = torch.tensor([[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]])
-    rep_ = rep(d)
+
+    rep_ = rep(d_ij)
 
     assert torch.allclose(vs, rep_)

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -125,44 +125,9 @@ def test_gaussian_rbf(RadialSymmetryFunction):
     assert torch.allclose(radial_symmetry_function_module.R_s, expected_offsets)
 
     # Test that the forward pass returns the expected output
-    d_ij = torch.tensor([1.0, 2.0, 3.0])
+    d_ij = torch.tensor([[1.0], [2.0], [3.0]])
     expected_output = radial_symmetry_function_module(d_ij)
-    assert expected_output.shape == (3, number_of_gaussians)
-
-
-@pytest.mark.parametrize("RadialSymmetryFunction", [RadialSymmetryFunction])
-def test_rbf_invariance(RadialSymmetryFunction):
-    # Define a set of coordinates
-    from openff.units import unit
-
-    coordinates = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]) / 10
-
-    # Initialize RBF
-    radial_symmetry_function_module = RadialSymmetryFunction(
-        number_of_gaussians=10, radial_cutoff=unit.Quantity(5.0, unit.angstrom)
-    )
-
-    # Calculate pairwise distances for the original coordinates
-    original_d_ij = torch.cdist(coordinates, coordinates)
-
-    # Apply RBF
-    original_output = radial_symmetry_function_module(original_d_ij)
-
-    # Apply a rotation and reflection to the coordinates
-    rotation_matrix = torch.tensor(
-        [[0, -1, 0], [1, 0, 0], [0, 0, 1]], dtype=torch.float32
-    )  # 90-degree rotation
-    reflected_coordinates = torch.mm(coordinates, rotation_matrix)
-    reflected_coordinates[:, 0] *= -1  # Reflect across the x-axis
-
-    # Recalculate pairwise distances
-    transformed_d_ij = torch.cdist(reflected_coordinates, reflected_coordinates)
-
-    # Apply Gaussian RBF to transformed coordinates
-    transformed_output = radial_symmetry_function_module(transformed_d_ij)
-
-    # Assert that the outputs are the same
-    assert torch.allclose(original_output, transformed_output, atol=1e-6)
+    assert expected_output.shape == (3, 1, number_of_gaussians)
 
 
 def test_scatter_add():
@@ -228,7 +193,6 @@ def test_energy_readout():
             2,
         ]
     )
-
 
 
 def test_welford():


### PR DESCRIPTION
## Description

Small refactoring changes to the structure of SchNet and the way the Cosine Cutoff is applied to the radial basis functions. This also impacts the feature aggregation. While making these changes, I noticed that we haven't had a useful unit test for the radial basis function class; I added this here now.

For reference (I will also add this to the documentation):
displacement vectors (`r_ij`) have shape (nr_of_atoms, 3)
distances (`d_ij`) have shape (nr_of_atoms, 1)
radial basis function (`f_ij`) have shape (nr_of_atoms, 1, number_of_gaussian)
cutoff has shape (nr_of_atoms, 1) 

## Todos
  - [ ] Refactor SchnET
  - [ ] Add unit test for radial symmetry function

## Status
- [ ] Ready to go