### PR TITLE
update equivariance test

### DIFF
--- a/modelforge/tests/helper_functions.py
+++ b/modelforge/tests/helper_functions.py
@@ -149,6 +149,7 @@ def equivariance_test_utils():
     """
 
     # Define translation function
+    torch.manual_seed(12345)
     x_translation = torch.randn(
         size=(1, 3),
     )


### PR DESCRIPTION
Updated the equivariance_test_utils in helper_functions to set a seed before calling a random translation to ensure the same test regardless of the sequence of calls prior.  This addresses issue #82 . 

This test was failing to meet the tolerance (for values close to zero) depending on the order called because  the translation tensor was generated via torch.randn.  I just added in a manual setting of a seed to ensure we are doing the same translation each time to avoid this test potentially failing as we add new tests/models to test.  


## Status
- [ ] Ready to go