### PR TITLE
Infrastructure to retrieve pretrained models from github lfs

### DIFF
--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -927,6 +927,8 @@ class ModelRetriever:
         storage_dir : str
             The local directory to store downloaded models, by default "./models".
         """
+        import os
+
         self.base_url = base_url
         if not os.path.exists(storage_dir):
             os.makedirs(storage_dir)

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -333,7 +333,7 @@ def test_equivariant_energies_and_forces(batch, inference_model, equivariance_ut
     # define the symmetry operations
     translation, rotation, reflection = equivariance_utils
     # define the tolerance
-    atol = 1e-4
+    atol = 1e-3
     # initialize the models
     model = inference_model.to(torch.float64)
 


### PR DESCRIPTION
## Description
This PR will enable the loading of pretrained parameters from a remote storage location.

## Todos
  - [ ] Implement ModelRetriever class that retrieves, caches and serves the model parameters
  - [ ] implement a useful set of identifiers for trained models (we can extend this at a later point)

## Status
- [ ] Ready to go