### PR TITLE
State Dictionary saving/loading

### DIFF
--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -8,7 +8,6 @@ from .utils import (
     AngularSymmetryFunction,
     FromAtomToMoleculeReduction,
 )
-from .models import TrainingAdapter
 from .models import NeuralNetworkPotentialFactory
 
 _IMPLEMENTED_NNPS = {

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1,17 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, NamedTuple, Tuple, Type, Mapping
 
-import lightning as pl
 import torch
 from loguru import logger as log
 from openff.units import unit
 from torch.nn import Module
-from torch.nn import functional as F
-from torch.optim import AdamW
-from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from modelforge.dataset.dataset import DatasetStatistics
-from modelforge.potential.utils import AtomicSelfEnergies, BatchData, NNPInput
+from modelforge.potential.utils import AtomicSelfEnergies, NNPInput
 
 if TYPE_CHECKING:
     from modelforge.dataset.dataset import DatasetStatistics
@@ -404,14 +400,11 @@ class NeuralNetworkPotentialFactory:
     @staticmethod
     def create_nnp(
         use: Literal["training", "inference"],
-        nnp_type: Literal["ANI2x", "SchNet", "PaiNN", "SAKE", "PhysNet"],
+        nnp_name: Literal["ANI2x", "SchNet", "PaiNN", "SAKE", "PhysNet"],
         simulation_environment: Literal["PyTorch", "JAX"] = "PyTorch",
-        nnp_parameters: Optional[Dict[str, Union[int, float]]] = None,
+        nnp_parameters: Optional[Dict[str, Union[int, float, str]]] = None,
         training_parameters: Optional[Dict[str, Any]] = None,
-        compile_model: bool = False,
-    ) -> Union[
-        Union["ANI2x", "SchNet", "PaiNN", "PhysNet"], "TrainingAdapter", "JAXModel"
-    ]:
+    ) -> Union[Type[torch.nn.Module], Type[JAXModel]]:
         """
         Creates an NNP instance of the specified type, configured either for training or inference.
 
@@ -419,7 +412,7 @@ class NeuralNetworkPotentialFactory:
         ----------
         use : str
             The use case for the NNP instance.
-        nnp_type : str
+        nnp_name : str
             The type of NNP to instantiate.
         simulation_environment : str
             The environment to use, either 'PyTorch' or 'JAX'.
@@ -427,8 +420,6 @@ class NeuralNetworkPotentialFactory:
             Parameters specific to the NNP model, by default {}.
         training_parameters : dict, optional
             Parameters for configuring the training, by default {}.
-        compile_model : bool, optional
-            Whether to compile the model, by default False
 
         Returns
         -------
@@ -444,30 +435,26 @@ class NeuralNetworkPotentialFactory:
         """
 
         from modelforge.potential import _IMPLEMENTED_NNPS
+        from modelforge.train.training import TrainingAdapter
 
         nnp_parameters = nnp_parameters or {}
         training_parameters = training_parameters or {}
 
         # get NNP
-        nnp_class: Type = _IMPLEMENTED_NNPS.get(nnp_type)
+        nnp_class: Type = _IMPLEMENTED_NNPS.get(nnp_name)
         if nnp_class is None:
-            raise NotImplementedError(f"NNP type {nnp_type} is not implemented.")
-
-        nnp_instance = nnp_class(**nnp_parameters)
+            raise NotImplementedError(f"NNP type {nnp_name} is not implemented.")
 
         # add modifications to NNP if requested
-
-        if compile_model:
-            nnp_instance = torch.compile(nnp_instance, mode="max-autotune")
-
         if use == "training":
             if simulation_environment == "JAX":
                 log.warning(
                     "Training in JAX is not availalbe. Falling back to PyTorch."
                 )
-            trainer = TrainingAdapter(model=nnp_instance, **training_parameters)
-            return trainer
+            nnp_parameters["nnp_name"] = nnp_name
+            return TrainingAdapter(nnp_parameters=nnp_parameters, **training_parameters)
         elif use == "inference":
+            nnp_instance = nnp_class(**nnp_parameters)
             if simulation_environment == "JAX":
                 return PyTorch2JAXConverter().convert_to_jax_model(nnp_instance)
             else:
@@ -876,484 +863,6 @@ class BaseNeuralNetworkPotential(Module, ABC):
             rescaled_E=processed_energy["rescaled_E"],
             molecular_ase=processed_energy["molecular_ase"],
         )
-
-
-class Loss:
-    """
-    Base class for loss computations, designed to be overridden by subclasses for specific types of losses.
-    Initializes with a model to compute predictions for energies and forces.
-    """
-
-    def __init__(self, model: Union["ANI2x", "SchNet", "PaiNN", "PhysNet"]) -> None:
-        self.model = model
-
-    def _get_forces(self, batch: BatchData) -> Dict[str, torch.Tensor]:
-        """
-        Extracts and computes the forces from a given batch during training or evaluation, if forces are available.
-        Handles cases gracefully where F might not be present in the batch.
-
-        Parameters
-        ----------
-        batch : BatchData
-            A single batch of data, including input features and target energies.
-
-        Returns
-        -------
-        Dict[str, torch.Tensor]
-            The true forces from the dataset and the predicted forces by the model.
-        """
-        nnp_input = batch.nnp_input
-        F_true = batch.metadata.F.to(torch.float32)
-        E_predict = self.model.forward(nnp_input).E
-        F_predict = -torch.autograd.grad(
-            E_predict.sum(), nnp_input.positions, create_graph=False, retain_graph=False
-        )[0]
-
-        return {"F_true": F_true, "F_predict": F_predict}
-
-    def _get_energies(self, batch: BatchData) -> Dict[str, torch.Tensor]:
-        """
-        Extracts and computes the energies from a given batch during training or evaluation.
-
-        Parameters
-        ----------
-        batch : BatchData
-            A single batch of data, including input features and target energies.
-
-        Returns
-        -------
-        Dict[str, torch.Tensor]
-            The true energies from the dataset and the predicted energies by the model.
-        """
-        nnp_input = batch.nnp_input
-        E_true = batch.metadata.E.to(torch.float32).squeeze(1)
-        E_predict = self.model.forward(nnp_input).E
-        return {"E_true": E_true, "E_predict": E_predict}
-
-
-class EnergyLoss(Loss):
-    """
-    Computes loss based on energy predictions.
-    """
-
-    def __init__(self, model: Union["ANI2x", "SchNet", "PaiNN", "PhysNet"]):
-        super().__init__(model)
-        log.info("Initializing EnergyLoss")
-
-    def compute_mse_loss(self, batch: BatchData) -> torch.Tensor:
-        """
-        Computes the MSE loss from energies.
-        """
-        energies = self._get_energies(batch)
-        # Compute MSE of energies
-        L_E = F.mse_loss(energies["E_predict"], energies["E_true"])
-
-        return L_E
-
-    def compute_rmse_loss(self, batch: BatchData) -> torch.Tensor:
-        """
-        Computes the RMSE loss from energies.
-        """
-        energies = self._get_energies(batch)
-        # Compute RMSE of energies
-        L_E = torch.sqrt(F.mse_loss(energies["E_predict"], energies["E_true"]))
-
-        return L_E
-
-
-class EnergyAndForceLoss(EnergyLoss):
-    """
-    Computes combined loss from energies and forces, with adjustable weighting.
-    """
-
-    def __init__(
-        self,
-        model: Union["ANI2x", "SchNet", "PaiNN", "PhysNet"],
-        force_weight: float = 1.0,
-        energy_weight: float = 1.0,
-    ) -> None:
-        super().__init__(model)
-        log.info("Initializing EnergyAndForceLoss")
-        self.force_weight = force_weight
-        self.energy_weight = energy_weight
-
-    def compute_mse_loss(self, batch: BatchData) -> torch.Tensor:
-        """
-        Computes the combined MSE loss from energies and forces, considering the available data.
-        """
-        energies = self._get_energies(batch)
-        forces = self._get_forces(batch)
-        # Compute MSE of energies
-        L_E = F.mse_loss(energies["E_predict"], energies["E_true"])
-        # Assuming forces_true and forces_predict are already negative gradients of the potential energy w.r.t positions
-        L_F = F.mse_loss(forces["F_predict"], forces["F_true"])
-
-        return self.energy_weight * L_E + self.force_weight * L_F
-
-
-class TrainingAdapter(pl.LightningModule):
-    """
-    Adapter class for training neural network potentials using PyTorch Lightning.
-
-    This class wraps around the base neural network potential model, facilitating training
-    and validation steps, optimization, and logging.
-
-    Attributes
-    ----------
-    base_model : Union[ANI2x, SchNet, PaiNN, PhysNet]
-        The underlying neural network potential model.
-    loss_function : torch.nn.modules.loss._Loss
-        Loss function used during training.
-    optimizer : torch.optim.Optimizer
-        Optimizer used for training.
-    learning_rate : float
-        Learning rate for the optimizer.
-    """
-
-    def __init__(
-        self,
-        model: Union["ANI2x", "SchNet", "PaiNN", "PhysNet"],
-        include_force: bool = False,
-        optimizer: Any = torch.optim.Adam,
-        lr: float = 1e-3,
-    ):
-        """
-        Initializes the TrainingAdapter with the specified model and training configuration.
-
-        Parameters
-        ----------
-        model : Union[ANI2x, SchNet, PaiNN, PhysNet]
-            The neural network potential model to be trained.
-        optimizer : Type[torch.optim.Optimizer], optional
-            The optimizer class to use for training, by default torch.optim.Adam.
-        lr : float, optional
-            The learning rate for the optimizer, by default 1e-3.
-        """
-        from typing import List
-
-        super().__init__()
-
-        self.model = model
-        self.optimizer = optimizer
-        self.learning_rate = lr
-        self.loss = (
-            EnergyAndForceLoss(model=self.model)
-            if include_force
-            else EnergyLoss(model=self.model)
-        )
-        self.eval_loss: List[torch.Tensor] = []
-
-    def config_prior(self):
-
-        if hasattr(self.model, "_config_prior"):
-            return self.model._config_prior()
-
-        log.warning("Model does not implement _config_prior().")
-        raise NotImplementedError()
-
-    def _log_batch_size(self, y: torch.Tensor) -> int:
-        """
-        Logs the size of the batch and returns it. Useful for logging and debugging.
-
-        Parameters
-        ----------
-        y : torch.Tensor
-            The tensor containing the target values of the batch.
-
-        Returns
-        -------
-        int
-            The size of the batch.
-        """
-        batch_size = int(y.numel())
-        return batch_size
-
-    def training_step(self, batch: BatchData, batch_idx: int) -> torch.Tensor:
-        """
-        Performs a training step using the given batch.
-
-        Parameters
-        ----------
-        batch : BatchData
-            The batch of data provided for the training.
-        batch_idx : int
-            The index of the current batch.
-
-        Returns
-        -------
-        torch.Tensor
-            The loss tensor computed for the current training step.
-        """
-
-        loss = self.loss.compute_mse_loss(batch)
-        self.batch_size = self._log_batch_size(loss)
-
-        self.log(
-            "ptl/train_loss",
-            loss,
-            on_step=True,
-            batch_size=self.batch_size,
-        )
-
-        return loss
-
-    def test_step(self, batch: BatchData, batch_idx: int) -> None:
-        """
-        Executes a test step using the given batch of data.
-
-        This method is called automatically during the test loop of the training process. It computes
-        the loss on a batch of test data and logs the results for analysis.
-
-        Parameters
-        ----------
-        batch : BatchData
-            The batch of data to test the model on.
-        batch_idx : int
-            The index of the batch within the test dataset.
-
-        Returns
-        -------
-        None
-            The results are logged and not directly returned.
-        """
-        loss = self.loss.compute_rmse_loss(batch)
-        self.batch_size = self._log_batch_size(loss)
-
-        self.log(
-            "ptl/test_loss",
-            loss,
-            batch_size=self.batch_size,
-            on_epoch=True,
-            prog_bar=True,
-        )
-
-    def validation_step(self, batch: BatchData, batch_idx: int) -> torch.Tensor:
-        """
-        Executes a single validation step.
-
-        Parameters
-        ----------
-        batch : BatchData
-            The batch of data provided for validation.
-        batch_idx : int
-            The index of the current batch.
-
-        Returns
-        -------
-        torch.Tensor
-            The loss tensor computed for the current validation step.
-        """
-
-        loss = self.loss.compute_rmse_loss(batch)
-        self.batch_size = self._log_batch_size(loss)
-
-        self.log(
-            "val_loss",
-            loss,
-            batch_size=self.batch_size,
-            on_epoch=True,
-            prog_bar=True,
-            sync_dist=True,
-        )
-        self.eval_loss.append(loss.detach())
-        return loss
-
-    def on_validation_epoch_end(self):
-        avg_loss = torch.stack(self.eval_loss).mean()
-        self.log("ptl/val_loss", avg_loss, sync_dist=True)
-        self.eval_loss.clear()
-
-    def configure_optimizers(self) -> Dict[str, Any]:
-        """
-        Configures the model's optimizers (and optionally schedulers).
-
-        Returns
-        -------
-        Dict[str, Any]
-            A dictionary containing the optimizer and optionally the learning rate scheduler
-            to be used within the PyTorch Lightning training process.
-        """
-
-        optimizer = self.optimizer(self.model.parameters(), lr=self.learning_rate)
-        scheduler = {
-            "scheduler": ReduceLROnPlateau(
-                optimizer, mode="min", factor=0.1, patience=20, verbose=True
-            ),
-            "monitor": "val_loss",  # Name of the metric to monitor
-            "interval": "epoch",
-            "frequency": 1,
-        }
-        return {"optimizer": optimizer, "lr_scheduler": scheduler}
-
-    def get_trainer(self):
-        """
-        Sets up and returns a PyTorch Lightning Trainer instance with configured logger and callbacks.
-
-        The trainer is configured with TensorBoard logging and an EarlyStopping callback to halt
-        the training process when the validation loss stops improving.
-
-        Returns
-        -------
-        Trainer
-            The configured PyTorch Lightning Trainer instance.
-        """
-
-        from lightning import Trainer
-        from lightning.pytorch.callbacks.early_stopping import EarlyStopping
-        from pytorch_lightning.loggers import TensorBoardLogger
-
-        # set up tensor board logger
-        logger = TensorBoardLogger("tb_logs", name="training")
-        early_stopping = EarlyStopping(
-            monitor="val_loss", min_delta=0.05, patience=20, verbose=True
-        )
-
-        return Trainer(
-            max_epochs=10_000,
-            num_nodes=1,
-            devices="auto",
-            accelerator="auto",
-            logger=logger,  # Add the logger here
-            callbacks=[early_stopping],
-        )
-
-    def train_func(self):
-        """
-        Defines the training function to be used with Ray for distributed training.
-
-        This function configures a PyTorch Lightning trainer with the Ray Distributed Data Parallel
-        (DDP) strategy for efficient distributed training. The training process utilizes a custom
-        training loop and environment setup provided by Ray.
-
-        Note: This function should be passed to a Ray Trainer or directly used with Ray tasks.
-        """
-
-        from ray.train.lightning import (
-            RayDDPStrategy,
-            RayLightningEnvironment,
-            RayTrainReportCallback,
-            prepare_trainer,
-        )
-
-        trainer = pl.Trainer(
-            devices="auto",
-            accelerator="auto",
-            strategy=RayDDPStrategy(find_unused_parameters=True),
-            callbacks=[RayTrainReportCallback()],
-            plugins=[RayLightningEnvironment()],
-            enable_progress_bar=False,
-        )
-        trainer = prepare_trainer(trainer)
-        trainer.fit(self, self.train_dataloader, self.val_dataloader)
-
-    def get_ray_trainer(self, number_of_workers: int = 2, use_gpu: bool = False):
-        """
-        Initializes and returns a Ray Trainer for distributed training.
-
-        Configures a Ray Trainer with a specified number of workers and GPU usage settings. This trainer
-        is prepared for distributed training using Ray, with support for checkpointing.
-
-        Parameters
-        ----------
-        number_of_workers : int, optional
-            The number of distributed workers to use, by default 2.
-        use_gpu : bool, optional
-            Specifies whether to use GPUs for training, by default False.
-
-        Returns
-        -------
-        Ray Trainer
-            The configured Ray Trainer for distributed training.
-        """
-
-        from ray.train import CheckpointConfig, RunConfig, ScalingConfig
-
-        scaling_config = ScalingConfig(
-            num_workers=number_of_workers,
-            use_gpu=use_gpu,
-            resources_per_worker={"CPU": 1, "GPU": 1} if use_gpu else {"CPU": 1},
-        )
-
-        run_config = RunConfig(
-            checkpoint_config=CheckpointConfig(
-                num_to_keep=2,
-                checkpoint_score_attribute="ptl/val_loss",
-                checkpoint_score_order="min",
-            ),
-        )
-        from ray.train.torch import TorchTrainer
-
-        # Define a TorchTrainer without hyper-parameters for Tuner
-        ray_trainer = TorchTrainer(
-            self.train_func,
-            scaling_config=scaling_config,
-            run_config=run_config,
-        )
-
-        return ray_trainer
-
-    def tune_with_ray(
-        self,
-        train_dataloader,
-        val_dataloader,
-        number_of_epochs: int = 5,
-        number_of_samples: int = 10,
-        number_of_ray_workers: int = 2,
-        train_on_gpu: bool = False,
-    ):
-        """
-        Performs hyperparameter tuning using Ray Tune.
-
-        This method sets up and starts a Ray Tune hyperparameter tuning session, utilizing the ASHA scheduler
-        for efficient trial scheduling and early stopping.
-
-        Parameters
-        ----------
-        train_dataloader : DataLoader
-            The DataLoader for training data.
-        val_dataloader : DataLoader
-            The DataLoader for validation data.
-        number_of_epochs : int, optional
-            The maximum number of epochs for training, by default 5.
-        number_of_samples : int, optional
-            The number of samples (trial runs) to perform, by default 10.
-        number_of_ray_workers : int, optional
-            The number of Ray workers to use for distributed training, by default 2.
-        use_gpu : bool, optional
-            Whether to use GPUs for training, by default False.
-
-        Returns
-        -------
-        Tune experiment analysis object
-            The result of the hyperparameter tuning session, containing performance metrics and the best hyperparameters found.
-        """
-
-        from ray import tune
-        from ray.tune.schedulers import ASHAScheduler
-
-        self.train_dataloader = train_dataloader
-        self.val_dataloader = val_dataloader
-
-        ray_trainer = self.get_ray_trainer(
-            number_of_workers=number_of_ray_workers, use_gpu=train_on_gpu
-        )
-        scheduler = ASHAScheduler(
-            max_t=number_of_epochs, grace_period=1, reduction_factor=2
-        )
-
-        tune_config = tune.TuneConfig(
-            metric="ptl/val_loss",
-            mode="min",
-            scheduler=scheduler,
-            num_samples=number_of_samples,
-        )
-
-        tuner = tune.Tuner(
-            ray_trainer,
-            param_space={"train_loop_config": self.config_prior()},
-            tune_config=tune_config,
-        )
-        return tuner.fit()
 
 
 class SingleTopologyAlchemicalBaseNNPModel(BaseNeuralNetworkPotential):

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -405,7 +405,7 @@ class NeuralNetworkPotentialFactory:
     def create_nnp(
         use: Literal["training", "inference"],
         nnp_type: Literal["ANI2x", "SchNet", "PaiNN", "SAKE", "PhysNet"],
-        simulation_environment: Literal["PyTorch", "JAX"],
+        simulation_environment: Literal["PyTorch", "JAX"] = "PyTorch",
         nnp_parameters: Optional[Dict[str, Union[int, float]]] = None,
         training_parameters: Optional[Dict[str, Any]] = None,
         compile_model: bool = False,

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -650,7 +650,6 @@ class BaseNeuralNetworkPotential(Module, ABC):
         self.calculate_distances_and_pairlist = Neighborlist(
             cutoff, only_unique_pairs=only_unique_pairs
         )
-        self._dtype: Optional[bool] = None  # set at runtime
         self._log_message_dtype = False
         self._log_message_units = False
         # initialize the per molecule readout module

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -461,6 +461,10 @@ class NeuralNetworkPotentialFactory:
             nnp_instance = torch.compile(nnp_instance, mode="max-autotune")
 
         if use == "training":
+            if simulation_environment == "JAX":
+                log.warning(
+                    "Training in JAX is not availalbe. Falling back to PyTorch."
+                )
             trainer = TrainingAdapter(model=nnp_instance, **training_parameters)
             return trainer
         elif use == "inference":

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -15,7 +15,7 @@ def train_model(request):
     model_name = request.param
     # Assuming NeuralNetworkPotentialFactory.create_nnp
     model = NeuralNetworkPotentialFactory.create_nnp(
-        use="training", nnp_type=model_name, simulation_environment="PyTorch"
+        use="training", nnp_name=model_name, simulation_environment="PyTorch"
     )
     return model
 
@@ -27,7 +27,7 @@ def inference_model(request):
     # Assuming you pass simulation_environment to create_nnp in some way
     return lambda env: NeuralNetworkPotentialFactory.create_nnp(
         use="inference",
-        nnp_type=model_name,
+        nnp_name=model_name,
         simulation_environment=env,
     )
 

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -95,6 +95,18 @@ def test_energy_scaling_and_offset():
     )
 
 
+@pytest.mark.parametrize("model_name", _IMPLEMENTED_NNPS)
+def test_state_dict_saving_and_loading(model_name):
+    from modelforge.potential import NeuralNetworkPotentialFactory
+    import torch
+
+    model = NeuralNetworkPotentialFactory.create_nnp("training", model_name, "PyTorch")
+    torch.save(model.state_dict(), "model.pth")
+
+    model = NeuralNetworkPotentialFactory.create_nnp("inference", model_name, "PyTorch")
+    model.load_state_dict(torch.load("model.pth"))
+
+
 def test_energy_between_simulation_environments(inference_model, batch):
     # compare that the energy is the same for the JAX and PyTorch Model
     import numpy as np

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -12,7 +12,7 @@ def test_JAX_wrapping(model_name, batch):
     # inference model
     model = NeuralNetworkPotentialFactory.create_nnp(
         use="inference",
-        nnp_type=model_name,
+        nnp_name=model_name,
         simulation_environment="JAX",
     )
     assert "JAX" in str(type(model))
@@ -31,13 +31,13 @@ def test_JAX_wrapping(model_name, batch):
 def test_model_factory(model_name, simulation_environment):
     from modelforge.potential.models import (
         NeuralNetworkPotentialFactory,
-        TrainingAdapter,
     )
+    from modelforge.train.training import TrainingAdapter
 
     # inference model
     model = NeuralNetworkPotentialFactory.create_nnp(
         use="inference",
-        nnp_type=model_name,
+        nnp_name=model_name,
         simulation_environment=simulation_environment,
     )
     assert model_name in str(type(model)) or "JAX" in str(type(model))

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -17,6 +17,7 @@ def test_train_with_lightning(train_model, initialized_dataset):
 
     from lightning import Trainer
     import torch
+    from modelforge.train.training import TrainingAdapter
 
     # Initialize PyTorch Lightning Trainer
     trainer = Trainer(max_epochs=2)
@@ -31,7 +32,7 @@ def test_train_with_lightning(train_model, initialized_dataset):
     )
     # save checkpoint
     trainer.save_checkpoint("test.chp")
-    model1 = model.load_from_checkpoint("test.chp")
+    model1 = TrainingAdapter.load_from_checkpoint("test.chp")
 
 
 def test_hypterparameter_tuning_with_ray(train_model, initialized_dataset):

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -32,7 +32,8 @@ def test_train_with_lightning(train_model, initialized_dataset):
     )
     # save checkpoint
     trainer.save_checkpoint("test.chp")
-    model1 = TrainingAdapter.load_from_checkpoint("test.chp")
+    model = TrainingAdapter.load_from_checkpoint("test.chp")
+    assert type(model) is not None
 
 
 def test_hypterparameter_tuning_with_ray(train_model, initialized_dataset):

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -29,6 +29,9 @@ def test_train_with_lightning(train_model, initialized_dataset):
         initialized_dataset.train_dataloader(),
         initialized_dataset.val_dataloader(),
     )
+    # save checkpoint
+    trainer.save_checkpoint("test.chp")
+    model1 = model.load_from_checkpoint("test.chp")
 
 
 def test_hypterparameter_tuning_with_ray(train_model, initialized_dataset):

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1,0 +1,483 @@
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+import lightning as pl
+from typing import TYPE_CHECKING, Any, Union, Dict, NamedTuple, Tuple, Type, Mapping
+import torch
+from loguru import logger as log
+from modelforge.potential.utils import AtomicSelfEnergies, BatchData, NNPInput
+from torch.nn import functional as F
+
+if TYPE_CHECKING:
+    from modelforge.dataset.dataset import DatasetStatistics
+    from modelforge.potential.ani import ANI2x, AniNeuralNetworkData
+    from modelforge.potential.painn import PaiNN, PaiNNNeuralNetworkData
+    from modelforge.potential.physnet import PhysNet, PhysNetNeuralNetworkData
+    from modelforge.potential.schnet import SchNet, SchnetNeuralNetworkData
+
+
+class Loss:
+    """
+    Base class for loss computations, designed to be overridden by subclasses for specific types of losses.
+    Initializes with a model to compute predictions for energies and forces.
+    """
+
+    def __init__(self, model: Union["ANI2x", "SchNet", "PaiNN", "PhysNet"]) -> None:
+        self.model = model
+
+    def _get_forces(self, batch: BatchData) -> Dict[str, torch.Tensor]:
+        """
+        Extracts and computes the forces from a given batch during training or evaluation, if forces are available.
+        Handles cases gracefully where F might not be present in the batch.
+
+        Parameters
+        ----------
+        batch : BatchData
+            A single batch of data, including input features and target energies.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            The true forces from the dataset and the predicted forces by the model.
+        """
+        nnp_input = batch.nnp_input
+        F_true = batch.metadata.F.to(torch.float32)
+        E_predict = self.model.forward(nnp_input).E
+        F_predict = -torch.autograd.grad(
+            E_predict.sum(), nnp_input.positions, create_graph=False, retain_graph=False
+        )[0]
+
+        return {"F_true": F_true, "F_predict": F_predict}
+
+    def _get_energies(self, batch: BatchData) -> Dict[str, torch.Tensor]:
+        """
+        Extracts and computes the energies from a given batch during training or evaluation.
+
+        Parameters
+        ----------
+        batch : BatchData
+            A single batch of data, including input features and target energies.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            The true energies from the dataset and the predicted energies by the model.
+        """
+        nnp_input = batch.nnp_input
+        E_true = batch.metadata.E.to(torch.float32).squeeze(1)
+        E_predict = self.model.forward(nnp_input).E
+        return {"E_true": E_true, "E_predict": E_predict}
+
+
+class EnergyAndForceLoss(Loss):
+    """
+    Computes combined loss from energies and forces, with adjustable weighting.
+    """
+
+    def __init__(
+        self,
+        model: Union["ANI2x", "SchNet", "PaiNN", "PhysNet"],
+        include_force: bool = False,
+        force_weight: float = 1.0,
+        energy_weight: float = 1.0,
+    ) -> None:
+        super().__init__(model)
+        log.info("Initializing EnergyAndForceLoss")
+        self.force_weight = force_weight
+        self.energy_weight = energy_weight
+        self.include_force = include_force
+
+    def compute_mse_loss(self, batch: BatchData) -> torch.Tensor:
+        """
+        Computes the combined MSE loss from energies and forces, considering the available data.
+        """
+        energies = self._get_energies(batch)
+        forces = self._get_forces(batch)
+        # Compute MSE of energies
+        L_E = F.mse_loss(energies["E_predict"], energies["E_true"])
+        if self.include_force:
+            L_F = F.mse_loss(forces["F_predict"], forces["F_true"])
+            return self.energy_weight * L_E + self.force_weight * L_F
+        else:
+            return L_E
+
+    def compute_rmse_loss(self, batch: BatchData) -> torch.Tensor:
+        """
+        Computes the RMSE loss from energies.
+        """
+        energies = self._get_energies(batch)
+        # Compute RMSE of energies
+        L_E = torch.sqrt(F.mse_loss(energies["E_predict"], energies["E_true"]))
+
+        return L_E
+
+
+from torch.optim import Optimizer
+
+
+class TrainingAdapter(pl.LightningModule):
+    """
+    Adapter class for training neural network potentials using PyTorch Lightning.
+
+    This class wraps around the base neural network potential model, facilitating training
+    and validation steps, optimization, and logging.
+
+    Attributes
+    ----------
+    base_model : Union[ANI2x, SchNet, PaiNN, PhysNet]
+        The underlying neural network potential model.
+    optimizer : torch.optim.Optimizer
+        Optimizer used for training.
+    learning_rate : float
+        Learning rate for the optimizer.
+    """
+
+    def __init__(
+        self,
+        *,
+        nnp_parameters: Dict[str, Any],
+        include_force: bool = False,
+        optimizer: Type[Optimizer] = torch.optim.Adam,
+        lr: float = 1e-3,
+    ):
+        """
+        Initializes the TrainingAdapter with the specified model and training configuration.
+
+        Parameters
+        ----------
+        model : Union[ANI2x, SchNet, PaiNN, PhysNet]
+            The neural network potential model to be trained.
+        optimizer : Type[torch.optim.Optimizer], optional
+            The optimizer class to use for training, by default torch.optim.Adam.
+        lr : float, optional
+            The learning rate for the optimizer, by default 1e-3.
+        """
+        from typing import List
+        from modelforge.potential import _IMPLEMENTED_NNPS
+
+        super().__init__()
+        self.save_hyperparameters()
+        nnp_name = nnp_parameters["nnp_name"]
+        nnp_parameters_ = nnp_parameters.copy()  # Make a copy of the dictionary
+        nnp_parameters_.pop(
+            "nnp_name", None
+        )  
+
+        nnp_class: Type = _IMPLEMENTED_NNPS.get(nnp_name)
+
+        self.model = nnp_class(**nnp_parameters_)
+        self.optimizer = optimizer
+        self.learning_rate = lr
+        self.loss = EnergyAndForceLoss(model=self.model, include_force=include_force)
+        self.eval_loss: List[torch.Tensor] = []
+
+    def config_prior(self):
+
+        if hasattr(self.model, "_config_prior"):
+            return self.model._config_prior()
+
+        log.warning("Model does not implement _config_prior().")
+        raise NotImplementedError()
+
+    def _log_batch_size(self, y: torch.Tensor) -> int:
+        """
+        Logs the size of the batch and returns it. Useful for logging and debugging.
+
+        Parameters
+        ----------
+        y : torch.Tensor
+            The tensor containing the target values of the batch.
+
+        Returns
+        -------
+        int
+            The size of the batch.
+        """
+        batch_size = int(y.numel())
+        return batch_size
+
+    def training_step(self, batch: BatchData, batch_idx: int) -> torch.Tensor:
+        """
+        Performs a training step using the given batch.
+
+        Parameters
+        ----------
+        batch : BatchData
+            The batch of data provided for the training.
+        batch_idx : int
+            The index of the current batch.
+
+        Returns
+        -------
+        torch.Tensor
+            The loss tensor computed for the current training step.
+        """
+
+        loss = self.loss.compute_mse_loss(batch)
+        self.batch_size = self._log_batch_size(loss)
+
+        self.log(
+            "ptl/train_loss",
+            loss,
+            on_step=True,
+            batch_size=self.batch_size,
+        )
+
+        return loss
+
+    def test_step(self, batch: BatchData, batch_idx: int) -> None:
+        """
+        Executes a test step using the given batch of data.
+
+        This method is called automatically during the test loop of the training process. It computes
+        the loss on a batch of test data and logs the results for analysis.
+
+        Parameters
+        ----------
+        batch : BatchData
+            The batch of data to test the model on.
+        batch_idx : int
+            The index of the batch within the test dataset.
+
+        Returns
+        -------
+        None
+            The results are logged and not directly returned.
+        """
+        loss = self.loss.compute_rmse_loss(batch)
+        self.batch_size = self._log_batch_size(loss)
+
+        self.log(
+            "ptl/test_loss",
+            loss,
+            batch_size=self.batch_size,
+            on_epoch=True,
+            prog_bar=True,
+        )
+
+    def validation_step(self, batch: BatchData, batch_idx: int) -> torch.Tensor:
+        """
+        Executes a single validation step.
+
+        Parameters
+        ----------
+        batch : BatchData
+            The batch of data provided for validation.
+        batch_idx : int
+            The index of the current batch.
+
+        Returns
+        -------
+        torch.Tensor
+            The loss tensor computed for the current validation step.
+        """
+
+        loss = self.loss.compute_rmse_loss(batch)
+        self.batch_size = self._log_batch_size(loss)
+
+        self.log(
+            "val_loss",
+            loss,
+            batch_size=self.batch_size,
+            on_epoch=True,
+            prog_bar=True,
+            sync_dist=True,
+        )
+        self.eval_loss.append(loss.detach())
+        return loss
+
+    def on_validation_epoch_end(self):
+        avg_loss = torch.stack(self.eval_loss).mean()
+        self.log("ptl/val_loss", avg_loss, sync_dist=True)
+        self.eval_loss.clear()
+
+    def configure_optimizers(self) -> Dict[str, Any]:
+        """
+        Configures the model's optimizers (and optionally schedulers).
+
+        Returns
+        -------
+        Dict[str, Any]
+            A dictionary containing the optimizer and optionally the learning rate scheduler
+            to be used within the PyTorch Lightning training process.
+        """
+
+        optimizer = self.optimizer(self.model.parameters(), lr=self.learning_rate)
+        scheduler = {
+            "scheduler": ReduceLROnPlateau(
+                optimizer, mode="min", factor=0.1, patience=20, verbose=True
+            ),
+            "monitor": "val_loss",  # Name of the metric to monitor
+            "interval": "epoch",
+            "frequency": 1,
+        }
+        return {"optimizer": optimizer, "lr_scheduler": scheduler}
+
+    def get_trainer(self):
+        """
+        Sets up and returns a PyTorch Lightning Trainer instance with configured logger and callbacks.
+
+        The trainer is configured with TensorBoard logging and an EarlyStopping callback to halt
+        the training process when the validation loss stops improving.
+
+        Returns
+        -------
+        Trainer
+            The configured PyTorch Lightning Trainer instance.
+        """
+
+        from lightning import Trainer
+        from lightning.pytorch.callbacks.early_stopping import EarlyStopping
+        from pytorch_lightning.loggers import TensorBoardLogger
+
+        # set up tensor board logger
+        logger = TensorBoardLogger("tb_logs", name="training")
+        early_stopping = EarlyStopping(
+            monitor="val_loss", min_delta=0.05, patience=20, verbose=True
+        )
+
+        return Trainer(
+            max_epochs=10_000,
+            num_nodes=1,
+            devices="auto",
+            accelerator="auto",
+            logger=logger,  # Add the logger here
+            callbacks=[early_stopping],
+        )
+
+    def train_func(self):
+        """
+        Defines the training function to be used with Ray for distributed training.
+
+        This function configures a PyTorch Lightning trainer with the Ray Distributed Data Parallel
+        (DDP) strategy for efficient distributed training. The training process utilizes a custom
+        training loop and environment setup provided by Ray.
+
+        Note: This function should be passed to a Ray Trainer or directly used with Ray tasks.
+        """
+
+        from ray.train.lightning import (
+            RayDDPStrategy,
+            RayLightningEnvironment,
+            RayTrainReportCallback,
+            prepare_trainer,
+        )
+
+        trainer = pl.Trainer(
+            devices="auto",
+            accelerator="auto",
+            strategy=RayDDPStrategy(find_unused_parameters=True),
+            callbacks=[RayTrainReportCallback()],
+            plugins=[RayLightningEnvironment()],
+            enable_progress_bar=False,
+        )
+        trainer = prepare_trainer(trainer)
+        trainer.fit(self, self.train_dataloader, self.val_dataloader)
+
+    def get_ray_trainer(self, number_of_workers: int = 2, use_gpu: bool = False):
+        """
+        Initializes and returns a Ray Trainer for distributed training.
+
+        Configures a Ray Trainer with a specified number of workers and GPU usage settings. This trainer
+        is prepared for distributed training using Ray, with support for checkpointing.
+
+        Parameters
+        ----------
+        number_of_workers : int, optional
+            The number of distributed workers to use, by default 2.
+        use_gpu : bool, optional
+            Specifies whether to use GPUs for training, by default False.
+
+        Returns
+        -------
+        Ray Trainer
+            The configured Ray Trainer for distributed training.
+        """
+
+        from ray.train import CheckpointConfig, RunConfig, ScalingConfig
+
+        scaling_config = ScalingConfig(
+            num_workers=number_of_workers,
+            use_gpu=use_gpu,
+            resources_per_worker={"CPU": 1, "GPU": 1} if use_gpu else {"CPU": 1},
+        )
+
+        run_config = RunConfig(
+            checkpoint_config=CheckpointConfig(
+                num_to_keep=2,
+                checkpoint_score_attribute="ptl/val_loss",
+                checkpoint_score_order="min",
+            ),
+        )
+        from ray.train.torch import TorchTrainer
+
+        # Define a TorchTrainer without hyper-parameters for Tuner
+        ray_trainer = TorchTrainer(
+            self.train_func,
+            scaling_config=scaling_config,
+            run_config=run_config,
+        )
+
+        return ray_trainer
+
+    def tune_with_ray(
+        self,
+        train_dataloader,
+        val_dataloader,
+        number_of_epochs: int = 5,
+        number_of_samples: int = 10,
+        number_of_ray_workers: int = 2,
+        train_on_gpu: bool = False,
+    ):
+        """
+        Performs hyperparameter tuning using Ray Tune.
+
+        This method sets up and starts a Ray Tune hyperparameter tuning session, utilizing the ASHA scheduler
+        for efficient trial scheduling and early stopping.
+
+        Parameters
+        ----------
+        train_dataloader : DataLoader
+            The DataLoader for training data.
+        val_dataloader : DataLoader
+            The DataLoader for validation data.
+        number_of_epochs : int, optional
+            The maximum number of epochs for training, by default 5.
+        number_of_samples : int, optional
+            The number of samples (trial runs) to perform, by default 10.
+        number_of_ray_workers : int, optional
+            The number of Ray workers to use for distributed training, by default 2.
+        use_gpu : bool, optional
+            Whether to use GPUs for training, by default False.
+
+        Returns
+        -------
+        Tune experiment analysis object
+            The result of the hyperparameter tuning session, containing performance metrics and the best hyperparameters found.
+        """
+
+        from ray import tune
+        from ray.tune.schedulers import ASHAScheduler
+
+        self.train_dataloader = train_dataloader
+        self.val_dataloader = val_dataloader
+
+        ray_trainer = self.get_ray_trainer(
+            number_of_workers=number_of_ray_workers, use_gpu=train_on_gpu
+        )
+        scheduler = ASHAScheduler(
+            max_t=number_of_epochs, grace_period=1, reduction_factor=2
+        )
+
+        tune_config = tune.TuneConfig(
+            metric="ptl/val_loss",
+            mode="min",
+            scheduler=scheduler,
+            num_samples=number_of_samples,
+        )
+
+        tuner = tune.Tuner(
+            ray_trainer,
+            param_space={"train_loop_config": self.config_prior()},
+            tune_config=tune_config,
+        )
+        return tuner.fit()


### PR DESCRIPTION
## Description
We are using a TrainingAdaptor to train neural network potentials (the Pytorch NNP model is an attribute of the TrainingAdaptor, which inherits from Pytorch-Lightning). When we serialize the state_dict, this is reflected in the keys, which are prefixed by `model.`. When we generate a model for inference, we don't use it with the TrainingAdapter, but the vanilla NNP (without any overhead from PyTorch-Lightning). To load a state dictionary correctly, we need to remove the `model.` prefix for each of the state_dict keys.

This PR overrides the native `load_state_dict` and adds a preprocessing step before calling `super().load_state_dict` to remove the `model.` prefix if found in the keys of the state_dict.  

## Todos
  - [x] override native `load_state_dict`
  - [x] write tests demonstrating the correct loading/saving of state_dict

## Status
- [x] Ready to go