### PR TITLE
Allow consistent `dtype` and `device` casting of models and input parameters

### DIFF
--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -609,26 +609,6 @@ class BaseNeuralNetworkPotential(torch.nn.Module, ABC):
 
         return nnp_input
 
-    def _set_dtype(self):
-        """
-        Sets the data type for the model based on its parameters.
-
-        Ensures consistency in data types across the model's parameters.
-        """
-
-        dtypes = list({p.dtype for p in self.parameters()})
-        assert len(dtypes) == 1, f"Multiple dtypes: {dtypes}"
-
-        if not self._log_message_dtype:
-            log.debug(f"Setting dtype to {dtypes[0]}.")
-            self._log_message_dtype = True
-
-        if self._dtype is not None and self._dtype != dtypes[0]:
-            log.warning(f"Setting dtype to {dtypes[0]}.")
-            log.warning(f"This is new, be carful. You are resetting the dtype!")
-
-        self._dtype = dtypes[0]
-
     def _input_checks(self, data: NamedTuple):
         """
         Performs input validation checks.
@@ -669,8 +649,6 @@ class BaseNeuralNetworkPotential(torch.nn.Module, ABC):
         EnergyOutput
             The calculated energies and other properties from the forward pass.
         """
-        # adjust the dtype of the input tensors to match the model parameters
-        self._set_dtype()
         # perform input checks
         self._input_checks(data)
         # prepare the input for the forward pass

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -127,7 +127,9 @@ class Metadata:
     number_of_atoms: int
     F: torch.Tensor = torch.tensor([], dtype=torch.float32)
 
-    def to(self, device: Optional[torch.device], dtype: Optional[torch.dtype]):
+    def to(
+        self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None
+    ):
         """Move all tensors in this instance to the specified device."""
         if device:
             self.E = self.E.to(device)

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -47,7 +47,6 @@ class NNPInput:
 
     def to(
         self,
-        *,
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
     ):
@@ -128,14 +127,18 @@ class Metadata:
     number_of_atoms: int
     F: torch.Tensor = torch.tensor([], dtype=torch.float32)
 
-    def to(self, device: torch.device):
+    def to(self, device: Optional[torch.device], dtype: Optional[torch.dtype]):
         """Move all tensors in this instance to the specified device."""
-        self.E = self.E.to(device)
-        self.F = self.F.to(device)
-        self.atomic_subsystem_counts = self.atomic_subsystem_counts.to(device)
-        self.atomic_subsystem_indices_referencing_dataset = (
-            self.atomic_subsystem_indices_referencing_dataset.to(device)
-        )
+        if device:
+            self.E = self.E.to(device)
+            self.F = self.F.to(device)
+            self.atomic_subsystem_counts = self.atomic_subsystem_counts.to(device)
+            self.atomic_subsystem_indices_referencing_dataset = (
+                self.atomic_subsystem_indices_referencing_dataset.to(device)
+            )
+        if dtype:
+            self.E = self.E.to(dtype)
+            self.F = self.F.to(dtype)
         return self
 
 
@@ -144,9 +147,13 @@ class BatchData:
     nnp_input: NNPInput
     metadata: Metadata
 
-    def to(self, device: torch.device):
-        self.nnp_input = self.nnp_input.to(device)
-        self.metadata = self.metadata.to(device)
+    def to(
+        self,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        self.nnp_input = self.nnp_input.to(device=device, dtype=dtype)
+        self.metadata = self.metadata.to(device=device, dtype=dtype)
         return self
 
 

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -45,12 +45,21 @@ class NNPInput:
     atomic_subsystem_indices: torch.Tensor
     total_charge: torch.Tensor
 
-    def to(self, device: torch.device):
-        """Move all tensors in this instance to the specified device."""
-        self.atomic_numbers = self.atomic_numbers.to(device)
-        self.positions = self.positions.to(device)
-        self.atomic_subsystem_indices = self.atomic_subsystem_indices.to(device)
-        self.total_charge = self.total_charge.to(device)
+    def to(
+        self,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        """Move all tensors in this instance to the specified device/dtype."""
+
+        if device:
+            self.atomic_numbers = self.atomic_numbers.to(device)
+            self.positions = self.positions.to(device)
+            self.atomic_subsystem_indices = self.atomic_subsystem_indices.to(device)
+            self.total_charge = self.total_charge.to(device)
+        if dtype:
+            self.positions = self.positions.to(dtype)
         return self
 
     def __post_init__(self):

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -308,7 +308,6 @@ def test_representation(setup_methane):
     from modelforge.potential import ANI2x
 
     mf_model = ANI2x()
-    mf_model._set_dtype()
     # perform input checks
     mf_model._input_checks(mf_input)
     # prepare the input for the forward pass

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -64,6 +64,7 @@ def test_energy_scaling_and_offset():
         output_with_ase.molecular_ase,
     )
 
+
 def test_forward_pass(inference_model, batch):
     # this test sends a single batch from different datasets through the model
 
@@ -331,12 +332,12 @@ def test_equivariant_energies_and_forces(batch, inference_model, equivariance_ut
     # define the tolerance
     atol = 1e-3
     # initialize the models
-    model = inference_model.to(torch.float64)
+    model = inference_model.double()
 
     # ------------------- #
     # start the test
     # reference values
-    nnp_input = batch.nnp_input
+    nnp_input = batch.nnp_input.to(dtype=torch.float64)
     reference_result = model(nnp_input).E.double()
     reference_forces = -torch.autograd.grad(
         reference_result.sum(),

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -319,6 +319,34 @@ def test_pairlist_on_dataset(initialized_dataset):
         assert shapePairlist[0] == 2
 
 
+def test_casting(batch, inference_model):
+    # test dtype casting
+    import torch
+
+    batch_ = batch.to(dtype=torch.float64)
+    assert batch_.nnp_input.positions.dtype == torch.float64
+    batch_ = batch_.to(dtype=torch.float32)
+    assert batch_.nnp_input.positions.dtype == torch.float32
+
+    nnp_input = batch.nnp_input.to(dtype=torch.float64)
+    assert nnp_input.positions.dtype == torch.float64
+    nnp_input = batch.nnp_input.to(dtype=torch.float32)
+    assert nnp_input.positions.dtype == torch.float32
+    nnp_input = batch.metadata.to(dtype=torch.float64)
+
+    # cast input and model to torch.float64
+    model = inference_model.to(dtype=torch.float64)
+    nnp_input = batch.nnp_input.to(dtype=torch.float64)
+
+    model(nnp_input)
+
+    # cast input and model to torch.float64
+    model = inference_model.to(dtype=torch.float32)
+    nnp_input = batch.nnp_input.to(dtype=torch.float32)
+
+    model(nnp_input)
+
+
 def test_equivariant_energies_and_forces(batch, inference_model, equivariance_utils):
     """
     Test the calculation of energies and forces for a molecule.

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -221,7 +221,6 @@ def test_painn_representation_implementation():
     mf_nnp_input = input["modelforge_methane_input"]
 
     schnetpack_results = schnetpack_painn(spk_input)
-    modelforge_painn._set_dtype()
     modelforge_painn._input_checks(mf_nnp_input)
     pain_nn_input_mf = modelforge_painn.prepare_inputs(
         mf_nnp_input, only_unique_pairs=False
@@ -578,7 +577,6 @@ def test_schnet_representation_implementation():
     mf_nnp_input = input["modelforge_methane_input"]
 
     schnetpack_results = schnetpack_schnet(spk_input)
-    modelforge_schnet._set_dtype()
     modelforge_schnet._input_checks(mf_nnp_input)
     schnet_nn_input_mf = modelforge_schnet.prepare_inputs(
         mf_nnp_input, only_unique_pairs=False


### PR DESCRIPTION
## Description

The data loader provides the input for each neural network as a data class. This PR adds methods to consistently cast each of the tensors to `device` and `dtype`, analogous to the model casting.

## Status
- [x] Ready to go