### PR TITLE
Refactor base class for neural network potentials

### DIFF
--- a/modelforge/dataset/qm9.py
+++ b/modelforge/dataset/qm9.py
@@ -108,7 +108,7 @@ class QM9Dataset(HDF5Dataset):
 
     @property
     def atomic_self_energies(self):
-        from modelforge.potential.utils import AtomicSelfEnergies
+        from modelforge.potential.processing import AtomicSelfEnergies
 
         return AtomicSelfEnergies(energies=self._ase)
 

--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -7,8 +7,8 @@ from .utils import (
     CosineCutoff,
     RadialSymmetryFunction,
     AngularSymmetryFunction,
-    FromAtomToMoleculeReduction,
 )
+from .processing import FromAtomToMoleculeReduction
 from .models import TrainingAdapter
 from .models import NeuralNetworkPotentialFactory
 

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -584,7 +584,7 @@ class ANI2x(torch.nn.Module):
             angular_dist_divisions,
             angle_sections,
         )
-        self.only_unique_pairs = False  # NOTE: for pairlist
+        self.only_unique_pairs = True  # NOTE: for pairlist
         self.input_preparation = InputPreparation(cutoff=radial_max_distance)
 
     def forward(self, data: NNPInput):

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -494,23 +494,6 @@ class ANI2xCore(BaseNeuralNetworkPotential):
 
         self.register_buffer("lookup_tensor", lookup_tensor)
 
-    def _config_prior(self):
-        log.info("Configuring ANI2x model hyperparameter prior distribution")
-        from ray import tune
-
-        from modelforge.train.utils import shared_config_prior
-
-        prior = {
-            "radial_max_distance": tune.uniform(5, 10),
-            "radial_min_distance": tune.uniform(0.6, 1.4),
-            "number_of_radial_basis_functions": tune.randint(12, 20),
-            "angular_max_distance": tune.uniform(2.5, 4.5),
-            "angular_min_distance": tune.uniform(0.6, 1.4),
-            "angle_sections": tune.randint(3, 8),
-        }
-        prior.update(shared_config_prior())
-        return prior
-
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: "PairListOutputs"
     ) -> AniNeuralNetworkData:
@@ -595,3 +578,20 @@ class ANI2x(torch.nn.Module):
             data, self.only_unique_pairs
         )
         return self.ani2x_core(data, pairlist_output)
+
+    def _config_prior(self):
+        log.info("Configuring ANI2x model hyperparameter prior distribution")
+        from ray import tune
+
+        from modelforge.train.utils import shared_config_prior
+
+        prior = {
+            "radial_max_distance": tune.uniform(5, 10),
+            "radial_min_distance": tune.uniform(0.6, 1.4),
+            "number_of_radial_basis_functions": tune.randint(12, 20),
+            "angular_max_distance": tune.uniform(2.5, 4.5),
+            "angular_min_distance": tune.uniform(0.6, 1.4),
+            "angle_sections": tune.randint(3, 8),
+        }
+        prior.update(shared_config_prior())
+        return prior

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -295,8 +295,9 @@ class NeuralNetworkPotentialFactory:
             raise NotImplementedError("Unknown NNP type requested.")
 
 
-class Neighborlist(torch.nn.Module):
+class InputPreparation(torch.nn.Module):
     def __init__(self, cutoff: unit.Quantity):
+        super().__init__()
         from .models import Neighborlist
 
         self.calculate_distances_and_pairlist = Neighborlist(cutoff)
@@ -497,7 +498,7 @@ class BaseNeuralNetworkPotential(torch.nn.Module, ABC):
         # perform model specific modifications
         nnp_input = self._model_specific_input_preparation(data, pairlist_output)
         # perform the forward pass implemented in the subclass
-        outputs = self._forward(inputs)
+        outputs = self._forward(nnp_input)
         # sum over atomic properties to generate per molecule properties
         E = self._readout(
             atom_specific_values=outputs["E_i"],
@@ -505,7 +506,7 @@ class BaseNeuralNetworkPotential(torch.nn.Module, ABC):
         )
         # postprocess energies: add atomic self energies,
         # and other constant factors used to optionally normalize the data range of the training dataset
-        processed_energy = self.postprocessing._energy_postprocessing(E, inputs)
+        processed_energy = self.postprocessing._energy_postprocessing(E, nnp_input)
         # return energies
         return EnergyOutput(
             E=processed_energy["E"],

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -302,7 +302,9 @@ class InputPreparation(torch.nn.Module):
 
         self.calculate_distances_and_pairlist = Neighborlist(cutoff)
 
-    def prepare_inputs(self, data: NNPInput, only_unique_pairs: bool = True):
+    def prepare_inputs(
+        self, data: Union[NNPInput, NamedTuple], only_unique_pairs: bool = True
+    ):
         """
         Prepares the input tensors for passing to the model.
 
@@ -332,7 +334,7 @@ class InputPreparation(torch.nn.Module):
 
         return pairlist_output
 
-    def _input_checks(self, data: NamedTuple):
+    def _input_checks(self, data: Union[NNPInput, NamedTuple]):
         """
         Performs input validation checks.
 
@@ -349,7 +351,7 @@ class InputPreparation(torch.nn.Module):
             If the input data does not meet the expected criteria.
         """
         # check that the input is instance of NNPInput
-        assert isinstance(data, NNPInput)
+        assert isinstance(data, NNPInput) or isinstance(data, Tuple)
 
         nr_of_atoms = data.atomic_numbers.shape[0]
         assert data.atomic_numbers.shape == torch.Size([nr_of_atoms])

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -139,22 +139,6 @@ class PaiNNCore(BaseNeuralNetworkPotential):
             ),
         )
 
-    def _config_prior(self):
-        log.info("Configuring PaiNN model hyperparameter prior distribution")
-        from ray import tune
-
-        from modelforge.potential.utils import shared_config_prior
-
-        prior = {
-            "number_of_atom_features": tune.randint(2, 256),
-            "number_of_interaction_modules": tune.randint(1, 5),
-            "cutoff": tune.uniform(5, 10),
-            "number_of_radial_basis_functions": tune.randint(8, 32),
-            "shared_filters": tune.choice([True, False]),
-            "shared_interactions": tune.choice([True, False]),
-        }
-        prior.update(shared_config_prior())
-        return prior
 
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: "PairListOutputs"
@@ -529,3 +513,20 @@ class PaiNN(torch.nn.Module):
             data, self.only_unique_pairs
         )
         return self.painn_core(data, pairlist_output)
+
+    def _config_prior(self):
+        log.info("Configuring PaiNN model hyperparameter prior distribution")
+        from ray import tune
+
+        from modelforge.potential.utils import shared_config_prior
+
+        prior = {
+            "number_of_atom_features": tune.randint(2, 256),
+            "number_of_interaction_modules": tune.randint(1, 5),
+            "cutoff": tune.uniform(5, 10),
+            "number_of_radial_basis_functions": tune.randint(8, 32),
+            "shared_filters": tune.choice([True, False]),
+            "shared_interactions": tune.choice([True, False]),
+        }
+        prior.update(shared_config_prior())
+        return prior

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -106,7 +106,7 @@ class PaiNN(BaseNeuralNetworkPotential):
         self.embedding_module = Embedding(max_Z, number_of_atom_features)
 
         # initialize the energy readout
-        from .utils import FromAtomToMoleculeReduction
+        from .processing import FromAtomToMoleculeReduction
 
         self.readout_module = FromAtomToMoleculeReduction()
 

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -190,8 +190,6 @@ class PaiNNCore(BaseNeuralNetworkPotential):
         mu = transformed_input["mu"]
         dir_ij = transformed_input["dir_ij"]
 
-        for i in [1, 2, 3]:
-            print(i)
 
         for i, (interaction_mod, mixing_mod) in enumerate(
             zip(self.interaction_modules, self.mixing_modules)

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -497,22 +497,6 @@ class PhysNetCore(BaseNeuralNetworkPotential):
         self.atomic_scale = nn.Parameter(torch.ones(max_Z, 2))
         self.atomic_shift = nn.Parameter(torch.ones(max_Z, 2))
 
-    def _config_prior(self):
-        log.info("Configuring SchNet model hyperparameter prior distribution")
-        from ray import tune
-
-        from modelforge.potential.utils import shared_config_prior
-
-        prior = {
-            "number_of_atom_features": tune.randint(2, 256),
-            "number_of_modules": tune.randint(3, 8),
-            "number_of_interaction_residual": tune.randint(2, 5),
-            "cutoff": tune.uniform(5, 10),
-            "number_of_radial_basis_functions": tune.randint(8, 32),
-        }
-        prior.update(shared_config_prior())
-        return prior
-
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: "PairListOutputs"
     ) -> PhysNetNeuralNetworkData:
@@ -658,3 +642,19 @@ class PhysNet(torch.nn.Module):
             data, self.only_unique_pairs
         )
         return self.physnet_core(data, pairlist_output)
+
+    def _config_prior(self):
+        log.info("Configuring SchNet model hyperparameter prior distribution")
+        from ray import tune
+
+        from modelforge.potential.utils import shared_config_prior
+
+        prior = {
+            "number_of_atom_features": tune.randint(2, 256),
+            "number_of_modules": tune.randint(3, 8),
+            "number_of_interaction_residual": tune.randint(2, 5),
+            "cutoff": tune.uniform(5, 10),
+            "number_of_radial_basis_functions": tune.randint(8, 32),
+        }
+        prior.update(shared_config_prior())
+        return prior

--- a/modelforge/potential/processing.py
+++ b/modelforge/potential/processing.py
@@ -1,0 +1,339 @@
+import torch
+from modelforge.dataset.dataset import DatasetStatistics
+from loguru import logger as log
+
+
+class FromAtomToMoleculeReduction(torch.nn.Module):
+
+    def __init__(self):
+        """
+        Initializes the energy readout module.
+        Performs the reduction of 'per_atom' property to 'per_molecule' property.
+        """
+        super().__init__()
+
+    def forward(self, x: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
+        """
+
+        Parameters
+        ----------
+        x, shape [nr_of_atoms, 1]
+        index, shape [nr_of_atoms]
+
+        Returns
+        -------
+        Tensor, shape [nr_of_moleculs, 1]
+            The total energy tensor.
+        """
+
+        # Perform scatter add operation
+        indices = index.to(torch.int64)
+        total_energy_per_molecule = torch.zeros(
+            len(index.unique()), dtype=x.dtype, device=x.device
+        )
+
+        total_energy_per_molecule = total_energy_per_molecule.scatter_add(0, indices, x)
+
+        # Sum across feature dimension to get final tensor of shape (num_molecules, 1)
+        # total_energy_per_molecule = result.sum(dim=1, keepdim=True)
+        return total_energy_per_molecule
+
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterator
+
+
+@dataclass
+class AtomicSelfEnergies:
+    """
+    AtomicSelfEnergies stores a mapping of atomic elements to their self energies.
+
+    Provides lookup by atomic number or symbol, iteration over the mapping,
+    and utilities to convert between atomic number and symbol.
+
+    Intended as a base class to be extended with specific element-energy values.
+    """
+
+    # We provide a dictionary with {str:float} of element name to atomic self-energy,
+    # which can then be accessed by atomic index or element name
+    energies: Dict[str, float] = field(default_factory=dict)
+    # Example mapping, replace or extend as necessary
+    atomic_number_to_element: Dict[int, str] = field(
+        default_factory=lambda: {
+            1: "H",
+            2: "He",
+            3: "Li",
+            4: "Be",
+            5: "B",
+            6: "C",
+            7: "N",
+            8: "O",
+            9: "F",
+            10: "Ne",
+            11: "Na",
+            12: "Mg",
+            13: "Al",
+            14: "Si",
+            15: "P",
+            16: "S",
+            17: "Cl",
+            18: "Ar",
+            19: "K",
+            20: "Ca",
+            21: "Sc",
+            22: "Ti",
+            23: "V",
+            24: "Cr",
+            25: "Mn",
+            26: "Fe",
+            27: "Co",
+            28: "Ni",
+            29: "Cu",
+            30: "Zn",
+            31: "Ga",
+            32: "Ge",
+            33: "As",
+            34: "Se",
+            35: "Br",
+            36: "Kr",
+            37: "Rb",
+            38: "Sr",
+            39: "Y",
+            40: "Zr",
+            41: "Nb",
+            42: "Mo",
+            43: "Tc",
+            44: "Ru",
+            45: "Rh",
+            46: "Pd",
+            47: "Ag",
+            48: "Cd",
+            49: "In",
+            50: "Sn",
+            # Add more elements as needed
+        }
+    )
+    _ase_tensor_for_indexing = None
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            # Convert atomic number to element symbol
+            element = self.atomic_number_to_element.get(key)
+            if element is None:
+                raise KeyError(f"Atomic number {key} not found.")
+            return self.energies.get(element)
+        elif isinstance(key, str):
+            # Directly access by element symbol
+            if key not in self.energies:
+                raise KeyError(f"Element {key} not found.")
+            return self.energies[key]
+        else:
+            raise TypeError(
+                "Key must be an integer (atomic number) or string (element name)."
+            )
+
+    def __iter__(self) -> Iterator[Dict[str, float]]:
+        """Iterate over the energies dictionary."""
+        for element, energy in self.energies.items():
+            atomic_number = self.element_to_atomic_number(element)
+            yield (atomic_number, energy)
+
+    def __len__(self) -> int:
+        """Return the number of element-energy pairs."""
+        return len(self.energies)
+
+    def element_to_atomic_number(self, element: str) -> int:
+        """Return the atomic number for a given element symbol."""
+        for atomic_number, elem_symbol in self.atomic_number_to_element.items():
+            if elem_symbol == element:
+                return atomic_number
+        raise ValueError(f"Element symbol '{element}' not found in the mapping.")
+
+    @property
+    def atomic_number_to_energy(self) -> Dict[int, float]:
+        """Return a dictionary mapping atomic numbers to their energies."""
+        return {
+            atomic_number: self[atomic_number]
+            for atomic_number in self.atomic_number_to_element.keys()
+            if self[atomic_number] is not None
+        }
+
+    @property
+    def ase_tensor_for_indexing(self) -> torch.Tensor:
+        if self._ase_tensor_for_indexing is None:
+            max_z = max(self.atomic_number_to_element.keys()) + 1
+            ase_tensor_for_indexing = torch.zeros(max_z)
+            for idx in self.atomic_number_to_element:
+                if self[idx]:
+                    ase_tensor_for_indexing[idx] = self[idx]
+                else:
+                    ase_tensor_for_indexing[idx] = 0.0
+            self._ase_tensor_for_indexing = ase_tensor_for_indexing
+
+        return self._ase_tensor_for_indexing
+
+
+from modelforge.potential.utils import NeuralNetworkData
+
+
+class EnergyScaling:
+    """
+    Provides a `EnergyScaling` class that handles the pre/postprocessing of energy calculations for neural network potentials.
+
+    The `EnergyScaling` class is responsible for:
+    - Calculating the molecular self energy from the atomic self energies.
+    - Rescaling the energies using dataset statistics.
+    - Combining the rescaled energies and molecular self energies to produce the final energy values.
+
+    The class also provides methods to access and update the dataset statistics used for the postprocessing.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the `DatasetStatistics` object with default values for the scaling factors and atomic self energies.
+        """
+
+        from modelforge.dataset.dataset import DatasetStatistics
+
+        self._dataset_statistics = DatasetStatistics(0.0, 1.0, AtomicSelfEnergies())
+
+    def _calculate_molecular_self_energy(
+        self, data: NeuralNetworkData, number_of_molecules: int
+    ) -> torch.Tensor:
+        """
+        Calculates the molecular self energy.
+
+        Parameters
+        ----------
+        data : NeuralNetworkData
+            The input data for the model, including atomic numbers and subsystem indices.
+        number_of_molecules : int
+            The number of molecules in the batch.
+
+        Returns
+        -------
+        torch.Tensor
+            The tensor containing the molecular self energy for each molecule.
+        """
+
+        atomic_numbers = data.atomic_numbers
+        atomic_subsystem_indices = data.atomic_subsystem_indices.to(
+            dtype=torch.long, device=atomic_numbers.device
+        )
+
+        # atomic_number_to_energy
+        atomic_self_energies = self.dataset_statistics.atomic_self_energies
+        ase_tensor_for_indexing = atomic_self_energies.ase_tensor_for_indexing.to(
+            device=atomic_numbers.device
+        )
+
+        # first, we need to use the atomic numbers to generate a tensor that
+        # contains the atomic self energy for each atomic number
+        ase_tensor = ase_tensor_for_indexing[atomic_numbers]
+
+        # then, we use the atomic_subsystem_indices to scatter add the atomic self
+        # energies in the ase_tensor to generate the molecular self energies
+        ase_tensor_zeros = torch.zeros((number_of_molecules,)).to(
+            device=atomic_numbers.device
+        )
+        ase_tensor = ase_tensor_zeros.scatter_add(
+            0, atomic_subsystem_indices, ase_tensor
+        )
+
+        return ase_tensor
+
+    def _rescale_energy(self, energies: torch.Tensor) -> torch.Tensor:
+        """
+        Rescales energies using the dataset statistics.
+
+        Parameters
+        ----------
+        energies : torch.Tensor
+            The tensor of energies to be rescaled.
+
+        Returns
+        -------
+        torch.Tensor
+            The rescaled energies.
+        """
+
+        return (
+            energies * self.dataset_statistics.scaling_stddev
+            + self.dataset_statistics.scaling_mean
+        )
+
+    def _energy_postprocessing(
+        self, properties_per_molecule: torch.Tensor, inputs: NeuralNetworkData
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Postprocesses the energies by rescaling and adding molecular self energy.
+
+        Parameters
+        ----------
+        properties_per_molecule : The properties computed per molecule.
+        inputs : The original input data to the model.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            The dictionary containing the postprocessed energy tensors.
+        """
+
+        # first, resale the energies
+        processed_energy = {}
+        processed_energy["raw_E"] = properties_per_molecule.clone().detach()
+        properties_per_molecule = self._rescale_energy(properties_per_molecule)
+        processed_energy["rescaled_E"] = properties_per_molecule.clone().detach()
+        # then, calculate the molecular self energy
+        molecular_ase = self._calculate_molecular_self_energy(
+            inputs, properties_per_molecule.numel()
+        )
+        processed_energy["molecular_ase"] = molecular_ase.clone().detach()
+        # add the molecular self energy to the rescaled energies
+        processed_energy["E"] = properties_per_molecule + molecular_ase
+        return processed_energy
+
+    @property
+    def dataset_statistics(self):
+        """
+        Property for accessing the model's dataset statistics.
+
+        Returns
+        -------
+        DatasetStatistics
+            The dataset statistics associated with the model.
+        """
+
+        return self._dataset_statistics
+
+    @dataset_statistics.setter
+    def dataset_statistics(self, value: "DatasetStatistics"):
+        """
+        Sets the dataset statistics for the model.
+
+        Parameters
+        ----------
+        value : DatasetStatistics
+            The new dataset statistics to be set for the model.
+        """
+
+        if not isinstance(value, DatasetStatistics):
+            raise ValueError("Value must be an instance of DatasetStatistics.")
+
+        self._dataset_statistics = value
+
+    def update_dataset_statistics(self, **kwargs):
+        """
+        Updates specific fields of the model's dataset statistics.
+
+        Parameters
+        ----------
+        **kwargs
+            Fields and their new values to update in the dataset statistics.
+        """
+
+        for key, value in kwargs.items():
+            if hasattr(self.dataset_statistics, key):
+                setattr(self.dataset_statistics, key, value)
+            else:
+                log.warning(f"{key} is not a valid field of DatasetStatistics.")

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -79,7 +79,7 @@ class SAKE(BaseNeuralNetworkPotential):
             cutoff: unit.Quantity = 5.0 * unit.angstrom,
             epsilon: float = 1e-8,
     ):
-        from .utils import FromAtomToMoleculeReduction
+        from .processing import FromAtomToMoleculeReduction
 
         log.debug("Initializing SAKE model.")
         super().__init__(cutoff=cutoff)

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -144,22 +144,6 @@ class SAKECore(BaseNeuralNetworkPotential):
 
         return nnp_input
 
-    def _config_prior(self):
-        log.info("Configuring SAKE model hyperparameter prior distribution")
-        from ray import tune
-
-        from modelforge.potential.utils import shared_config_prior
-
-        prior = {
-            "number_of_atom_features": tune.randint(2, 256),
-            "number_of_modules": tune.randint(3, 8),
-            "number_of_spatial_attention_heads": tune.randint(2, 5),
-            "cutoff": tune.uniform(5, 10),
-            "number_of_radial_basis_functions": tune.randint(8, 32),
-        }
-        prior.update(shared_config_prior())
-        return prior
-
     def _forward(self, data: SAKENeuralNetworkInput):
         """
         Compute atomic representations/embeddings.
@@ -595,4 +579,20 @@ class SAKE(torch.nn.Module):
         pairlist_output = self.input_preparation.prepare_inputs(
             data, self.only_unique_pairs
         )
-        return self.ani2x_core(data, pairlist_output)
+        return self.sake_core(data, pairlist_output)
+
+    def _config_prior(self):
+        log.info("Configuring SAKE model hyperparameter prior distribution")
+        from ray import tune
+
+        from modelforge.potential.utils import shared_config_prior
+
+        prior = {
+            "number_of_atom_features": tune.randint(2, 256),
+            "number_of_modules": tune.randint(3, 8),
+            "number_of_spatial_attention_heads": tune.randint(2, 5),
+            "cutoff": tune.uniform(5, 10),
+            "number_of_radial_basis_functions": tune.randint(8, 32),
+        }
+        prior.update(shared_config_prior())
+        return prior

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -6,8 +6,13 @@ from typing import Dict, Tuple
 from openff.units import unit
 
 from .models import BaseNeuralNetworkPotential, PairListOutputs
-from .utils import Dense, scatter_softmax, NNPInput, SAKERadialSymmetryFunction, \
-    SAKERadialBasisFunction
+from .utils import (
+    Dense,
+    scatter_softmax,
+    NNPInput,
+    SAKERadialSymmetryFunction,
+    SAKERadialBasisFunction,
+)
 import torch
 import torch.nn.functional as F
 
@@ -61,7 +66,7 @@ class SAKENeuralNetworkInput:
     atomic_embedding: torch.Tensor
 
 
-class SAKE(BaseNeuralNetworkPotential):
+class SAKECore(BaseNeuralNetworkPotential):
     """SAKE - spatial attention kinetic networks with E(n) equivariance.
 
     Reference:
@@ -70,14 +75,14 @@ class SAKE(BaseNeuralNetworkPotential):
     """
 
     def __init__(
-            self,
-            max_Z: int = 100,
-            number_of_atom_features: int = 64,
-            number_of_interaction_modules: int = 6,
-            number_of_spatial_attention_heads: int = 4,
-            number_of_radial_basis_functions: int = 50,
-            cutoff: unit.Quantity = 5.0 * unit.angstrom,
-            epsilon: float = 1e-8,
+        self,
+        max_Z: int = 100,
+        number_of_atom_features: int = 64,
+        number_of_interaction_modules: int = 6,
+        number_of_spatial_attention_heads: int = 4,
+        number_of_radial_basis_functions: int = 50,
+        cutoff: unit.Quantity = 5.0 * unit.angstrom,
+        epsilon: float = 1e-8,
     ):
         from .processing import FromAtomToMoleculeReduction
 
@@ -86,8 +91,6 @@ class SAKE(BaseNeuralNetworkPotential):
         self.nr_interaction_blocks = number_of_interaction_modules
         self.nr_heads = number_of_spatial_attention_heads
         self.max_Z = max_Z
-
-        self.only_unique_pairs = False  # NOTE: for pairlist
 
         self.embedding = Dense(max_Z, number_of_atom_features)
         self.energy_layer = nn.Sequential(
@@ -112,20 +115,23 @@ class SAKE(BaseNeuralNetworkPotential):
                 activation=torch.nn.SiLU(),
                 cutoff=cutoff,
                 number_of_radial_basis_functions=number_of_radial_basis_functions,
-                epsilon=epsilon
+                epsilon=epsilon,
             )
             for _ in range(self.nr_interaction_blocks)
         )
 
     def _model_specific_input_preparation(
-            self, data: "NNPInput", pairlist_output: "PairListOutputs"
+        self, data: "NNPInput", pairlist_output: "PairListOutputs"
     ) -> SAKENeuralNetworkInput:
         # Perform atomic embedding
 
         number_of_atoms = data.atomic_numbers.shape[0]
 
         atomic_embedding = self.embedding(
-            F.one_hot(data.atomic_numbers.long(), num_classes=self.max_Z).to(self.embedding.weight.dtype))
+            F.one_hot(data.atomic_numbers.long(), num_classes=self.max_Z).to(
+                self.embedding.weight.dtype
+            )
+        )
 
         nnp_input = SAKENeuralNetworkInput(
             pair_indices=pairlist_output.pair_indices,
@@ -133,7 +139,7 @@ class SAKE(BaseNeuralNetworkPotential):
             positions=data.positions.to(self.embedding.weight.dtype),
             atomic_numbers=data.atomic_numbers,
             atomic_subsystem_indices=data.atomic_subsystem_indices,
-            atomic_embedding=atomic_embedding
+            atomic_embedding=atomic_embedding,
         )
 
         return nnp_input
@@ -154,10 +160,7 @@ class SAKE(BaseNeuralNetworkPotential):
         prior.update(shared_config_prior())
         return prior
 
-    def _forward(
-            self,
-            data: SAKENeuralNetworkInput
-    ):
+    def _forward(self, data: SAKENeuralNetworkInput):
         """
         Compute atomic representations/embeddings.
 
@@ -183,10 +186,7 @@ class SAKE(BaseNeuralNetworkPotential):
         # Use squeeze to remove dimensions of size 1
         E_i = self.energy_layer(h).squeeze(1)
 
-        return {
-            "E_i": E_i,
-            "atomic_subsystem_indices": data.atomic_subsystem_indices
-        }
+        return {"E_i": E_i, "atomic_subsystem_indices": data.atomic_subsystem_indices}
 
 
 class SAKEInteraction(nn.Module):
@@ -196,21 +196,22 @@ class SAKEInteraction(nn.Module):
     Wang and Chodera (2023) Sec. 5 Algorithm 1.
     """
 
-    def __init__(self,
-                 nr_atom_basis: int,
-                 nr_edge_basis: int,
-                 nr_edge_basis_hidden: int,
-                 nr_atom_basis_hidden: int,
-                 nr_atom_basis_spatial_hidden: int,
-                 nr_atom_basis_spatial: int,
-                 nr_atom_basis_velocity: int,
-                 nr_coefficients: int,
-                 nr_heads: int,
-                 activation: nn.Module,
-                 cutoff: float,
-                 number_of_radial_basis_functions: int,
-                 epsilon: float,
-                 ):
+    def __init__(
+        self,
+        nr_atom_basis: int,
+        nr_edge_basis: int,
+        nr_edge_basis_hidden: int,
+        nr_atom_basis_hidden: int,
+        nr_atom_basis_spatial_hidden: int,
+        nr_atom_basis_spatial: int,
+        nr_atom_basis_velocity: int,
+        nr_coefficients: int,
+        nr_heads: int,
+        activation: nn.Module,
+        cutoff: float,
+        number_of_radial_basis_functions: int,
+        epsilon: float,
+    ):
         """
         Parameters
         ----------
@@ -252,39 +253,70 @@ class SAKEInteraction(nn.Module):
         self.radial_symmetry_function_module = SAKERadialSymmetryFunction(
             number_of_radial_basis_functions=number_of_radial_basis_functions,
             max_distance=cutoff,
-            dtype=torch.float32, trainable=True,
-            radial_basis_function=SAKERadialBasisFunction(
-                cutoff, 0.0 * unit.nanometer))
+            dtype=torch.float32,
+            trainable=True,
+            radial_basis_function=SAKERadialBasisFunction(cutoff, 0.0 * unit.nanometer),
+        )
 
         self.node_mlp = nn.Sequential(
-            Dense(self.nr_atom_basis + self.nr_heads * self.nr_edge_basis + self.nr_atom_basis_spatial,
-                  self.nr_atom_basis_hidden, activation=activation),
-            Dense(self.nr_atom_basis_hidden, self.nr_atom_basis, activation=activation)
+            Dense(
+                self.nr_atom_basis
+                + self.nr_heads * self.nr_edge_basis
+                + self.nr_atom_basis_spatial,
+                self.nr_atom_basis_hidden,
+                activation=activation,
+            ),
+            Dense(self.nr_atom_basis_hidden, self.nr_atom_basis, activation=activation),
         )
 
         self.post_norm_mlp = nn.Sequential(
-            Dense(self.nr_coefficients, self.nr_atom_basis_spatial_hidden, activation=activation),
-            Dense(self.nr_atom_basis_spatial_hidden, self.nr_atom_basis_spatial, activation=activation)
+            Dense(
+                self.nr_coefficients,
+                self.nr_atom_basis_spatial_hidden,
+                activation=activation,
+            ),
+            Dense(
+                self.nr_atom_basis_spatial_hidden,
+                self.nr_atom_basis_spatial,
+                activation=activation,
+            ),
         )
 
-        self.edge_mlp_in = nn.Linear(self.nr_atom_basis * 2, number_of_radial_basis_functions)
+        self.edge_mlp_in = nn.Linear(
+            self.nr_atom_basis * 2, number_of_radial_basis_functions
+        )
 
         self.edge_mlp_out = nn.Sequential(
-            Dense(self.nr_atom_basis * 2 + number_of_radial_basis_functions + 1,
-                  self.nr_edge_basis_hidden,
-                  activation=activation),
+            Dense(
+                self.nr_atom_basis * 2 + number_of_radial_basis_functions + 1,
+                self.nr_edge_basis_hidden,
+                activation=activation,
+            ),
             nn.Linear(nr_edge_basis_hidden, nr_edge_basis),
         )
 
-        self.semantic_attention_mlp = Dense(self.nr_edge_basis, self.nr_heads, activation=nn.CELU(alpha=2.0))
-
-        self.velocity_mlp = nn.Sequential(
-            Dense(self.nr_atom_basis, self.nr_atom_basis_velocity, activation=activation),
-            Dense(self.nr_atom_basis_velocity, 1, activation=lambda x: 2.0 * F.sigmoid(x), bias=False)
+        self.semantic_attention_mlp = Dense(
+            self.nr_edge_basis, self.nr_heads, activation=nn.CELU(alpha=2.0)
         )
 
-        self.x_mixing_mlp = Dense(self.nr_heads * self.nr_edge_basis, self.nr_coefficients, bias=False,
-                                  activation=nn.Tanh())
+        self.velocity_mlp = nn.Sequential(
+            Dense(
+                self.nr_atom_basis, self.nr_atom_basis_velocity, activation=activation
+            ),
+            Dense(
+                self.nr_atom_basis_velocity,
+                1,
+                activation=lambda x: 2.0 * F.sigmoid(x),
+                bias=False,
+            ),
+        )
+
+        self.x_mixing_mlp = Dense(
+            self.nr_heads * self.nr_edge_basis,
+            self.nr_coefficients,
+            bias=False,
+            activation=nn.Tanh(),
+        )
 
         self.v_mixing_mlp = Dense(self.nr_coefficients, 1, bias=False)
 
@@ -308,7 +340,9 @@ class SAKEInteraction(nn.Module):
             Intermediate edge features. Shape [nr_pairs, nr_edge_basis].
         """
         h_ij_cat = torch.cat([h_i_by_pair, h_j_by_pair], dim=-1)
-        h_ij_filtered = self.radial_symmetry_function_module(d_ij) * self.edge_mlp_in(h_ij_cat)
+        h_ij_filtered = self.radial_symmetry_function_module(d_ij) * self.edge_mlp_in(
+            h_ij_cat
+        )
         return self.edge_mlp_out(
             torch.cat([h_ij_cat, h_ij_filtered, d_ij.unsqueeze(-1)], dim=-1)
         )
@@ -337,7 +371,7 @@ class SAKEInteraction(nn.Module):
 
     def update_velocity(self, v, h, combinations, idx_i):
         """Update node velocity features for the next layer.
-        
+
         Wang and Chodera (2023) Sec. 5 Eq. 12.
 
         Parameters
@@ -358,12 +392,14 @@ class SAKEInteraction(nn.Module):
         """
         v_ij = self.v_mixing_mlp(combinations.transpose(-1, -2)).squeeze(-1)
         expanded_idx_i = idx_i.view(-1, 1).expand_as(v_ij)
-        dv = torch.zeros_like(v).scatter_reduce(0, expanded_idx_i, v_ij, "mean", include_self=False)
+        dv = torch.zeros_like(v).scatter_reduce(
+            0, expanded_idx_i, v_ij, "mean", include_self=False
+        )
         return self.velocity_mlp(h) * v + dv
 
     def get_combinations(self, h_ij_semantic, dir_ij):
         """Compute linear combinations of mixed edge features.
-        
+
         Summation term in Wang and Chodera (2023) Sec. 4 Eq. 6.
 
         Parameters
@@ -402,9 +438,13 @@ class SAKEInteraction(nn.Module):
         """
         expanded_idx_i = idx_i.view(-1, 1, 1).expand_as(combinations)
         out_shape = (nr_atoms, self.nr_coefficients, combinations.shape[-1])
-        zeros = torch.zeros(out_shape, dtype=combinations.dtype, device=combinations.device)
-        combinations_mean = zeros.scatter_reduce(0, expanded_idx_i, combinations, "mean", include_self=False)
-        combinations_norm_square = (combinations_mean ** 2).sum(dim=-1)
+        zeros = torch.zeros(
+            out_shape, dtype=combinations.dtype, device=combinations.device
+        )
+        combinations_mean = zeros.scatter_reduce(
+            0, expanded_idx_i, combinations, "mean", include_self=False
+        )
+        combinations_norm_square = (combinations_mean**2).sum(dim=-1)
         return self.post_norm_mlp(combinations_norm_square)
 
     def aggregate(self, h_ij_semantic, idx_i, nr_atoms):
@@ -428,7 +468,9 @@ class SAKEInteraction(nn.Module):
         """
         expanded_idx_i = idx_i.view(-1, 1).expand_as(h_ij_semantic)
         out_shape = (nr_atoms, self.nr_heads * self.nr_edge_basis)
-        zeros = torch.zeros(out_shape, dtype=h_ij_semantic.dtype, device=h_ij_semantic.device)
+        zeros = torch.zeros(
+            out_shape, dtype=h_ij_semantic.dtype, device=h_ij_semantic.device
+        )
         return zeros.scatter_add(0, expanded_idx_i, h_ij_semantic)
 
     def get_semantic_attention(self, h_ij_edge, idx_i, idx_j, d_ij, nr_atoms):
@@ -454,20 +496,25 @@ class SAKEInteraction(nn.Module):
         torch.Tensor
             Semantic attention. Shape [nr_pairs, nr_heads * nr_edge_basis].
         """
-        h_ij_att_weights = self.semantic_attention_mlp(h_ij_edge) - (torch.eq(idx_i, idx_j) * 1e5).unsqueeze(-1)
+        h_ij_att_weights = self.semantic_attention_mlp(h_ij_edge) - (
+            torch.eq(idx_i, idx_j) * 1e5
+        ).unsqueeze(-1)
         expanded_idx_i = idx_i.view(-1, 1).expand_as(h_ij_att_weights)
-        combined_ij_att = scatter_softmax(h_ij_att_weights, expanded_idx_i, dim=0, dim_size=nr_atoms,
-                                          device=h_ij_edge.device)
+        combined_ij_att = scatter_softmax(
+            h_ij_att_weights,
+            expanded_idx_i,
+            dim=0,
+            dim_size=nr_atoms,
+            device=h_ij_edge.device,
+        )
         # p: nr_pairs, f: nr_edge_basis, h: nr_heads
-        return torch.reshape(torch.einsum("pf,ph->pfh", h_ij_edge, combined_ij_att),
-                             (len(idx_i), self.nr_edge_basis * self.nr_heads))
+        return torch.reshape(
+            torch.einsum("pf,ph->pfh", h_ij_edge, combined_ij_att),
+            (len(idx_i), self.nr_edge_basis * self.nr_heads),
+        )
 
     def forward(
-            self,
-            h: torch.Tensor,
-            x: torch.Tensor,
-            v: torch.Tensor,
-            pairlist: torch.Tensor
+        self, h: torch.Tensor, x: torch.Tensor, v: torch.Tensor, pairlist: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Compute interaction layer output.
 
@@ -489,16 +536,20 @@ class SAKEInteraction(nn.Module):
         idx_i, idx_j = pairlist
         nr_of_atoms_in_all_systems, _ = x.shape
         r_ij = x[idx_j] - x[idx_i]
-        d_ij = torch.sqrt((r_ij ** 2).sum(dim=1) + self.epsilon)
+        d_ij = torch.sqrt((r_ij**2).sum(dim=1) + self.epsilon)
         dir_ij = r_ij / (d_ij.unsqueeze(-1) + self.epsilon)
 
         h_ij_edge = self.update_edge(h[idx_j], h[idx_i], d_ij)
-        h_ij_semantic = self.get_semantic_attention(h_ij_edge, idx_i, idx_j, d_ij, nr_of_atoms_in_all_systems)
+        h_ij_semantic = self.get_semantic_attention(
+            h_ij_edge, idx_i, idx_j, d_ij, nr_of_atoms_in_all_systems
+        )
         del h_ij_edge
         h_i_semantic = self.aggregate(h_ij_semantic, idx_i, nr_of_atoms_in_all_systems)
         combinations = self.get_combinations(h_ij_semantic, dir_ij)
         del h_ij_semantic
-        h_i_spatial = self.get_spatial_attention(combinations, idx_i, nr_of_atoms_in_all_systems)
+        h_i_spatial = self.get_spatial_attention(
+            combinations, idx_i, nr_of_atoms_in_all_systems
+        )
         h_updated = self.update_node(h, h_i_semantic, h_i_spatial)
         del h, h_i_semantic, h_i_spatial
         v_updated = self.update_velocity(v, h_updated, combinations, idx_i)
@@ -506,3 +557,42 @@ class SAKEInteraction(nn.Module):
         x_updated = x + v_updated
 
         return h_updated, x_updated, v_updated
+
+
+from .models import InputPreparation, NNPInput
+
+
+class SAKE(torch.nn.Module):
+
+    def __init__(
+        self,
+        max_Z: int = 100,
+        number_of_atom_features: int = 64,
+        number_of_interaction_modules: int = 6,
+        number_of_spatial_attention_heads: int = 4,
+        number_of_radial_basis_functions: int = 50,
+        cutoff: unit.Quantity = 5.0 * unit.angstrom,
+        epsilon: float = 1e-8,
+    ):
+        super().__init__()
+        self.sake_core = SAKECore(
+            max_Z=max_Z,
+            number_of_atom_features=number_of_atom_features,
+            number_of_interaction_modules=number_of_interaction_modules,
+            number_of_spatial_attention_heads=number_of_spatial_attention_heads,
+            number_of_radial_basis_functions=number_of_radial_basis_functions,
+            cutoff=cutoff,
+            epsilon=epsilon,
+        )
+
+        self.only_unique_pairs = True  # NOTE: for pairlist
+        self.input_preparation = InputPreparation(cutoff=cutoff)
+
+    def forward(self, data: NNPInput):
+        # perform input checks
+        self.input_preparation._input_checks(data)
+        # prepare the input for the forward pass
+        pairlist_output = self.input_preparation.prepare_inputs(
+            data, self.only_unique_pairs
+        )
+        return self.ani2x_core(data, pairlist_output)

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -389,7 +389,7 @@ class SchNETRepresentation(nn.Module):
         return {"f_ij": f_ij, "f_cutoff": f_cutoff}
 
 
-from typing import NamedTuple
+from typing import NamedTuple, Union
 
 from .models import InputPreparation, NNPInput
 

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -404,7 +404,7 @@ class SchNet(torch.nn.Module):
             The cutoff distance for interactions.
         """
         super().__init__()
-        self.model = SchNetCore(
+        self.schnet_core = SchNetCore(
             max_Z=max_Z,
             number_of_atom_features=number_of_atom_features,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
@@ -422,7 +422,7 @@ class SchNet(torch.nn.Module):
         pairlist_output = self.input_preparation.prepare_inputs(
             data, self.only_unique_pairs
         )
-        return self.model(data, pairlist_output)
+        return self.schnet_core(data, pairlist_output)
 
     def _config_prior(self):
         log.info("Configuring SchNet model hyperparameter prior distribution")

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -124,7 +124,7 @@ class SchNet(BaseNeuralNetworkPotential):
         self.embedding_module = Embedding(max_Z, number_of_atom_features)
 
         # initialize the energy readout
-        from .utils import FromAtomToMoleculeReduction
+        from .processing import FromAtomToMoleculeReduction
 
         self.readout_module = FromAtomToMoleculeReduction()
 

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -156,22 +156,6 @@ class SchNetCore(BaseNeuralNetworkPotential):
             ),
         )
 
-    def _config_prior(self):
-        log.info("Configuring SchNet model hyperparameter prior distribution")
-        from ray import tune
-
-        from modelforge.potential.utils import shared_config_prior
-
-        prior = {
-            "number_of_atom_features": tune.randint(2, 256),
-            "number_of_interaction_modules": tune.randint(1, 5),
-            "cutoff": tune.uniform(5, 10),
-            "number_of_radial_basis_functions": tune.randint(8, 32),
-            "number_of_filters": tune.randint(32, 128),
-            "shared_interactions": tune.choice([True, False]),
-        }
-        prior.update(shared_config_prior())
-        return prior
 
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: "PairListOutputs"
@@ -439,3 +423,20 @@ class SchNet(torch.nn.Module):
             data, self.only_unique_pairs
         )
         return self.model(data, pairlist_output)
+
+    def _config_prior(self):
+        log.info("Configuring SchNet model hyperparameter prior distribution")
+        from ray import tune
+
+        from modelforge.potential.utils import shared_config_prior
+
+        prior = {
+            "number_of_atom_features": tune.randint(2, 256),
+            "number_of_interaction_modules": tune.randint(1, 5),
+            "cutoff": tune.uniform(5, 10),
+            "number_of_radial_basis_functions": tune.randint(8, 32),
+            "number_of_filters": tune.randint(32, 128),
+            "shared_interactions": tune.choice([True, False]),
+        }
+        prior.update(shared_config_prior())
+        return prior

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -21,6 +21,9 @@ class NeuralNetworkData:
     total_charge: torch.Tensor
 
 
+from typing import NamedTuple
+
+
 @dataclass
 class NNPInput:
     """
@@ -99,7 +102,7 @@ class NNPInput:
                 "The size of atomic_subsystem_indices and the first dimension of positions must match"
             )
 
-    def as_namedtuple(self):
+    def as_namedtuple(self) -> NamedTuple:
         """Export the dataclass fields and values as a named tuple."""
 
         from dataclasses import dataclass, fields
@@ -366,7 +369,6 @@ class CosineCutoff(nn.Module):
 
 
 from typing import Dict
-
 
 
 class ShiftedSoftplus(nn.Module):

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -5,6 +5,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 from loguru import logger as log
+from pint import Quantity
+from typing import Union
 
 
 @dataclass
@@ -41,7 +43,7 @@ class NNPInput:
     """
 
     atomic_numbers: torch.Tensor
-    positions: Any  # Temporarily use Any to allow for openff.units.unit.Quantity
+    positions: Union[torch.Tensor, Quantity]
     atomic_subsystem_indices: torch.Tensor
     total_charge: torch.Tensor
 
@@ -68,7 +70,7 @@ class NNPInput:
         self.total_charge = self.total_charge.to(torch.int32)
 
         # Unit conversion for positions
-        if isinstance(self.positions, unit.Quantity):
+        if isinstance(self.positions, Quantity):
             positions = self.positions.to(unit.nanometer).m
             self.positions = torch.tensor(
                 positions, dtype=torch.float32, requires_grad=True
@@ -365,175 +367,6 @@ class CosineCutoff(nn.Module):
 
 from typing import Dict
 
-
-class FromAtomToMoleculeReduction(nn.Module):
-
-    def __init__(self):
-        """
-        Initializes the energy readout module.
-        Performs the reduction of 'per_atom' property to 'per_molecule' property.
-        """
-        super().__init__()
-
-    def forward(self, x: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
-        """
-
-        Parameters
-        ----------
-        x, shape [nr_of_atoms, 1]
-        index, shape [nr_of_atoms]
-
-        Returns
-        -------
-        Tensor, shape [nr_of_moleculs, 1]
-            The total energy tensor.
-        """
-
-        # Perform scatter add operation
-        indices = index.to(torch.int64)
-        total_energy_per_molecule = torch.zeros(
-            len(index.unique()), dtype=x.dtype, device=x.device
-        )
-
-        total_energy_per_molecule = total_energy_per_molecule.scatter_add(0, indices, x)
-
-        # Sum across feature dimension to get final tensor of shape (num_molecules, 1)
-        # total_energy_per_molecule = result.sum(dim=1, keepdim=True)
-        return total_energy_per_molecule
-
-
-from dataclasses import dataclass, field
-from typing import Dict, Iterator
-
-
-@dataclass
-class AtomicSelfEnergies:
-    """
-    AtomicSelfEnergies stores a mapping of atomic elements to their self energies.
-
-    Provides lookup by atomic number or symbol, iteration over the mapping,
-    and utilities to convert between atomic number and symbol.
-
-    Intended as a base class to be extended with specific element-energy values.
-    """
-
-    # We provide a dictionary with {str:float} of element name to atomic self-energy,
-    # which can then be accessed by atomic index or element name
-    energies: Dict[str, float] = field(default_factory=dict)
-    # Example mapping, replace or extend as necessary
-    atomic_number_to_element: Dict[int, str] = field(
-        default_factory=lambda: {
-            1: "H",
-            2: "He",
-            3: "Li",
-            4: "Be",
-            5: "B",
-            6: "C",
-            7: "N",
-            8: "O",
-            9: "F",
-            10: "Ne",
-            11: "Na",
-            12: "Mg",
-            13: "Al",
-            14: "Si",
-            15: "P",
-            16: "S",
-            17: "Cl",
-            18: "Ar",
-            19: "K",
-            20: "Ca",
-            21: "Sc",
-            22: "Ti",
-            23: "V",
-            24: "Cr",
-            25: "Mn",
-            26: "Fe",
-            27: "Co",
-            28: "Ni",
-            29: "Cu",
-            30: "Zn",
-            31: "Ga",
-            32: "Ge",
-            33: "As",
-            34: "Se",
-            35: "Br",
-            36: "Kr",
-            37: "Rb",
-            38: "Sr",
-            39: "Y",
-            40: "Zr",
-            41: "Nb",
-            42: "Mo",
-            43: "Tc",
-            44: "Ru",
-            45: "Rh",
-            46: "Pd",
-            47: "Ag",
-            48: "Cd",
-            49: "In",
-            50: "Sn",
-            # Add more elements as needed
-        }
-    )
-    _ase_tensor_for_indexing = None
-
-    def __getitem__(self, key):
-        if isinstance(key, int):
-            # Convert atomic number to element symbol
-            element = self.atomic_number_to_element.get(key)
-            if element is None:
-                raise KeyError(f"Atomic number {key} not found.")
-            return self.energies.get(element)
-        elif isinstance(key, str):
-            # Directly access by element symbol
-            if key not in self.energies:
-                raise KeyError(f"Element {key} not found.")
-            return self.energies[key]
-        else:
-            raise TypeError(
-                "Key must be an integer (atomic number) or string (element name)."
-            )
-
-    def __iter__(self) -> Iterator[Dict[str, float]]:
-        """Iterate over the energies dictionary."""
-        for element, energy in self.energies.items():
-            atomic_number = self.element_to_atomic_number(element)
-            yield (atomic_number, energy)
-
-    def __len__(self) -> int:
-        """Return the number of element-energy pairs."""
-        return len(self.energies)
-
-    def element_to_atomic_number(self, element: str) -> int:
-        """Return the atomic number for a given element symbol."""
-        for atomic_number, elem_symbol in self.atomic_number_to_element.items():
-            if elem_symbol == element:
-                return atomic_number
-        raise ValueError(f"Element symbol '{element}' not found in the mapping.")
-
-    @property
-    def atomic_number_to_energy(self) -> Dict[int, float]:
-        """Return a dictionary mapping atomic numbers to their energies."""
-        return {
-            atomic_number: self[atomic_number]
-            for atomic_number in self.atomic_number_to_element.keys()
-            if self[atomic_number] is not None
-        }
-
-    @property
-    def ase_tensor_for_indexing(self) -> torch.Tensor:
-        if self._ase_tensor_for_indexing is None:
-            max_z = max(self.atomic_number_to_element.keys()) + 1
-            ase_tensor_for_indexing = torch.zeros(max_z)
-            for idx in self.atomic_number_to_element:
-                if self[idx]:
-                    ase_tensor_for_indexing[idx] = self[idx]
-                else:
-                    ase_tensor_for_indexing[idx] = 0.0
-            self._ase_tensor_for_indexing = ase_tensor_for_indexing
-
-        return self._ase_tensor_for_indexing
 
 
 class ShiftedSoftplus(nn.Module):
@@ -951,32 +784,37 @@ class AniRadialSymmetryFunction(RadialSymmetryFunction):
 
 class SAKERadialSymmetryFunction(RadialSymmetryFunction):
     def calculate_radial_basis_centers(
-            self,
-            _unitless_min_distance,
-            _unitless_max_distance,
-            number_of_radial_basis_functions,
-            dtype,
+        self,
+        _unitless_min_distance,
+        _unitless_max_distance,
+        number_of_radial_basis_functions,
+        dtype,
     ):
         # initialize means and betas according to the default values in PhysNet
         # https://pubs.acs.org/doi/10.1021/acs.jctc.9b00181
 
         start_value = torch.exp(
-            torch.scalar_tensor(-_unitless_max_distance + _unitless_min_distance, dtype=dtype)
+            torch.scalar_tensor(
+                -_unitless_max_distance + _unitless_min_distance, dtype=dtype
+            )
         )
-        centers = torch.linspace(start_value, 1, number_of_radial_basis_functions, dtype=dtype)
+        centers = torch.linspace(
+            start_value, 1, number_of_radial_basis_functions, dtype=dtype
+        )
         return centers
 
     def calculate_radial_scale_factor(
-            self,
-            _unitless_min_distance,
-            _unitless_max_distance,
-            number_of_radial_basis_functions,
+        self,
+        _unitless_min_distance,
+        _unitless_max_distance,
+        number_of_radial_basis_functions,
     ):
         start_value = torch.exp(
             torch.scalar_tensor(-_unitless_max_distance + _unitless_min_distance)
         )
         radial_scale_factor = torch.tensor(
-            [(2 / number_of_radial_basis_functions * (1 - start_value)) ** -2] * number_of_radial_basis_functions
+            [(2 / number_of_radial_basis_functions * (1 - start_value)) ** -2]
+            * number_of_radial_basis_functions
         )
         return radial_scale_factor
 
@@ -986,20 +824,26 @@ class SAKERadialBasisFunction(RadialBasisFunction):
     def __init__(self, max_distance, min_distance):
         super().__init__()
         self._unitless_min_distance = min_distance.to(unit.nanometer).m
-        self.alpha = (5.0 * unit.nanometer / (max_distance - min_distance)).to_base_units().m  # check units
+        self.alpha = (
+            (5.0 * unit.nanometer / (max_distance - min_distance)).to_base_units().m
+        )  # check units
 
     def compute(
-            self,
-            distances: torch.Tensor,
-            centers: torch.Tensor,
-            scale_factors: torch.Tensor,
+        self,
+        distances: torch.Tensor,
+        centers: torch.Tensor,
+        scale_factors: torch.Tensor,
     ) -> torch.Tensor:
         return torch.exp(
-            -scale_factors *
-            (torch.exp(
-                self.alpha *
-                (-distances.unsqueeze(-1) + self._unitless_min_distance))
-             - centers) ** 2
+            -scale_factors
+            * (
+                torch.exp(
+                    self.alpha
+                    * (-distances.unsqueeze(-1) + self._unitless_min_distance)
+                )
+                - centers
+            )
+            ** 2
         )
 
 
@@ -1103,7 +947,11 @@ def neighbor_list_with_cutoff(
 
 
 def scatter_softmax(
-        src: torch.Tensor, index: torch.Tensor, dim: int, dim_size: Optional[int] = None, device: Optional[torch.device] = None
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int,
+    dim_size: Optional[int] = None,
+    device: Optional[torch.device] = None,
 ) -> torch.Tensor:
     """
     Softmax operation over all values in :attr:`src` tensor that share indices
@@ -1130,28 +978,33 @@ def scatter_softmax(
     Adapted from: https://github.com/rusty1s/pytorch_scatter/blob/c31915e1c4ceb27b2e7248d21576f685dc45dd01/torch_scatter/composite/softmax.py
     """
     if not torch.is_floating_point(src):
-        raise ValueError('`scatter_softmax` can only be computed over tensors '
-                         'with floating point data types.')
+        raise ValueError(
+            "`scatter_softmax` can only be computed over tensors "
+            "with floating point data types."
+        )
 
     assert dim >= 0, f"dim must be non-negative, got {dim}"
-    assert dim < src.dim(), f"dim must be less than the number of dimensions of src {src.dim()}, got {dim}"
+    assert (
+        dim < src.dim()
+    ), f"dim must be less than the number of dimensions of src {src.dim()}, got {dim}"
 
     out_shape = [
-        other_dim_size
-        if (other_dim != dim)
-        else dim_size
-        for (other_dim, other_dim_size)
-        in enumerate(src.shape)
+        other_dim_size if (other_dim != dim) else dim_size
+        for (other_dim, other_dim_size) in enumerate(src.shape)
     ]
 
     zeros = torch.zeros(out_shape, dtype=src.dtype, device=device)
-    max_value_per_index = zeros.scatter_reduce(dim, index, src, "amax", include_self=False)
+    max_value_per_index = zeros.scatter_reduce(
+        dim, index, src, "amax", include_self=False
+    )
     max_per_src_element = max_value_per_index.gather(dim, index)
 
     recentered_scores = src - max_per_src_element
     recentered_scores_exp = recentered_scores.exp()
 
-    sum_per_index = torch.zeros(out_shape, dtype=src.dtype, device=device).scatter_add(dim, index, recentered_scores_exp)
+    sum_per_index = torch.zeros(out_shape, dtype=src.dtype, device=device).scatter_add(
+        dim, index, recentered_scores_exp
+    )
     normalizing_constants = sum_per_index.gather(dim, index)
 
     return recentered_scores_exp.div(normalizing_constants)

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -309,10 +309,14 @@ def test_representation(setup_methane):
 
     mf_model = ANI2x()
     # perform input checks
-    mf_model._input_checks(mf_input)
+    mf_model.input_preparation._input_checks(mf_input)
     # prepare the input for the forward pass
-    data = mf_model.prepare_inputs(mf_input, True)
-    representation = mf_model.ani_representation_module(data)
+    pairlist_output = mf_model.input_preparation.prepare_inputs(mf_input, True)
+    nnp_input = mf_model.ani2x_core._model_specific_input_preparation(
+        mf_input, pairlist_output
+    )
+    representation = mf_model.ani2x_core.ani_representation_module(nnp_input)
+
     tochani_aev = tochani_aev.squeeze(0)
 
     # test for equivalenc

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -71,24 +71,36 @@ def test_painn_interaction_equivariance(methane):
     )
 
     # prepare reference and perturbed inputs
-    reference_prepared_input = painn.prepare_inputs(
+    pairlist_output = painn.input_preparation.prepare_inputs(
         methane_input, only_unique_pairs=False
     )
+    reference_prepared_input = painn.painn_core._model_specific_input_preparation(
+        methane_input, pairlist_output
+    )
+
     reference_d_ij = reference_prepared_input.d_ij
     reference_r_ij = reference_prepared_input.r_ij
     reference_dir_ij = reference_r_ij / reference_d_ij
-    reference_f_ij = painn.representation_module.radial_symmetry_function_module(
-        reference_d_ij
+    reference_f_ij = (
+        painn.painn_core.representation_module.radial_symmetry_function_module(
+            reference_d_ij
+        )
     )
 
-    perturbed_prepared_input = painn.prepare_inputs(
+    pairlist_output = painn.input_preparation.prepare_inputs(
         perturbed_methane_input, only_unique_pairs=False
     )
+    perturbed_prepared_input = painn.painn_core._model_specific_input_preparation(
+        perturbed_methane_input, pairlist_output
+    )
+
     perturbed_d_ij = perturbed_prepared_input.d_ij
     perturbed_r_ij = perturbed_prepared_input.r_ij
     perturbed_dir_ij = perturbed_r_ij / perturbed_d_ij
-    perturbed_f_ij = painn.representation_module.radial_symmetry_function_module(
-        perturbed_d_ij
+    perturbed_f_ij = (
+        painn.painn_core.representation_module.radial_symmetry_function_module(
+            perturbed_d_ij
+        )
     )
 
     # check that the invariant properties are preserved
@@ -108,8 +120,12 @@ def test_painn_interaction_equivariance(methane):
 
     # Test that the interaction block is equivariant
     # First we test the transformed inputs
-    reference_tranformed_inputs = painn.representation_module(reference_prepared_input)
-    perturbed_tranformed_inputs = painn.representation_module(perturbed_prepared_input)
+    reference_tranformed_inputs = painn.painn_core.representation_module(
+        reference_prepared_input
+    )
+    perturbed_tranformed_inputs = painn.painn_core.representation_module(
+        perturbed_prepared_input
+    )
 
     assert torch.allclose(
         reference_tranformed_inputs["q"], perturbed_tranformed_inputs["q"]
@@ -118,7 +134,7 @@ def test_painn_interaction_equivariance(methane):
         reference_tranformed_inputs["mu"], perturbed_tranformed_inputs["mu"]
     )
 
-    painn_interaction = painn.interaction_modules[0]
+    painn_interaction = painn.painn_core.interaction_modules[0]
 
     reference_r = painn_interaction(
         reference_tranformed_inputs["q"],
@@ -143,10 +159,10 @@ def test_painn_interaction_equivariance(methane):
     assert torch.allclose(reference_q, perturbed_q)
     assert not torch.allclose(reference_mu, perturbed_mu)
 
-    mixed_reference_q, mixed_reference_mu = painn.mixing_modules[0](
+    mixed_reference_q, mixed_reference_mu = painn.painn_core.mixing_modules[0](
         reference_q, reference_mu
     )
-    mixed_perturbed_q, mixed_perturbed_mu = painn.mixing_modules[0](
+    mixed_perturbed_q, mixed_perturbed_mu = painn.painn_core.mixing_modules[0](
         perturbed_q, perturbed_mu
     )
 

--- a/modelforge/tests/test_sake.py
+++ b/modelforge/tests/test_sake.py
@@ -115,17 +115,25 @@ def test_sake_interaction_equivariance(h_atol, eq_atol):
     perturbed_methane_input.positions = torch.matmul(methane.positions, rotation_matrix)
 
     # prepare reference and perturbed inputs
-    reference_prepared_input = sake.prepare_inputs(methane, only_unique_pairs=False)
+    pairlist_output = sake.input_preparation.prepare_inputs(
+        methane, only_unique_pairs=False
+    )
+    reference_prepared_input = sake.sake_core._model_specific_input_preparation(
+        methane, pairlist_output
+    )
     reference_v_torch = torch.randn_like(reference_prepared_input.positions)
 
-    perturbed_prepared_input = sake.prepare_inputs(perturbed_methane_input)
+    pairlist_output = sake.input_preparation.prepare_inputs(perturbed_methane_input)
+    perturbed_prepared_input = sake.sake_core._model_specific_input_preparation(
+        perturbed_methane_input, pairlist_output
+    )
     perturbed_v_torch = torch.matmul(reference_v_torch, rotation_matrix)
 
     (
         reference_h_out_torch,
         reference_x_out_torch,
         reference_v_out_torch,
-    ) = sake.interaction_modules[0](
+    ) = sake.sake_core.interaction_modules[0](
         reference_prepared_input.atomic_embedding,
         reference_prepared_input.positions,
         reference_v_torch,
@@ -135,7 +143,7 @@ def test_sake_interaction_equivariance(h_atol, eq_atol):
         perturbed_h_out_torch,
         perturbed_x_out_torch,
         perturbed_v_out_torch,
-    ) = sake.interaction_modules[0](
+    ) = sake.sake_core.interaction_modules[0](
         perturbed_prepared_input.atomic_embedding,
         perturbed_prepared_input.positions,
         perturbed_v_torch,

--- a/modelforge/tests/test_sake.py
+++ b/modelforge/tests/test_sake.py
@@ -46,12 +46,13 @@ def test_sake_forward():
     nr_of_mols = methane.atomic_subsystem_indices.unique().shape[0]
 
     assert (
-            len(energy) == nr_of_mols
+        len(energy) == nr_of_mols
     )  # Assuming energy is calculated per sample in the batch
 
 
 def test_sake_interaction_forward():
     from modelforge.potential.utils import SAKERadialSymmetryFunction
+
     nr_atoms = 41
     nr_atom_basis = 47
     geometry_basis = 3
@@ -68,7 +69,7 @@ def test_sake_interaction_forward():
         activation=torch.nn.ReLU(),
         cutoff=5.0 * unit.angstrom,
         number_of_radial_basis_functions=53,
-        epsilon=1e-5
+        epsilon=1e-5,
     )
     h = torch.randn(nr_atoms, nr_atom_basis)
     x = torch.randn(nr_atoms, geometry_basis)
@@ -111,9 +112,7 @@ def test_sake_interaction_equivariance(h_atol, eq_atol):
     # get methane input
     methane = next(iter(dataset.train_dataloader())).nnp_input
     perturbed_methane_input = replace(methane)
-    perturbed_methane_input.positions = torch.matmul(
-        methane.positions, rotation_matrix
-    )
+    perturbed_methane_input.positions = torch.matmul(methane.positions, rotation_matrix)
 
     # prepare reference and perturbed inputs
     reference_prepared_input = sake.prepare_inputs(methane, only_unique_pairs=False)
@@ -122,23 +121,39 @@ def test_sake_interaction_equivariance(h_atol, eq_atol):
     perturbed_prepared_input = sake.prepare_inputs(perturbed_methane_input)
     perturbed_v_torch = torch.matmul(reference_v_torch, rotation_matrix)
 
-    reference_h_out_torch, reference_x_out_torch, reference_v_out_torch = sake.interaction_modules[0](
+    (
+        reference_h_out_torch,
+        reference_x_out_torch,
+        reference_v_out_torch,
+    ) = sake.interaction_modules[0](
         reference_prepared_input.atomic_embedding,
         reference_prepared_input.positions,
         reference_v_torch,
-        reference_prepared_input.pair_indices
+        reference_prepared_input.pair_indices,
     )
-    perturbed_h_out_torch, perturbed_x_out_torch, perturbed_v_out_torch = sake.interaction_modules[0](
+    (
+        perturbed_h_out_torch,
+        perturbed_x_out_torch,
+        perturbed_v_out_torch,
+    ) = sake.interaction_modules[0](
         perturbed_prepared_input.atomic_embedding,
         perturbed_prepared_input.positions,
         perturbed_v_torch,
-        perturbed_prepared_input.pair_indices
+        perturbed_prepared_input.pair_indices,
     )
 
     # x and v are equivariant, h is invariant
     assert torch.allclose(reference_h_out_torch, perturbed_h_out_torch, atol=h_atol)
-    assert torch.allclose(torch.matmul(reference_x_out_torch, rotation_matrix), perturbed_x_out_torch, atol=eq_atol)
-    assert torch.allclose(torch.matmul(reference_v_out_torch, rotation_matrix), perturbed_v_out_torch, atol=eq_atol)
+    assert torch.allclose(
+        torch.matmul(reference_x_out_torch, rotation_matrix),
+        perturbed_x_out_torch,
+        atol=eq_atol,
+    )
+    assert torch.allclose(
+        torch.matmul(reference_v_out_torch, rotation_matrix),
+        perturbed_v_out_torch,
+        atol=eq_atol,
+    )
 
 
 def make_reference_equivalent_sake_interaction(out_features, hidden_features, nr_heads):
@@ -159,15 +174,16 @@ def make_reference_equivalent_sake_interaction(out_features, hidden_features, nr
         activation=torch.nn.SiLU(),
         cutoff=cutoff,
         number_of_radial_basis_functions=50,
-        epsilon=1e-5
+        epsilon=1e-5,
     )
 
     # Define the reference layer
-    ref_sake_interaction = reference_sake.layers.DenseSAKELayer(out_features=out_features,
-                                                                hidden_features=hidden_features,
-                                                                n_heads=nr_heads,
-                                                                cutoff=None,
-                                                                )
+    ref_sake_interaction = reference_sake.layers.DenseSAKELayer(
+        out_features=out_features,
+        hidden_features=hidden_features,
+        n_heads=nr_heads,
+        cutoff=None,
+    )
 
     return mf_sake_block, ref_sake_interaction
 
@@ -179,13 +195,19 @@ def make_equivalent_pairlist_mask(key, nr_atoms, nr_pairs, include_self_pairs):
     non_self_pairs_jax = jnp.array(onp.array(non_self_pairs))
     if include_self_pairs:
         nr_pairs_choose = nr_pairs - nr_atoms
-        assert nr_pairs_choose >= 0, "Number of pairs must be greater than or equal to the number of atoms if " \
-                                     "include_self_pairs is True."
+        assert nr_pairs_choose >= 0, (
+            "Number of pairs must be greater than or equal to the number of atoms if "
+            "include_self_pairs is True."
+        )
     else:
         nr_pairs_choose = nr_pairs
-    pairlist_jax = jax.random.choice(key, non_self_pairs_jax, (nr_pairs_choose,), replace=False).T
+    pairlist_jax = jax.random.choice(
+        key, non_self_pairs_jax, (nr_pairs_choose,), replace=False
+    ).T
     if include_self_pairs:
-        pairlist_jax = jnp.concatenate([pairlist_jax, jnp.array(onp.array(all_pairs[self_pairs].T))], axis=1)
+        pairlist_jax = jnp.concatenate(
+            [pairlist_jax, jnp.array(onp.array(all_pairs[self_pairs].T))], axis=1
+        )
     pairlist = torch.tensor(onp.array(pairlist_jax), dtype=torch.int64)
     mask = jnp.zeros((nr_atoms, nr_atoms))
     for i in range(nr_pairs):
@@ -206,10 +228,13 @@ def test_sake_layer_against_reference(include_self_pairs, v_is_none):
     key = jax.random.PRNGKey(1884)
     torch.manual_seed(1884)
 
-    pairlist, mask = make_equivalent_pairlist_mask(key, nr_atoms, nr_pairs, include_self_pairs=include_self_pairs)
+    pairlist, mask = make_equivalent_pairlist_mask(
+        key, nr_atoms, nr_pairs, include_self_pairs=include_self_pairs
+    )
 
-    mf_sake_block, ref_sake_interaction = make_reference_equivalent_sake_interaction(out_features, hidden_features,
-                                                                                     nr_heads)
+    mf_sake_block, ref_sake_interaction = make_reference_equivalent_sake_interaction(
+        out_features, hidden_features, nr_heads
+    )
     # Generate random input data in JAX
     h_key, x_key, v_key, init_key = jax.random.split(key, 4)
     h_jax = jax.random.normal(h_key, (nr_atoms, nr_atom_basis))
@@ -227,55 +252,101 @@ def test_sake_layer_against_reference(include_self_pairs, v_is_none):
 
     variables = ref_sake_interaction.init(init_key, h_jax, x_jax, v_jax, mask)
     layer = variables["params"]
-    layer["edge_model"]["kernel"]["betas"] = mf_sake_block.radial_symmetry_function_module.radial_scale_factor.detach().numpy().T
-    layer["edge_model"]["kernel"]["means"] = mf_sake_block.radial_symmetry_function_module.radial_basis_centers.detach().numpy().T
-    layer["edge_model"]["mlp_in"]["bias"] = mf_sake_block.edge_mlp_in.bias.detach().numpy().T
-    layer["edge_model"]["mlp_in"]["kernel"] = mf_sake_block.edge_mlp_in.weight.detach().numpy().T
-    layer["edge_model"]["mlp_out"]["layers_0"]["bias"] = mf_sake_block.edge_mlp_out[
-        0].bias.detach().numpy().T
-    layer["edge_model"]["mlp_out"]["layers_0"]["kernel"] = mf_sake_block.edge_mlp_out[
-        0].weight.detach().numpy().T
-    layer["edge_model"]["mlp_out"]["layers_2"]["bias"] = mf_sake_block.edge_mlp_out[
-        1].bias.detach().numpy().T
-    layer["edge_model"]["mlp_out"]["layers_2"]["kernel"] = mf_sake_block.edge_mlp_out[
-        1].weight.detach().numpy().T
-    layer["node_mlp"]["layers_0"]["bias"] = mf_sake_block.node_mlp[0].bias.detach().numpy().T
-    layer["node_mlp"]["layers_0"]["kernel"] = mf_sake_block.node_mlp[0].weight.detach().numpy().T
-    layer["node_mlp"]["layers_2"]["bias"] = mf_sake_block.node_mlp[1].bias.detach().numpy().T
-    layer["node_mlp"]["layers_2"]["kernel"] = mf_sake_block.node_mlp[1].weight.detach().numpy().T
-    layer["post_norm_mlp"]["layers_0"]["bias"] = mf_sake_block.post_norm_mlp[
-        0].bias.detach().numpy().T
-    layer["post_norm_mlp"]["layers_0"]["kernel"] = mf_sake_block.post_norm_mlp[
-        0].weight.detach().numpy().T
-    layer["post_norm_mlp"]["layers_2"]["bias"] = mf_sake_block.post_norm_mlp[
-        1].bias.detach().numpy().T
-    layer["post_norm_mlp"]["layers_2"]["kernel"] = mf_sake_block.post_norm_mlp[
-        1].weight.detach().numpy().T
-    layer["semantic_attention_mlp"]["layers_0"][
-        "bias"] = mf_sake_block.semantic_attention_mlp.bias.detach().numpy().T
-    layer["semantic_attention_mlp"]["layers_0"][
-        "kernel"] = mf_sake_block.semantic_attention_mlp.weight.detach().numpy().T
+    layer["edge_model"]["kernel"]["betas"] = (
+        mf_sake_block.radial_symmetry_function_module.radial_scale_factor.detach()
+        .numpy()
+        .T
+    )
+    layer["edge_model"]["kernel"]["means"] = (
+        mf_sake_block.radial_symmetry_function_module.radial_basis_centers.detach()
+        .numpy()
+        .T
+    )
+    layer["edge_model"]["mlp_in"]["bias"] = (
+        mf_sake_block.edge_mlp_in.bias.detach().numpy().T
+    )
+    layer["edge_model"]["mlp_in"]["kernel"] = (
+        mf_sake_block.edge_mlp_in.weight.detach().numpy().T
+    )
+    layer["edge_model"]["mlp_out"]["layers_0"]["bias"] = (
+        mf_sake_block.edge_mlp_out[0].bias.detach().numpy().T
+    )
+    layer["edge_model"]["mlp_out"]["layers_0"]["kernel"] = (
+        mf_sake_block.edge_mlp_out[0].weight.detach().numpy().T
+    )
+    layer["edge_model"]["mlp_out"]["layers_2"]["bias"] = (
+        mf_sake_block.edge_mlp_out[1].bias.detach().numpy().T
+    )
+    layer["edge_model"]["mlp_out"]["layers_2"]["kernel"] = (
+        mf_sake_block.edge_mlp_out[1].weight.detach().numpy().T
+    )
+    layer["node_mlp"]["layers_0"]["bias"] = (
+        mf_sake_block.node_mlp[0].bias.detach().numpy().T
+    )
+    layer["node_mlp"]["layers_0"]["kernel"] = (
+        mf_sake_block.node_mlp[0].weight.detach().numpy().T
+    )
+    layer["node_mlp"]["layers_2"]["bias"] = (
+        mf_sake_block.node_mlp[1].bias.detach().numpy().T
+    )
+    layer["node_mlp"]["layers_2"]["kernel"] = (
+        mf_sake_block.node_mlp[1].weight.detach().numpy().T
+    )
+    layer["post_norm_mlp"]["layers_0"]["bias"] = (
+        mf_sake_block.post_norm_mlp[0].bias.detach().numpy().T
+    )
+    layer["post_norm_mlp"]["layers_0"]["kernel"] = (
+        mf_sake_block.post_norm_mlp[0].weight.detach().numpy().T
+    )
+    layer["post_norm_mlp"]["layers_2"]["bias"] = (
+        mf_sake_block.post_norm_mlp[1].bias.detach().numpy().T
+    )
+    layer["post_norm_mlp"]["layers_2"]["kernel"] = (
+        mf_sake_block.post_norm_mlp[1].weight.detach().numpy().T
+    )
+    layer["semantic_attention_mlp"]["layers_0"]["bias"] = (
+        mf_sake_block.semantic_attention_mlp.bias.detach().numpy().T
+    )
+    layer["semantic_attention_mlp"]["layers_0"]["kernel"] = (
+        mf_sake_block.semantic_attention_mlp.weight.detach().numpy().T
+    )
     if not v_is_none:
-        layer["velocity_mlp"]["layers_0"]["kernel"] = mf_sake_block.velocity_mlp[0].weight.detach().numpy().T
-        layer["velocity_mlp"]["layers_0"]["bias"] = mf_sake_block.velocity_mlp[0].bias.detach().numpy().T
-        layer["velocity_mlp"]["layers_2"]["kernel"] = mf_sake_block.velocity_mlp[1].weight.detach().numpy().T
+        layer["velocity_mlp"]["layers_0"]["kernel"] = (
+            mf_sake_block.velocity_mlp[0].weight.detach().numpy().T
+        )
+        layer["velocity_mlp"]["layers_0"]["bias"] = (
+            mf_sake_block.velocity_mlp[0].bias.detach().numpy().T
+        )
+        layer["velocity_mlp"]["layers_2"]["kernel"] = (
+            mf_sake_block.velocity_mlp[1].weight.detach().numpy().T
+        )
     layer["v_mixing"]["kernel"] = mf_sake_block.v_mixing_mlp.weight.detach().numpy().T
-    layer["x_mixing"]["layers_0"]["kernel"] = mf_sake_block.x_mixing_mlp.weight.detach().numpy().T
+    layer["x_mixing"]["layers_0"]["kernel"] = (
+        mf_sake_block.x_mixing_mlp.weight.detach().numpy().T
+    )
 
     mf_h, mf_x, mf_v = mf_sake_block(h, x, v, pairlist)
 
-    ref_h, ref_x, ref_v = ref_sake_interaction.apply(variables, h_jax, x_jax, v_jax, mask)
+    ref_h, ref_x, ref_v = ref_sake_interaction.apply(
+        variables, h_jax, x_jax, v_jax, mask
+    )
 
     ref_h_is_nan = torch.from_numpy(onp.isnan(ref_h))
     ref_x_is_nan = torch.from_numpy(onp.isnan(ref_x))
     ref_v_is_nan = torch.from_numpy(onp.isnan(ref_v))
 
-    assert torch.allclose(torch.nan_to_num(mf_h, nan=0.0) * ~ref_h_is_nan,
-                          torch.nan_to_num(torch.from_numpy(onp.array(ref_h)), nan=0.0))
-    assert torch.allclose(torch.nan_to_num(mf_x, nan=0.0) * ~ref_x_is_nan,
-                          torch.nan_to_num(torch.from_numpy(onp.array(ref_x)), nan=0.0))
-    assert torch.allclose(torch.nan_to_num(mf_v, nan=0.0) * ~ref_v_is_nan,
-                          torch.nan_to_num(torch.from_numpy(onp.array(ref_v)), nan=0.0))
+    assert torch.allclose(
+        torch.nan_to_num(mf_h, nan=0.0) * ~ref_h_is_nan,
+        torch.nan_to_num(torch.from_numpy(onp.array(ref_h)), nan=0.0),
+    )
+    assert torch.allclose(
+        torch.nan_to_num(mf_x, nan=0.0) * ~ref_x_is_nan,
+        torch.nan_to_num(torch.from_numpy(onp.array(ref_x)), nan=0.0),
+    )
+    assert torch.allclose(
+        torch.nan_to_num(mf_v, nan=0.0) * ~ref_v_is_nan,
+        torch.nan_to_num(torch.from_numpy(onp.array(ref_v)), nan=0.0),
+    )
 
 
 def test_sake_model_against_reference():
@@ -294,7 +365,7 @@ def test_sake_model_against_reference():
         number_of_spatial_attention_heads=nr_heads,
         cutoff=cutoff,
         number_of_radial_basis_functions=50,
-        epsilon=1e-8
+        epsilon=1e-8,
     )
 
     ref_sake = reference_sake.models.DenseSAKEModel(
@@ -302,7 +373,7 @@ def test_sake_model_against_reference():
         out_features=1,
         depth=nr_interaction_blocks,
         n_heads=nr_heads,
-        cutoff=None
+        cutoff=None,
     )
 
     from modelforge.dataset import QM9Dataset
@@ -317,59 +388,124 @@ def test_sake_model_against_reference():
     dataset.prepare_data(remove_self_energies=True, normalize=False)
     # get methane input
     methane = next(iter(dataset.train_dataloader())).nnp_input
-    prepared_methane = mf_sake.prepare_inputs(methane)
+    pairlist_output = mf_sake.input_preparation.prepare_inputs(methane)
+    prepared_methane = mf_sake.sake_core._model_specific_input_preparation(
+        methane, pairlist_output
+    )
 
-    mask = jnp.zeros((prepared_methane.number_of_atoms, prepared_methane.number_of_atoms))
+    mask = jnp.zeros(
+        (prepared_methane.number_of_atoms, prepared_methane.number_of_atoms)
+    )
     for i in range(prepared_methane.pair_indices.shape[1]):
-        mask = mask.at[prepared_methane.pair_indices[0, i].item(), prepared_methane.pair_indices[1, i].item()].set(1)
+        mask = mask.at[
+            prepared_methane.pair_indices[0, i].item(),
+            prepared_methane.pair_indices[1, i].item(),
+        ].set(1)
 
     h = jax.nn.one_hot(prepared_methane.atomic_numbers.detach().numpy(), max_Z)
     x = prepared_methane.positions.detach().numpy()
     variables = ref_sake.init(key, h, x, mask=mask)
 
-    variables["params"]["embedding_in"]["kernel"] = mf_sake.embedding.weight.detach().numpy().T
-    variables["params"]["embedding_in"]["bias"] = mf_sake.embedding.bias.detach().numpy().T
-    variables["params"]["embedding_out"]["layers_0"]["kernel"] = mf_sake.energy_layer[0].weight.detach().numpy().T
-    variables["params"]["embedding_out"]["layers_0"]["bias"] = mf_sake.energy_layer[0].bias.detach().numpy().T
-    variables["params"]["embedding_out"]["layers_2"]["kernel"] = mf_sake.energy_layer[2].weight.detach().numpy().T
-    variables["params"]["embedding_out"]["layers_2"]["bias"] = mf_sake.energy_layer[2].bias.detach().numpy().T
-    layers = ((layer_name, variables["params"][layer_name]) for layer_name in variables["params"].keys() if
-              layer_name.startswith("d"))
-    for (layer_name, layer), mf_sake_block in zip(layers, mf_sake.interaction_modules.children()):
-        layer["edge_model"]["kernel"]["betas"] = mf_sake_block.radial_symmetry_function_module.radial_scale_factor.detach().numpy().T
-        layer["edge_model"]["kernel"]["means"] = mf_sake_block.radial_symmetry_function_module.radial_basis_centers.detach().numpy().T
-        layer["edge_model"]["mlp_in"]["bias"] = mf_sake_block.edge_mlp_in.bias.detach().numpy().T
-        layer["edge_model"]["mlp_in"]["kernel"] = mf_sake_block.edge_mlp_in.weight.detach().numpy().T
-        layer["edge_model"]["mlp_out"]["layers_0"]["bias"] = mf_sake_block.edge_mlp_out[
-            0].bias.detach().numpy().T
-        layer["edge_model"]["mlp_out"]["layers_0"]["kernel"] = mf_sake_block.edge_mlp_out[
-            0].weight.detach().numpy().T
-        layer["edge_model"]["mlp_out"]["layers_2"]["bias"] = mf_sake_block.edge_mlp_out[
-            1].bias.detach().numpy().T
-        layer["edge_model"]["mlp_out"]["layers_2"]["kernel"] = mf_sake_block.edge_mlp_out[
-            1].weight.detach().numpy().T
-        layer["node_mlp"]["layers_0"]["bias"] = mf_sake_block.node_mlp[0].bias.detach().numpy().T
-        layer["node_mlp"]["layers_0"]["kernel"] = mf_sake_block.node_mlp[0].weight.detach().numpy().T
-        layer["node_mlp"]["layers_2"]["bias"] = mf_sake_block.node_mlp[1].bias.detach().numpy().T
-        layer["node_mlp"]["layers_2"]["kernel"] = mf_sake_block.node_mlp[1].weight.detach().numpy().T
-        layer["post_norm_mlp"]["layers_0"]["bias"] = mf_sake_block.post_norm_mlp[
-            0].bias.detach().numpy().T
-        layer["post_norm_mlp"]["layers_0"]["kernel"] = mf_sake_block.post_norm_mlp[
-            0].weight.detach().numpy().T
-        layer["post_norm_mlp"]["layers_2"]["bias"] = mf_sake_block.post_norm_mlp[
-            1].bias.detach().numpy().T
-        layer["post_norm_mlp"]["layers_2"]["kernel"] = mf_sake_block.post_norm_mlp[
-            1].weight.detach().numpy().T
-        layer["semantic_attention_mlp"]["layers_0"][
-            "bias"] = mf_sake_block.semantic_attention_mlp.bias.detach().numpy().T
-        layer["semantic_attention_mlp"]["layers_0"][
-            "kernel"] = mf_sake_block.semantic_attention_mlp.weight.detach().numpy().T
+    variables["params"]["embedding_in"]["kernel"] = (
+        mf_sake.sake_core.embedding.weight.detach().numpy().T
+    )
+    variables["params"]["embedding_in"]["bias"] = (
+        mf_sake.sake_core.embedding.bias.detach().numpy().T
+    )
+    variables["params"]["embedding_out"]["layers_0"]["kernel"] = (
+        mf_sake.sake_core.energy_layer[0].weight.detach().numpy().T
+    )
+    variables["params"]["embedding_out"]["layers_0"]["bias"] = (
+        mf_sake.sake_core.energy_layer[0].bias.detach().numpy().T
+    )
+    variables["params"]["embedding_out"]["layers_2"]["kernel"] = (
+        mf_sake.sake_core.energy_layer[2].weight.detach().numpy().T
+    )
+    variables["params"]["embedding_out"]["layers_2"]["bias"] = (
+        mf_sake.sake_core.energy_layer[2].bias.detach().numpy().T
+    )
+    layers = (
+        (layer_name, variables["params"][layer_name])
+        for layer_name in variables["params"].keys()
+        if layer_name.startswith("d")
+    )
+    for (layer_name, layer), mf_sake_block in zip(
+        layers, mf_sake.sake_core.interaction_modules.children()
+    ):
+        layer["edge_model"]["kernel"]["betas"] = (
+            mf_sake_block.radial_symmetry_function_module.radial_scale_factor.detach()
+            .numpy()
+            .T
+        )
+        layer["edge_model"]["kernel"]["means"] = (
+            mf_sake_block.radial_symmetry_function_module.radial_basis_centers.detach()
+            .numpy()
+            .T
+        )
+        layer["edge_model"]["mlp_in"]["bias"] = (
+            mf_sake_block.edge_mlp_in.bias.detach().numpy().T
+        )
+        layer["edge_model"]["mlp_in"]["kernel"] = (
+            mf_sake_block.edge_mlp_in.weight.detach().numpy().T
+        )
+        layer["edge_model"]["mlp_out"]["layers_0"]["bias"] = (
+            mf_sake_block.edge_mlp_out[0].bias.detach().numpy().T
+        )
+        layer["edge_model"]["mlp_out"]["layers_0"]["kernel"] = (
+            mf_sake_block.edge_mlp_out[0].weight.detach().numpy().T
+        )
+        layer["edge_model"]["mlp_out"]["layers_2"]["bias"] = (
+            mf_sake_block.edge_mlp_out[1].bias.detach().numpy().T
+        )
+        layer["edge_model"]["mlp_out"]["layers_2"]["kernel"] = (
+            mf_sake_block.edge_mlp_out[1].weight.detach().numpy().T
+        )
+        layer["node_mlp"]["layers_0"]["bias"] = (
+            mf_sake_block.node_mlp[0].bias.detach().numpy().T
+        )
+        layer["node_mlp"]["layers_0"]["kernel"] = (
+            mf_sake_block.node_mlp[0].weight.detach().numpy().T
+        )
+        layer["node_mlp"]["layers_2"]["bias"] = (
+            mf_sake_block.node_mlp[1].bias.detach().numpy().T
+        )
+        layer["node_mlp"]["layers_2"]["kernel"] = (
+            mf_sake_block.node_mlp[1].weight.detach().numpy().T
+        )
+        layer["post_norm_mlp"]["layers_0"]["bias"] = (
+            mf_sake_block.post_norm_mlp[0].bias.detach().numpy().T
+        )
+        layer["post_norm_mlp"]["layers_0"]["kernel"] = (
+            mf_sake_block.post_norm_mlp[0].weight.detach().numpy().T
+        )
+        layer["post_norm_mlp"]["layers_2"]["bias"] = (
+            mf_sake_block.post_norm_mlp[1].bias.detach().numpy().T
+        )
+        layer["post_norm_mlp"]["layers_2"]["kernel"] = (
+            mf_sake_block.post_norm_mlp[1].weight.detach().numpy().T
+        )
+        layer["semantic_attention_mlp"]["layers_0"]["bias"] = (
+            mf_sake_block.semantic_attention_mlp.bias.detach().numpy().T
+        )
+        layer["semantic_attention_mlp"]["layers_0"]["kernel"] = (
+            mf_sake_block.semantic_attention_mlp.weight.detach().numpy().T
+        )
         if layer_name != "d0":
-            layer["velocity_mlp"]["layers_0"]["kernel"] = mf_sake_block.velocity_mlp[0].weight.detach().numpy().T
-            layer["velocity_mlp"]["layers_0"]["bias"] = mf_sake_block.velocity_mlp[0].bias.detach().numpy().T
-            layer["velocity_mlp"]["layers_2"]["kernel"] = mf_sake_block.velocity_mlp[1].weight.detach().numpy().T
-        layer["v_mixing"]["kernel"] = mf_sake_block.v_mixing_mlp.weight.detach().numpy().T
-        layer["x_mixing"]["layers_0"]["kernel"] = mf_sake_block.x_mixing_mlp.weight.detach().numpy().T
+            layer["velocity_mlp"]["layers_0"]["kernel"] = (
+                mf_sake_block.velocity_mlp[0].weight.detach().numpy().T
+            )
+            layer["velocity_mlp"]["layers_0"]["bias"] = (
+                mf_sake_block.velocity_mlp[0].bias.detach().numpy().T
+            )
+            layer["velocity_mlp"]["layers_2"]["kernel"] = (
+                mf_sake_block.velocity_mlp[1].weight.detach().numpy().T
+            )
+        layer["v_mixing"]["kernel"] = (
+            mf_sake_block.v_mixing_mlp.weight.detach().numpy().T
+        )
+        layer["x_mixing"]["layers_0"]["kernel"] = (
+            mf_sake_block.x_mixing_mlp.weight.detach().numpy().T
+        )
 
     # jax.tree_util.tree_map_with_path(lambda path, leaf: print(path, leaf.shape), variables)
 
@@ -398,13 +534,9 @@ def test_model_invariance():
 
     rotation_matrix = torch.tensor([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
     perturbed_methane_input = replace(methane)
-    perturbed_methane_input.positions = torch.matmul(
-        methane.positions, rotation_matrix
-    )
+    perturbed_methane_input.positions = torch.matmul(methane.positions, rotation_matrix)
 
     reference_out = model(methane)
     perturbed_out = model(perturbed_methane_input)
 
     assert torch.allclose(reference_out.E, perturbed_out.E)
-
-

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -221,9 +221,12 @@ def test_painn_representation_implementation():
     mf_nnp_input = input["modelforge_methane_input"]
 
     schnetpack_results = schnetpack_painn(spk_input)
-    modelforge_painn._input_checks(mf_nnp_input)
-    pain_nn_input_mf = modelforge_painn.prepare_inputs(
+    modelforge_painn.input_preparation._input_checks(mf_nnp_input)
+    pairlist_output = modelforge_painn.input_preparation.prepare_inputs(
         mf_nnp_input, only_unique_pairs=False
+    )
+    pain_nn_input_mf = modelforge_painn.painn_core._model_specific_input_preparation(
+        mf_nnp_input, pairlist_output
     )
 
     # ---------------------------------------- #
@@ -242,13 +245,11 @@ def test_painn_representation_implementation():
     d_ij = torch.norm(r_ij, dim=1, keepdim=True)
     dir_ij = r_ij / d_ij
     schnetpack_phi_ij = schnetpack_painn.radial_basis(d_ij)
-    modelforge_phi_ij = (
-        modelforge_painn.representation_module.radial_symmetry_function_module(
-            d_ij / 10
-        ).unsqueeze(
-            1
-        )  # NOTE: for the sake of comparision, changing the shape here
-    )  # NOTE: converting to nm
+    modelforge_phi_ij = modelforge_painn.painn_core.representation_module.radial_symmetry_function_module(
+        d_ij / 10
+    ).unsqueeze(
+        1
+    )  # NOTE: for the sake of comparision, changing the shape here  # NOTE: converting to nm
 
     assert torch.allclose(schnetpack_phi_ij, modelforge_phi_ij)
     phi_ij = schnetpack_phi_ij
@@ -256,7 +257,7 @@ def test_painn_representation_implementation():
     # test cutoff
     # ---------------------------------------- #
     fcut_spk = schnetpack_painn.cutoff_fn(d_ij)
-    fcut_mf = modelforge_painn.representation_module.cutoff_module(
+    fcut_mf = modelforge_painn.painn_core.representation_module.cutoff_module(
         d_ij / 10
     )  # NOTE: converting to nm
     assert torch.allclose(fcut_spk, fcut_mf)
@@ -277,7 +278,9 @@ def test_painn_representation_implementation():
         spk_input[properties.Z].to(torch.int32), mf_nnp_input.atomic_numbers.squeeze()
     )
     embedding_spk = schnetpack_painn.embedding(spk_input[properties.Z])
-    embedding_mf = modelforge_painn.embedding_module(mf_nnp_input.atomic_numbers)
+    embedding_mf = modelforge_painn.painn_core.embedding_module(
+        mf_nnp_input.atomic_numbers
+    )
 
     assert torch.allclose(embedding_spk, embedding_mf)
     # ---------------------------------------- #
@@ -303,7 +306,7 @@ def test_painn_representation_implementation():
     [
         dense.reset_parameters()
         for i in range(nr_of_interactions)
-        for dense in modelforge_painn.interaction_modules[i].interatomic_net
+        for dense in modelforge_painn.painn_core.interaction_modules[i].interatomic_net
     ]
     torch.manual_seed(1234)
     [
@@ -311,17 +314,17 @@ def test_painn_representation_implementation():
         for i in range(nr_of_interactions)
         for dense in schnetpack_painn.interactions[i].interatomic_context_net
     ]
-    print(modelforge_painn.interaction_modules[0].interatomic_net[0].weight)
+    print(modelforge_painn.painn_core.interaction_modules[0].interatomic_net[0].weight)
     print(schnetpack_painn.interactions[0].interatomic_context_net[0].weight)
 
     assert torch.allclose(
-        modelforge_painn.interaction_modules[0].interatomic_net[0].weight,
+        modelforge_painn.painn_core.interaction_modules[0].interatomic_net[0].weight,
         schnetpack_painn.interactions[0].interatomic_context_net[0].weight,
         atol=1e-4,
     )
 
     # first layer
-    mf_intra_net = modelforge_painn.interaction_modules[0].interatomic_net
+    mf_intra_net = modelforge_painn.painn_core.interaction_modules[0].interatomic_net
     spk_intra_net = schnetpack_painn.interactions[0].interatomic_context_net
     intra_mf_q = mf_intra_net(q_mf_initial)
     intra_spk_q = spk_intra_net(q_spk_initial)
@@ -337,11 +340,11 @@ def test_painn_representation_implementation():
     torch.manual_seed(1234)
     pair_indices = pain_nn_input_mf.pair_indices
     filter_list = torch.split(
-        filters_mf, 3 * modelforge_painn.number_of_atom_features, dim=-1
+        filters_mf, 3 * modelforge_painn.painn_core.number_of_atom_features, dim=-1
     )
 
     # test intra-atomic NNP
-    q_mf, mu_mf = modelforge_painn.interaction_modules[0](
+    q_mf, mu_mf = modelforge_painn.painn_core.interaction_modules[0](
         q_mf_initial,
         mu_mf_initial,
         filter_list[0].squeeze(1),  # NOTE: change of shape
@@ -361,9 +364,15 @@ def test_painn_representation_implementation():
     torch.manual_seed(1234)
     [
         (
-            modelforge_painn.mixing_modules[i].mu_channel_mix.reset_parameters(),
-            modelforge_painn.mixing_modules[i].intra_atomic_net[0].reset_parameters(),
-            modelforge_painn.mixing_modules[i].intra_atomic_net[1].reset_parameters(),
+            modelforge_painn.painn_core.mixing_modules[
+                i
+            ].mu_channel_mix.reset_parameters(),
+            modelforge_painn.painn_core.mixing_modules[i]
+            .intra_atomic_net[0]
+            .reset_parameters(),
+            modelforge_painn.painn_core.mixing_modules[i]
+            .intra_atomic_net[1]
+            .reset_parameters(),
         )
         for i in range(nr_of_interactions)
     ]
@@ -383,20 +392,20 @@ def test_painn_representation_implementation():
     for i in range(nr_of_interactions):
         print(i, flush=True)
         assert torch.allclose(
-            modelforge_painn.mixing_modules[i].mu_channel_mix.weight,
+            modelforge_painn.painn_core.mixing_modules[i].mu_channel_mix.weight,
             schnetpack_painn.mixing[i].mu_channel_mix.weight,
         )
         assert torch.allclose(
-            modelforge_painn.mixing_modules[i].intra_atomic_net[0].weight,
+            modelforge_painn.painn_core.mixing_modules[i].intra_atomic_net[0].weight,
             schnetpack_painn.mixing[i].intraatomic_context_net[0].weight,
         )
         assert torch.allclose(
-            modelforge_painn.mixing_modules[i].intra_atomic_net[1].weight,
+            modelforge_painn.painn_core.mixing_modules[i].intra_atomic_net[1].weight,
             schnetpack_painn.mixing[i].intraatomic_context_net[1].weight,
         )
 
     mixed_spk_q, mixed_spk_mu = schnetpack_painn.mixing[0](q_spk, mu_spk)
-    mixed_mf_q, mixed_mf_mu = modelforge_painn.mixing_modules[0](q_mf, mu_mf)
+    mixed_mf_q, mixed_mf_mu = modelforge_painn.painn_core.mixing_modules[0](q_mf, mu_mf)
     assert torch.allclose(mixed_mf_q, mixed_spk_q)
     assert torch.allclose(mixed_mf_mu, mixed_spk_mu)
 
@@ -423,15 +432,15 @@ def test_painn_representation_implementation():
         q_spk, mu_spk = mixing(q_spk, mu_spk)
 
     mf_filter_list = torch.split(
-        filters_mf, 3 * modelforge_painn.number_of_atom_features, dim=-1
+        filters_mf, 3 * modelforge_painn.painn_core.number_of_atom_features, dim=-1
     )
     # q_mf = q_mf_initial
     # mu_mf = mu_mf_initial
 
     for i, (interaction, mixing) in enumerate(
         zip(
-            modelforge_painn.interaction_modules[0:1],
-            modelforge_painn.mixing_modules[0:1],
+            modelforge_painn.painn_core.interaction_modules[0:1],
+            modelforge_painn.painn_core.mixing_modules[0:1],
         )
     ):
         q_mf, mu_mf = interaction(
@@ -449,7 +458,7 @@ def test_painn_representation_implementation():
         filters_spk, 3 * schnetpack_painn.n_atom_basis, dim=-1
     )
     mf_filter_list = torch.split(
-        filters_mf, 3 * modelforge_painn.number_of_atom_features, dim=-1
+        filters_mf, 3 * modelforge_painn.painn_core.number_of_atom_features, dim=-1
     )
 
     # q_spk = q_spk_initial
@@ -459,8 +468,8 @@ def test_painn_representation_implementation():
         zip(
             schnetpack_painn.interactions,
             schnetpack_painn.mixing,
-            modelforge_painn.interaction_modules,
-            modelforge_painn.mixing_modules,
+            modelforge_painn.painn_core.interaction_modules,
+            modelforge_painn.painn_core.mixing_modules,
         )
     ):
         q_spk, mu_spk = spk_interaction(
@@ -486,15 +495,15 @@ def test_painn_representation_implementation():
 
     # reset filter parameters
     torch.manual_seed(1234)
-    modelforge_painn.representation_module.filter_net.reset_parameters()
+    modelforge_painn.painn_core.representation_module.filter_net.reset_parameters()
     torch.manual_seed(1234)
     schnetpack_painn.filter_net.reset_parameters()
     assert torch.allclose(
-        modelforge_painn.representation_module.filter_net.weight,
+        modelforge_painn.painn_core.representation_module.filter_net.weight,
         schnetpack_painn.filter_net.weight,
         atol=1e-4,
     )
-    modelforge_results = modelforge_painn._forward(pain_nn_input_mf)
+    modelforge_results = modelforge_painn.painn_core._forward(pain_nn_input_mf)
     schnetpack_results = schnetpack_painn(spk_input)
 
     assert (
@@ -548,7 +557,7 @@ def setup_mf_schnet_representation(
         number_of_interaction_modules=nr_of_interactions,
         number_of_radial_basis_functions=number_of_radial_basis_functions,
         cutoff=cutoff,
-        number_of_filters = number_of_atom_features
+        number_of_filters=number_of_atom_features,
     )
 
 
@@ -577,7 +586,7 @@ def test_schnet_representation_implementation():
     mf_nnp_input = input["modelforge_methane_input"]
 
     schnetpack_results = schnetpack_schnet(spk_input)
-    modelforge_schnet._input_checks(mf_nnp_input)
+    modelforge_schnet.painn_core._input_checks(mf_nnp_input)
     schnet_nn_input_mf = modelforge_schnet.prepare_inputs(
         mf_nnp_input, only_unique_pairs=False
     )

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -1,10 +1,11 @@
 import os
 import pytest
+import platform
 
-IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+ON_MACOS = platform.system() == "Darwin"
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skipping this test on GitHub Actions")
+@pytest.mark.skipif(ON_MACOS, reason="Skipping this test on GitHub Actions")
 def test_train_with_lightning(train_model, initialized_dataset):
     """
     Test the forward pass for a given model and dataset.
@@ -33,7 +34,7 @@ def test_train_with_lightning(train_model, initialized_dataset):
     )
 
 
-@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skipping this test on GitHub Actions")
+@pytest.mark.skipif(ON_MACOS, reason="Skipping this test on GitHub Actions")
 def test_hypterparameter_tuning_with_ray(train_model, initialized_dataset):
 
     train_model.tune_with_ray(

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -1,8 +1,10 @@
-from typing import Type
-
+import os
 import pytest
 
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
+
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skipping this test on GitHub Actions")
 def test_train_with_lightning(train_model, initialized_dataset):
     """
     Test the forward pass for a given model and dataset.
@@ -31,6 +33,7 @@ def test_train_with_lightning(train_model, initialized_dataset):
     )
 
 
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skipping this test on GitHub Actions")
 def test_hypterparameter_tuning_with_ray(train_model, initialized_dataset):
 
     train_model.tune_with_ray(

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -379,7 +379,7 @@ def test_embedding():
 
 
 def test_energy_readout():
-    from modelforge.potential.utils import FromAtomToMoleculeReduction
+    from modelforge.potential.processing import FromAtomToMoleculeReduction
     import torch
 
     # the EnergyReadout module performs a linear pass to reduce the nr_of_atom_basis to 1

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -6,7 +6,7 @@ from modelforge.potential.utils import CosineCutoff, RadialSymmetryFunction
 
 
 def test_ase_dataclass():
-    from modelforge.potential.utils import AtomicSelfEnergies
+    from modelforge.potential.processing import AtomicSelfEnergies
 
     # Example usage
     atomic_self_energies = AtomicSelfEnergies(
@@ -347,8 +347,12 @@ def test_scatter_softmax():
     src = 1.1 ** torch.arange(10).reshape(2, 5)
     expanded_index = index.expand_as(src)
     util_out = scatter_softmax(src, expanded_index, dim=1, dim_size=3)
-    correct_out = torch.tensor([[0.4750208259, 0.5249791741, 0.4697868228, 0.5302131772, 1.0000000000],
-                                [0.4598240554, 0.5401759744, 0.4514355958, 0.5485643744, 1.0000000000]])
+    correct_out = torch.tensor(
+        [
+            [0.4750208259, 0.5249791741, 0.4697868228, 0.5302131772, 1.0000000000],
+            [0.4598240554, 0.5401759744, 0.4514355958, 0.5485643744, 1.0000000000],
+        ]
+    )
     assert torch.allclose(util_out, correct_out)
 
 
@@ -423,5 +427,3 @@ def test_welford():
         assert np.isclose(online_estimator.mean / target_mean, 1.0, rtol=1e-1)
         assert np.isclose(online_estimator.variance / target_variance, 1.0, rtol=1e-1)
         assert np.isclose(online_estimator.stddev / target_stddev, 1.0, rtol=1e-1)
-
-


### PR DESCRIPTION
## Description

Previously, we have implemented all base functionality, including the neighbor list calculation, in a base class from which each neural network inherits. While this was straightforward, this abstraction made exporting the model and exchanging the neighbor list calculation difficult.
To make these use cases work, the new structure is as follows (outlined for ANI):
`ANI2x` class that wraps and initializes `ANI2xCore` and `InputPreparation` instances. The `InputPreparation` class takes cartesian coordinates as input and outputs `d_ij` and `r_ij`, as well as neighbor indices. The `ANI2Core` performs all calculations necessary for the neural network operating on the output of the `InputPreparation`.

When models are exported, only the `Core` class is exported.
 

## Todos
  - [x] Refactor base class
  - [x] Refactor neural network classes
  - [x] Update tests

## Status
- [x] Ready to go