### PR TITLE
Addressing overuse of fixtures

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -62,22 +62,24 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
         self.dataset_statistics: Dict[str, float] = {}
 
         self.properties_of_interest["atomic_numbers"] = torch.from_numpy(
-            dataset[property_name.Z]
-        )
+            dataset[property_name.Z].flatten()
+        ).to(torch.int32)
         self.properties_of_interest["positions"] = torch.from_numpy(
             dataset[property_name.R]
-        )
-        self.properties_of_interest["E"] = torch.from_numpy(dataset[property_name.E])
+        ).to(torch.float32)
+        self.properties_of_interest["E"] = torch.from_numpy(
+            dataset[property_name.E]
+        ).to(torch.float64)
 
         if property_name.Q is not None:
             self.properties_of_interest["Q"] = torch.from_numpy(
                 dataset[property_name.Q]
-            )
+            ).to(torch.int32)
         else:
             # this is a per atom property, so it will match the first dimension of the geometry
             self.properties_of_interest["Q"] = torch.zeros(
                 (dataset[property_name.R].shape[0], 1)
-            )
+            ).to(torch.int32)
 
         if property_name.F is not None:
             self.properties_of_interest["F"] = torch.from_numpy(
@@ -198,25 +200,16 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
         series_atom_end_idx = self.series_atom_start_idxs_by_conf[idx + 1]
         single_atom_start_idx = self.single_atom_start_idxs_by_conf[idx]
         single_atom_end_idx = self.single_atom_end_idxs_by_conf[idx]
-        atomic_numbers = (
-            self.properties_of_interest["atomic_numbers"][
-                single_atom_start_idx:single_atom_end_idx
-            ]
-            .clone()
-            .detach()
-            .squeeze(1)
-        ).to(torch.int64)
-        positions = (
-            self.properties_of_interest["positions"][
-                series_atom_start_idx:series_atom_end_idx
-            ]
-            .clone()
-            .detach()
-        ).to(torch.float32)
-        E = (
-            (self.properties_of_interest["E"][idx]).clone().detach().to(torch.float64)
-        )  # NOTE: upgrading to float64 to avoid precision issues
-        Q = (self.properties_of_interest["Q"][idx]).clone().detach().to(torch.int32)
+        atomic_numbers = self.properties_of_interest["atomic_numbers"][
+            single_atom_start_idx:single_atom_end_idx
+        ]
+        positions = self.properties_of_interest["positions"][
+            series_atom_start_idx:series_atom_end_idx
+        ]
+        E = self.properties_of_interest["E"][
+            idx
+        ]  # NOTE: upgrading to float64 to avoid precision issues
+        Q = self.properties_of_interest["Q"][idx]
 
         return {
             "atomic_numbers": atomic_numbers,

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -62,6 +62,26 @@ from modelforge.dataset.dataset import DatasetFactory, TorchDataset
 from modelforge.dataset import _ImplementedDatasets
 
 
+def single_batch(batch_size: int = 64):
+    """
+    Utility function to create a single batch of data for testing.
+    """
+    data_module = initialize_datamodule(
+        dataset_name="QM9",
+        batch_size=batch_size,
+        for_unit_testing=True,
+    )
+    return next(iter(data_module.train_dataloader()))
+
+
+@pytest.fixture(scope="session")
+def single_batch_with_batchsize_64():
+    """
+    Utility fixture to create a single batch of data for testing.
+    """
+    return single_batch(batch_size=64)
+
+
 def initialize_dataset(
     dataset_name: str, local_cache_dir: str, for_unit_testing: bool = True
 ) -> DataModule:

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -117,8 +117,8 @@ def prep_temp_dir(tmp_path_factory):
 
     filename = str(uuid.uuid4())
 
-    fn = tmp_path_factory.mktemp(f"dataset_test_{filename}")
-    return fn
+    tmp_path_factory.mktemp(f"dataset_test/")
+    return f"dataset_test"
 
 
 @dataclass

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -30,6 +30,7 @@ def initialize_datamodule(
     batch_size: int = 64,
     splitting_strategy: SplittingStrategy = FirstComeFirstServeSplittingStrategy(),
     remove_self_energies: bool = True,
+    regression_ase: bool = False,
 ) -> DataModule:
     """
     Initialize a dataset for a given mode.
@@ -41,6 +42,7 @@ def initialize_datamodule(
         batch_size=batch_size,
         for_unit_testing=for_unit_testing,
         remove_self_energies=remove_self_energies,
+        regression_ase=regression_ase,
     )
     data_module.prepare_data()
     data_module.setup()
@@ -61,7 +63,7 @@ from modelforge.dataset import _ImplementedDatasets
 
 
 def initialize_dataset(
-    dataset_name: str, local_cache_dir: str, for_unit_testing
+    dataset_name: str, local_cache_dir: str, for_unit_testing: bool = True
 ) -> DataModule:
     """
     Initialize a dataset for a given mode.
@@ -91,9 +93,6 @@ class DataSetContainer:
 
 
 from typing import Dict
-
-# This will store the cached datasets
-dataset_cache: Dict[str, DataSetContainer] = {}
 
 from modelforge.dataset import _ImplementedDatasets
 
@@ -172,11 +171,7 @@ dataset_container: Dict[str, DataSetContainer] = {
 
 
 def get_dataset_container(dataset_name: str) -> DataSetContainer:
-    datasetDC = dataset_cache.get(dataset_name, None)
-
-    if datasetDC is None:
-        datasetDC = dataset_container[dataset_name]
-
+    datasetDC = dataset_container[dataset_name]
     return datasetDC
 
 

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -52,8 +52,10 @@ def initialize_datamodule(
 # dataset fixture
 @pytest.fixture
 def dataset_factory():
-    def create_dataset(dataset_name: str):
-        return initialize_dataset(dataset_name)
+    def create_dataset(
+        dataset_name: str, local_cache_dir: str, for_unit_testing: bool = True
+    ):
+        return initialize_dataset(dataset_name, local_cache_dir, for_unit_testing)
 
     return create_dataset
 
@@ -63,14 +65,16 @@ from modelforge.dataset import _ImplementedDatasets
 
 
 def initialize_dataset(
-    dataset_name: str,
+    dataset_name: str, local_cache_dir: str, for_unit_testing
 ) -> DataModule:
     """
     Initialize a dataset for a given mode.
     """
 
     factory = DatasetFactory()
-    data = _ImplementedDatasets.get_dataset_class(dataset_name)()
+    data = _ImplementedDatasets.get_dataset_class(dataset_name)(
+        local_cache_dir=local_cache_dir, for_unit_testing=for_unit_testing
+    )
     dataset = factory.create_dataset(data)
 
     return dataset

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -91,7 +91,10 @@ def single_batch_with_batchsize_1():
 
 
 def initialize_dataset(
-    dataset_name: str, local_cache_dir: str, for_unit_testing: bool = True
+    dataset_name: str,
+    local_cache_dir: str,
+    for_unit_testing: bool = True,
+    force_download: bool = False,
 ) -> DataModule:
     """
     Initialize a dataset for a given mode.
@@ -99,7 +102,9 @@ def initialize_dataset(
 
     factory = DatasetFactory()
     data = _ImplementedDatasets.get_dataset_class(dataset_name)(
-        local_cache_dir=local_cache_dir, for_unit_testing=for_unit_testing
+        local_cache_dir=local_cache_dir,
+        for_unit_testing=for_unit_testing,
+        force_download=force_download,
     )
     dataset = factory.create_dataset(data)
 

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -113,7 +113,11 @@ def initialize_dataset(
 
 @pytest.fixture(scope="session")
 def prep_temp_dir(tmp_path_factory):
-    fn = tmp_path_factory.mktemp("dataset_testing")
+    import uuid
+
+    filename = str(uuid.uuid4())
+
+    fn = tmp_path_factory.mktemp(f"dataset_test_{filename}")
     return fn
 
 

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -82,6 +82,14 @@ def single_batch_with_batchsize_64():
     return single_batch(batch_size=64)
 
 
+@pytest.fixture(scope="session")
+def single_batch_with_batchsize_1():
+    """
+    Utility fixture to create a single batch of data for testing.
+    """
+    return single_batch(batch_size=1)
+
+
 def initialize_dataset(
     dataset_name: str, local_cache_dir: str, for_unit_testing: bool = True
 ) -> DataModule:

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -338,7 +338,7 @@ def test_different_scenarios_of_file_availability(
 
     # first check if we remove the npz file, rerunning it will regenerate it
     os.remove(f"{local_cache_dir}/{data.processed_data_file['name']}")
-    dataset_factory(dataset_name, local_cache_dir)
+    dataset_factory(dataset_name=dataset_name, local_cache_dir=local_cache_dir)
 
     assert os.path.exists(f"{local_cache_dir}/{data.processed_data_file['name']}")
 
@@ -388,7 +388,9 @@ def test_different_scenarios_of_file_availability(
 
     # now we will remove the gz file and run it again
     os.remove(f"{local_cache_dir}/{data.gz_data_file['name']}")
-    dataset_factory(dataset_name=dataset_name, local_cache_dir=local_cache_dir)
+    dataset_factory(
+        dataset_name=dataset_name, local_cache_dir=local_cache_dir, force_download=True
+    )
     assert os.path.exists(f"{local_cache_dir}/{data.gz_data_file['name']}")
 
 

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -508,7 +508,9 @@ def test_numpy_dataset_assignment(dataset_name):
     from modelforge.dataset import _ImplementedDatasets
 
     factory = DatasetFactory()
-    data = _ImplementedDatasets.get_dataset_class(dataset_name)()
+    data = _ImplementedDatasets.get_dataset_class(dataset_name)(
+        for_unit_testing=for_unit_testing
+    )
     factory._load_or_process_data(data)
 
     assert hasattr(data, "numpy_data")

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -125,10 +125,10 @@ def test_dataset_basic_operations():
 
 
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
-def test_different_properties_of_interest(dataset_name, initialize_dataset):
+def test_different_properties_of_interest(dataset_name, dataset_factory):
     # This test checks the DatasetFactory and PyTorch dataset
 
-    dataset = initialize_dataset(dataset_name)
+    dataset = dataset_factory(dataset_name)
     assert dataset.data.properties_of_interest == [
         "geometry",
         "atomic_numbers",
@@ -157,11 +157,12 @@ def test_different_properties_of_interest(dataset_name, initialize_dataset):
     assert len(raw_data_item) != 3
 
 
-@pytest.mark.parametrize("dataset", DATASETS)
-def test_file_existence_after_initialization(dataset, prep_temp_dir):
+@pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
+def test_file_existence_after_initialization(dataset_name, initialize_dataset):
     """Test if files are created after dataset initialization."""
 
     local_cache_dir = str(prep_temp_dir)
+    dataset = initialize_dataset(dataset_name)
 
     factory = DatasetFactory()
     data = dataset(for_unit_testing=True, local_cache_dir=local_cache_dir)
@@ -296,13 +297,14 @@ def test_metadata_validation(prep_temp_dir):
     assert data._metadata_validation("qm9_test.json", local_cache_dir) == False
 
 
-@pytest.mark.parametrize("dataset", DATASETS)
-def test_different_scenarios_of_file_availability(dataset, prep_temp_dir):
+@pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
+def test_different_scenarios_of_file_availability(dataset_name, prep_temp_dir):
     """Test the behavior when raw and processed dataset files are removed."""
 
     local_cache_dir = str(prep_temp_dir) + "/test_diff_scenarios"
 
     factory = DatasetFactory()
+    dataset = _ImplementedDatasets[dataset_name]
     data = dataset(for_unit_testing=True, local_cache_dir=local_cache_dir)
 
     # this will download the .gz, the .hdf5 and the .npz files
@@ -498,15 +500,16 @@ def test_dataset_splitting(splitting_strategy, datasets_to_test):
         print(f"AssertionError raised: {excinfo}")
 
 
-@pytest.mark.parametrize("dataset", DATASETS)
-def test_dataset_downloader(dataset, prep_temp_dir):
+@pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
+def test_dataset_downloader(dataset_name, dataset_factory, prep_temp_dir):
     """
     Test the DatasetDownloader functionality.
     """
     local_cache_dir = str(prep_temp_dir)
-
-    data = dataset(for_unit_testing=True, local_cache_dir=local_cache_dir)
-    data._download()
+    dataset = dataset_factory(dataset_name, local_cache_dir)
+    data = _ImplementedDatasets.get_dataset_class(dataset_name)(
+        local_cache_dir=local_cache_dir, for_unit_testing=True
+    )
     assert os.path.exists(f"{local_cache_dir}/{data.gz_data_file['name']}")
 
 

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -13,8 +13,8 @@ from modelforge.utils.prop import PropertyNames
 
 @pytest.fixture(scope="session")
 def prep_temp_dir(tmp_path_factory):
-    fn = tmp_path_factory.mktemp("dataset_test")
-    return fn
+    tmp_path_factory.mktemp("dataset_test")
+    return "dataset_test"
 
 
 def test_dataset_imported():
@@ -95,7 +95,7 @@ def test_dataset_basic_operations():
 
 
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
-def test_different_properties_of_interest(dataset_name, dataset_factory):
+def test_different_properties_of_interest(dataset_name, dataset_factory, prep_temp_dir):
 
     local_cache_dir = str(prep_temp_dir)
 
@@ -179,17 +179,19 @@ def test_different_properties_of_interest(dataset_name, dataset_factory):
 
 
 @pytest.mark.parametrize("dataset_name", ["QM9"])
-def test_file_existence_after_initialization(dataset_name, dataset_factory):
+def test_file_existence_after_initialization(dataset_name, dataset_factory, prep_temp_dir):
     """Test if files are created after dataset initialization."""
 
     local_cache_dir = str(prep_temp_dir)
-    if os.path.exists(f"{local_cache_dir}"):
-        os.rmdir(local_cache_dir)
 
     data = _ImplementedDatasets.get_dataset_class(dataset_name)(
         local_cache_dir=local_cache_dir, for_unit_testing=True
     )
 
+    if os.path.exists(f"{local_cache_dir}"):
+        os.rmdir(f"{local_cache_dir}/{data.gz_data_file['name']}")
+        os.rmdir(f"{local_cache_dir}/{data.hdf5_data_file['name']}")
+        os.rmdir(f"{local_cache_dir}/{data.processed_data_file['name']}")
     assert not os.path.exists(f"{local_cache_dir}/{data.gz_data_file['name']}")
     assert not os.path.exists(f"{local_cache_dir}/{data.hdf5_data_file['name']}")
     assert not os.path.exists(f"{local_cache_dir}/{data.processed_data_file['name']}")
@@ -397,7 +399,7 @@ def test_different_scenarios_of_file_availability(
 
 
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
-def test_data_item_format_of_datamodule(dataset_name, datamodule_factory):
+def test_data_item_format_of_datamodule(dataset_name, datamodule_factory, prep_temp_dir):
     """Test the format of individual data items in the dataset."""
     from typing import Dict
 

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -183,6 +183,8 @@ def test_file_existence_after_initialization(dataset_name, dataset_factory):
     """Test if files are created after dataset initialization."""
 
     local_cache_dir = str(prep_temp_dir)
+    if os.path.exists(f"{local_cache_dir}"):
+        os.rmdir(local_cache_dir)
 
     data = _ImplementedDatasets.get_dataset_class(dataset_name)(
         local_cache_dir=local_cache_dir, for_unit_testing=True

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -11,12 +11,6 @@ from modelforge.dataset import _ImplementedDatasets
 from modelforge.utils.prop import PropertyNames
 
 
-@pytest.fixture(scope="session")
-def prep_temp_dir(tmp_path_factory):
-    tmp_path_factory.mktemp("dataset_test")
-    return "dataset_test"
-
-
 def test_dataset_imported():
     """Sample test, will always pass so long as import statement worked."""
 
@@ -179,7 +173,9 @@ def test_different_properties_of_interest(dataset_name, dataset_factory, prep_te
 
 
 @pytest.mark.parametrize("dataset_name", ["QM9"])
-def test_file_existence_after_initialization(dataset_name, dataset_factory, prep_temp_dir):
+def test_file_existence_after_initialization(
+    dataset_name, dataset_factory, prep_temp_dir
+):
     """Test if files are created after dataset initialization."""
 
     local_cache_dir = str(prep_temp_dir)
@@ -189,9 +185,7 @@ def test_file_existence_after_initialization(dataset_name, dataset_factory, prep
     )
 
     if os.path.exists(f"{local_cache_dir}"):
-        os.rmdir(f"{local_cache_dir}/{data.gz_data_file['name']}")
-        os.rmdir(f"{local_cache_dir}/{data.hdf5_data_file['name']}")
-        os.rmdir(f"{local_cache_dir}/{data.processed_data_file['name']}")
+        os.rmdir(f"{local_cache_dir}")
     assert not os.path.exists(f"{local_cache_dir}/{data.gz_data_file['name']}")
     assert not os.path.exists(f"{local_cache_dir}/{data.hdf5_data_file['name']}")
     assert not os.path.exists(f"{local_cache_dir}/{data.processed_data_file['name']}")
@@ -399,7 +393,9 @@ def test_different_scenarios_of_file_availability(
 
 
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
-def test_data_item_format_of_datamodule(dataset_name, datamodule_factory, prep_temp_dir):
+def test_data_item_format_of_datamodule(
+    dataset_name, datamodule_factory, prep_temp_dir
+):
     """Test the format of individual data items in the dataset."""
     from typing import Dict
 

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -91,7 +91,7 @@ def test_dataset_basic_operations():
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
 def test_different_properties_of_interest(dataset_name, dataset_factory, prep_temp_dir):
 
-    local_cache_dir = str(prep_temp_dir)
+    local_cache_dir = str(prep_temp_dir) + "/data_test"
 
     data = _ImplementedDatasets.get_dataset_class(
         dataset_name,
@@ -177,18 +177,20 @@ def test_file_existence_after_initialization(
     dataset_name, dataset_factory, prep_temp_dir
 ):
     """Test if files are created after dataset initialization."""
+    import contextlib
 
-    local_cache_dir = str(prep_temp_dir)
+    local_cache_dir = str(prep_temp_dir) + "/data_test"
 
     data = _ImplementedDatasets.get_dataset_class(dataset_name)(
         local_cache_dir=local_cache_dir, for_unit_testing=True
     )
 
-    if os.path.exists(f"{local_cache_dir}"):
-        os.rmdir(f"{local_cache_dir}")
-    assert not os.path.exists(f"{local_cache_dir}/{data.gz_data_file['name']}")
-    assert not os.path.exists(f"{local_cache_dir}/{data.hdf5_data_file['name']}")
-    assert not os.path.exists(f"{local_cache_dir}/{data.processed_data_file['name']}")
+    with contextlib.suppress(FileNotFoundError):
+
+        os.remove(f"{local_cache_dir}/{data.gz_data_file['name']}")
+        os.remove(f"{local_cache_dir}/{data.hdf5_data_file['name']}")
+        os.remove(f"{local_cache_dir}/{data.processed_data_file['name']}")
+
     dataset = dataset_factory(
         dataset_name=dataset_name,
         for_unit_testing=True,
@@ -201,13 +203,18 @@ def test_file_existence_after_initialization(
 
 
 def test_caching(prep_temp_dir):
-    local_cache_dir = str(prep_temp_dir)
-    local_cache_dir = local_cache_dir + "/data_test"
+    import contextlib
+
+    local_cache_dir = str(prep_temp_dir) + "/data_test"
     from modelforge.dataset.qm9 import QM9Dataset
 
     data = QM9Dataset(for_unit_testing=True, local_cache_dir=local_cache_dir)
 
     # first test that no file exists
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(f"{local_cache_dir}/{data.gz_data_file['name']}")
+        os.remove(f"{local_cache_dir}/{data.hdf5_data_file['name']}")
+        os.remove(f"{local_cache_dir}/{data.processed_data_file['name']}")
     assert not os.path.exists(f"{local_cache_dir}/{data.gz_data_file['name']}")
     # the _file_validation method also checks the path in addition to the checksum
     assert (
@@ -273,7 +280,7 @@ def test_metadata_validation(prep_temp_dir):
     """When we generate an .npz file, we also write out metadata in a .json file which is used
     to validate if we can use .npz file, or we need to regenerate it."""
 
-    local_cache_dir = str(prep_temp_dir)
+    local_cache_dir = str(prep_temp_dir) + "/data_test"
 
     from modelforge.dataset.qm9 import QM9Dataset
 
@@ -325,7 +332,7 @@ def test_different_scenarios_of_file_availability(
     dataset_name, prep_temp_dir, dataset_factory
 ):
     """Test the behavior when raw and processed dataset files are removed."""
-    local_cache_dir = str(prep_temp_dir) + "/test_diff_scenarios"
+    local_cache_dir = str(prep_temp_dir) + "/test_diff_scenario"
 
     # this will download the .gz, the .hdf5 and the .npz files
     dataset_factory(dataset_name=dataset_name, local_cache_dir=local_cache_dir)
@@ -399,7 +406,8 @@ def test_data_item_format_of_datamodule(
     """Test the format of individual data items in the dataset."""
     from typing import Dict
 
-    local_cache_dir = str(prep_temp_dir)
+    local_cache_dir = str(prep_temp_dir) + "/data_test"
+
     dm = datamodule_factory(
         dataset_name=dataset_name,
         batch_size=512,
@@ -537,7 +545,8 @@ def test_dataset_downloader(dataset_name, dataset_factory, prep_temp_dir):
     """
     Test the DatasetDownloader functionality.
     """
-    local_cache_dir = str(prep_temp_dir)
+    local_cache_dir = str(prep_temp_dir) + "/data_test"
+
     dataset = dataset_factory(
         dataset_name=dataset_name, local_cache_dir=local_cache_dir
     )

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -99,26 +99,71 @@ def test_different_properties_of_interest(dataset_name, dataset_factory):
 
     local_cache_dir = str(prep_temp_dir)
 
-    data = _ImplementedDatasets.get_dataset_class(dataset_name,)(
-        for_unit_testing=True, local_cache_dir=local_cache_dir
-    )
-    assert data.properties_of_interest == [
-        "geometry",
-        "atomic_numbers",
-        "internal_energy_at_0K",
-        "charges",
-    ]
+    data = _ImplementedDatasets.get_dataset_class(
+        dataset_name,
+    )(for_unit_testing=True, local_cache_dir=local_cache_dir)
+    if dataset_name == "QM9":
+        assert data.properties_of_interest == [
+            "geometry",
+            "atomic_numbers",
+            "internal_energy_at_0K",
+            "charges",
+        ]
 
-    data.properties_of_interest = [
-        "internal_energy_at_0K",
-        "geometry",
-        "atomic_numbers",
-    ]
-    assert data.properties_of_interest == [
-        "internal_energy_at_0K",
-        "geometry",
-        "atomic_numbers",
-    ]
+        data.properties_of_interest = [
+            "internal_energy_at_0K",
+            "geometry",
+            "atomic_numbers",
+        ]
+        assert data.properties_of_interest == [
+            "internal_energy_at_0K",
+            "geometry",
+            "atomic_numbers",
+        ]
+
+    elif dataset_name == "ANI1x" or dataset_name == "ANI2x":
+        assert data.properties_of_interest == [
+            "geometry",
+            "atomic_numbers",
+            "wb97x_dz.energy",
+            "wb97x_dz.forces",
+        ]
+
+        data.properties_of_interest = [
+            "internal_energy_at_0K",
+            "geometry",
+            "atomic_numbers",
+            "wb97x_dz.energy",
+            "wb97x_dz.forces",
+        ]
+        assert data.properties_of_interest == [
+            "internal_energy_at_0K",
+            "geometry",
+            "atomic_numbers",
+            "wb97x_dz.energy",
+            "wb97x_dz.forces",
+        ]
+    elif dataset_name == "SPICE2":
+        assert data.properties_of_interest == [
+            "geometry",
+            "atomic_numbers",
+            "dft_total_energy",
+            "dft_total_force",
+            "mbis_charges",
+        ]
+
+        data.properties_of_interest = [
+            "dft_total_energy",
+            "geometry",
+            "atomic_numbers",
+            "mbis_charges",
+        ]
+        assert data.properties_of_interest == [
+            "dft_total_energy",
+            "geometry",
+            "atomic_numbers",
+            "mbis_charges",
+        ]
 
     dataset = dataset_factory(
         dataset_name=dataset_name, local_cache_dir=local_cache_dir
@@ -508,9 +553,7 @@ def test_numpy_dataset_assignment(dataset_name):
     from modelforge.dataset import _ImplementedDatasets
 
     factory = DatasetFactory()
-    data = _ImplementedDatasets.get_dataset_class(dataset_name)(
-        for_unit_testing=True
-    )
+    data = _ImplementedDatasets.get_dataset_class(dataset_name)(for_unit_testing=True)
     factory._load_or_process_data(data)
 
     assert hasattr(data, "numpy_data")

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -99,7 +99,7 @@ def test_different_properties_of_interest(dataset_name, dataset_factory):
 
     local_cache_dir = str(prep_temp_dir)
 
-    data = _ImplementedDatasets.get_dataset_class(dataset_name)(
+    data = _ImplementedDatasets.get_dataset_class(dataset_name,)(
         for_unit_testing=True, local_cache_dir=local_cache_dir
     )
     assert data.properties_of_interest == [
@@ -509,7 +509,7 @@ def test_numpy_dataset_assignment(dataset_name):
 
     factory = DatasetFactory()
     data = _ImplementedDatasets.get_dataset_class(dataset_name)(
-        for_unit_testing=for_unit_testing
+        for_unit_testing=True
     )
     factory._load_or_process_data(data)
 

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -118,7 +118,9 @@ def test_state_dict_saving_and_loading(model_name):
 
 
 @pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())
-def test_energy_between_simulation_environments(model_name, single_batch_with_batchsize_64):
+def test_energy_between_simulation_environments(
+    model_name, single_batch_with_batchsize_64
+):
     # compare that the energy is the same for the JAX and PyTorch Model
     import numpy as np
     import torch
@@ -390,7 +392,7 @@ def test_pairlist():
     assert not pair_indices.shape == neighbor_indices.shape
 
 
-@pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
+@pytest.mark.parametrize("dataset_name", ["QM9"])
 def test_pairlist_on_dataset(dataset_name, datamodule_factory):
     from modelforge.potential.models import Neighborlist
 

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -27,6 +27,8 @@ def test_painn_forward(model_parameter, single_batch_with_batchsize_64):
     """
     Test the forward pass of the Schnet model.
     """
+    import torch
+
     print(f"model_parameter: {model_parameter}")
     (
         max_Z,
@@ -42,7 +44,7 @@ def test_painn_forward(model_parameter, single_batch_with_batchsize_64):
         cutoff=cutoff,
         number_of_interaction_modules=nr_interaction_blocks,
     )
-    nnp_input = single_batch_with_batchsize_64.nnp_input
+    nnp_input = single_batch_with_batchsize_64.nnp_input.to(dtype=torch.float32)
     energy = painn(nnp_input).E
     nr_of_mols = nnp_input.atomic_subsystem_indices.unique().shape[0]
 

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -23,7 +23,7 @@ from openff.units import unit
         [100, 120, 5, unit.Quantity(5.0, unit.angstrom), 3],
     ),
 )
-def test_painn_forward(batch, model_parameter):
+def test_painn_forward(model_parameter, single_batch_with_batchsize_64):
     """
     Test the forward pass of the Schnet model.
     """
@@ -42,7 +42,7 @@ def test_painn_forward(batch, model_parameter):
         cutoff=cutoff,
         number_of_interaction_modules=nr_interaction_blocks,
     )
-    nnp_input = batch.nnp_input
+    nnp_input = single_batch_with_batchsize_64.nnp_input
     energy = painn(nnp_input).E
     nr_of_mols = nnp_input.atomic_subsystem_indices.unique().shape[0]
 
@@ -51,7 +51,7 @@ def test_painn_forward(batch, model_parameter):
     )  # Assuming energy is calculated per sample in the batch
 
 
-def test_painn_interaction_equivariance(methane):
+def test_painn_interaction_equivariance(single_batch_with_batchsize_64):
     from modelforge.potential.painn import PaiNN
     from dataclasses import replace
     import torch
@@ -63,7 +63,7 @@ def test_painn_interaction_equivariance(methane):
     )
 
     painn = PaiNN().to(torch.float64)
-    methane_input = methane.nnp_input.to(dtype=torch.float64)
+    methane_input = single_batch_with_batchsize_64.nnp_input.to(dtype=torch.float64)
     perturbed_methane_input = replace(methane_input)
     perturbed_methane_input.positions = torch.matmul(
         methane_input.positions, rotation_matrix
@@ -84,9 +84,7 @@ def test_painn_interaction_equivariance(methane):
         )
     )
 
-    pairlist_output = painn.input_preparation.prepare_inputs(
-        perturbed_methane_input
-    )
+    pairlist_output = painn.input_preparation.prepare_inputs(perturbed_methane_input)
     perturbed_prepared_input = painn.core_module._model_specific_input_preparation(
         perturbed_methane_input, pairlist_output
     )

--- a/modelforge/tests/test_physnet.py
+++ b/modelforge/tests/test_physnet.py
@@ -10,6 +10,7 @@ def test_physnet_forward(single_batch_with_batchsize_64):
     from modelforge.potential.physnet import PhysNet
 
     model = PhysNet(number_of_modules=1, number_of_interaction_residual=1)
+    model.to(torch.float32)
     print(model)
     yhat = model(single_batch_with_batchsize_64.nnp_input)
 

--- a/modelforge/tests/test_physnet.py
+++ b/modelforge/tests/test_physnet.py
@@ -10,7 +10,7 @@ def test_physnet_forward(single_batch_with_batchsize_64):
     from modelforge.potential.physnet import PhysNet
 
     model = PhysNet(number_of_modules=1, number_of_interaction_residual=1)
-    model.to(torch.float32)
+    model = model.to(torch.float32)
     print(model)
     yhat = model(single_batch_with_batchsize_64.nnp_input)
 

--- a/modelforge/tests/test_physnet.py
+++ b/modelforge/tests/test_physnet.py
@@ -5,13 +5,13 @@ def test_physnet_init():
     model = PhysNet()
 
 
-def test_physnet_forward(batch):
+def test_physnet_forward(single_batch_with_batchsize_64):
     import torch
     from modelforge.potential.physnet import PhysNet
 
     model = PhysNet(number_of_modules=1, number_of_interaction_residual=1)
     print(model)
-    yhat = model(batch.nnp_input)
+    yhat = model(single_batch_with_batchsize_64.nnp_input)
 
 
 def test_rbf():

--- a/modelforge/tests/test_physnet.py
+++ b/modelforge/tests/test_physnet.py
@@ -12,7 +12,7 @@ def test_physnet_forward(single_batch_with_batchsize_64):
     model = PhysNet(number_of_modules=1, number_of_interaction_residual=1)
     model = model.to(torch.float32)
     print(model)
-    yhat = model(single_batch_with_batchsize_64.nnp_input)
+    yhat = model(single_batch_with_batchsize_64.nnp_input.to(torch.float32))
 
 
 def test_rbf():

--- a/modelforge/tests/test_physnet.py
+++ b/modelforge/tests/test_physnet.py
@@ -12,7 +12,7 @@ def test_physnet_forward(single_batch_with_batchsize_64):
     model = PhysNet(number_of_modules=1, number_of_interaction_residual=1)
     model = model.to(torch.float32)
     print(model)
-    yhat = model(single_batch_with_batchsize_64.nnp_input.to(torch.float32))
+    yhat = model(single_batch_with_batchsize_64.nnp_input.to(dtype=torch.float32))
 
 
 def test_rbf():

--- a/modelforge/tests/test_pt_lightning.py
+++ b/modelforge/tests/test_pt_lightning.py
@@ -1,0 +1,12 @@
+def test_datamodule():
+    # This is an example script that trains an implemented model on the QM9 dataset.
+    from modelforge.dataset.dataset import DataModule
+
+    # Set up dataset
+
+    dm = DataModule(
+        name="QM9",
+        batch_size=512,
+        normalize=False,
+    )
+

--- a/modelforge/tests/test_sake.py
+++ b/modelforge/tests/test_sake.py
@@ -25,12 +25,12 @@ def test_SAKE_init():
 from openff.units import unit
 
 
-def test_sake_forward(single_data_point):
+def test_sake_forward(single_batch_with_batchsize_64):
     """
     Test the forward pass of the SAKE model.
     """
     # get methane input
-    methane = single_data_point.nnp_input
+    methane = single_batch_with_batchsize_64.nnp_input
 
     sake = SAKE()
     energy = sake(methane).E
@@ -72,7 +72,7 @@ def test_sake_interaction_forward():
 
 @pytest.mark.parametrize("eq_atol", [3e-1])
 @pytest.mark.parametrize("h_atol", [8e-2])
-def test_sake_layer_equivariance(h_atol, eq_atol, single_data_point):
+def test_sake_layer_equivariance(h_atol, eq_atol, single_batch_with_batchsize_64):
     import torch
     from modelforge.potential.sake import SAKE
     from dataclasses import replace
@@ -88,7 +88,7 @@ def test_sake_layer_equivariance(h_atol, eq_atol, single_data_point):
     sake = SAKE(number_of_atom_features=nr_atom_basis)  # only for preparing inputs
 
     # get methane input
-    methane = single_data_point.nnp_input
+    methane = single_batch_with_batchsize_64.nnp_input
     perturbed_methane_input = replace(methane)
     perturbed_methane_input.positions = torch.matmul(methane.positions, rotation_matrix)
 
@@ -391,7 +391,7 @@ def test_sake_layer_against_reference(include_self_pairs, v_is_none):
     )
 
 
-def test_sake_model_against_reference(single_data_point):
+def test_sake_model_against_reference(single_batch_with_batchsize_1):
     nr_heads = 5
     nr_atom_basis = 11
     max_Z = 13
@@ -419,7 +419,7 @@ def test_sake_model_against_reference(single_data_point):
     )
 
     # get methane input
-    methane = single_data_point.nnp_input
+    methane = single_batch_with_batchsize_1.nnp_input
     pairlist_output = mf_sake.input_preparation.prepare_inputs(methane)
     prepared_methane = mf_sake.core_module._model_specific_input_preparation(
         methane, pairlist_output
@@ -551,12 +551,12 @@ def test_sake_model_against_reference(single_data_point):
     # assert torch.allclose(mf_out.E, torch.from_numpy(onp.array(ref_out[0])))
 
 
-def test_model_invariance(single_data_point):
+def test_model_invariance(single_batch_with_batchsize_1):
     from dataclasses import replace
 
     model = SAKE()
     # get methane input
-    methane = single_data_point.nnp_input
+    methane = single_batch_with_batchsize_1.nnp_input
 
     rotation_matrix = torch.tensor([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
     perturbed_methane_input = replace(methane)

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -22,7 +22,7 @@ from openff.units import unit
         [128, 120, 64, unit.Quantity(5.0, unit.angstrom), 3],
     ),
 )
-def test_schnet_forward(batch, model_parameter):
+def test_schnet_forward(single_batch_with_batchsize_64, model_parameter):
     """
     Test the forward pass of the Schnet model.
     """
@@ -41,8 +41,10 @@ def test_schnet_forward(batch, model_parameter):
         cutoff=cutoff,
         number_of_interaction_modules=nr_interaction_blocks,
     )
-    energy = schnet(batch.nnp_input).E
-    nr_of_mols = batch.nnp_input.atomic_subsystem_indices.unique().shape[0]
+    energy = schnet(single_batch_with_batchsize_64.nnp_input).E
+    nr_of_mols = single_batch_with_batchsize_64.nnp_input.atomic_subsystem_indices.unique().shape[
+        0
+    ]
 
     assert (
         len(energy) == nr_of_mols

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -13,7 +13,7 @@ from modelforge.potential import NeuralNetworkPotentialFactory
 
 @pytest.mark.skipif(ON_MACOS, reason="Skipping this test on MacOS GitHub Actions")
 @pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())
-@pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
+@pytest.mark.parametrize("dataset_name", ["QM9"])
 def test_train_with_lightning(model_name, dataset_name):
     """
     Test the forward pass for a given model and dataset.

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -6,10 +6,15 @@ import platform
 ON_MACOS = platform.system() == "Darwin"
 
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+from modelforge.potential import _Implemented_NNPs
+from modelforge.dataset import _ImplementedDatasets
+from modelforge.potential import NeuralNetworkPotentialFactory
 
 
 @pytest.mark.skipif(ON_MACOS, reason="Skipping this test on MacOS GitHub Actions")
-def test_train_with_lightning(train_model, initialized_QM9_dataset):
+@pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())
+@pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
+def test_train_with_lightning(model_name, dataset_name):
     """
     Test the forward pass for a given model and dataset.
 
@@ -24,17 +29,27 @@ def test_train_with_lightning(train_model, initialized_QM9_dataset):
     from lightning import Trainer
     import torch
     from modelforge.train.training import TrainingAdapter
+    from modelforge.dataset.dataset import DataModule
+
+    dm = DataModule(
+        name=dataset_name,
+        batch_size=512,
+        remove_self_energies=True,
+        for_unit_testing=True,
+    )
+    dm.prepare_data()
+    dm.setup()
+    # Set up model
+    model = NeuralNetworkPotentialFactory.create_nnp("training", model_name)
 
     # Initialize PyTorch Lightning Trainer
     trainer = Trainer(max_epochs=2)
 
-    # Move model to the appropriate dtype and device
-    model = train_model.to(torch.float32)
     # Run training loop and validate
     trainer.fit(
         model,
-        initialized_QM9_dataset.train_dataloader(),
-        initialized_QM9_dataset.val_dataloader(),
+        dm.train_dataloader(),
+        dm.val_dataloader(),
     )
     # save checkpoint
     trainer.save_checkpoint("test.chp")
@@ -43,11 +58,16 @@ def test_train_with_lightning(train_model, initialized_QM9_dataset):
 
 
 @pytest.mark.skipif(ON_MACOS, reason="Skipping this test on MacOS GitHub Actions")
-def test_hypterparameter_tuning_with_ray(train_model, initialized_QM9_dataset):
+@pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())
+@pytest.mark.parametrize("dataset_name", ["QM9"])
+def test_hypterparameter_tuning_with_ray(model_name, dataset_name, datamodule_factory):
 
-    train_model.tune_with_ray(
-        train_dataloader=initialized_QM9_dataset.train_dataloader(),
-        val_dataloader=initialized_QM9_dataset.val_dataloader(),
+    dm = datamodule_factory(dataset_name=dataset_name)
+    model = NeuralNetworkPotentialFactory.create_nnp("training", model_name)
+
+    model.tune_with_ray(
+        train_dataloader=dm.train_dataloader(),
+        val_dataloader=dm.val_dataloader(),
         number_of_ray_workers=1,
         number_of_epochs=1,
         number_of_samples=1,


### PR DESCRIPTION
## Description

We have accumulated technical debts in the configuration of some of our tests. This PR is a first attempt to clean up the overuse of slightly similar but different fixtures, for which the control flow is hidden in `conftest.py,` making it sometimes difficult to understand what is done in a particular test.

I opted for explicitly passing control parameters to each test instead of hiding these in fixtures. I have cleaned up some of the fixtures and simplified them where appropriate. We still use fixtures to set up datasets/databases/database containers. (Sidenote: In one of the next PRs, we need to address the inflationary use of the word dataset in the classes --- it is challenging to distinguish between some of the concepts without reading the documentation.)

## Todos
  - [x] simplify fixtures
  - [x] clean up tests

## Status
- [x] Ready to go