### PR TITLE
Further speed up to _subtract_self_energies 

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -978,8 +978,7 @@ class DataModule(pl.LightningDataModule):
                     dataset.properties_of_interest["atomic_numbers"][start_idx:end_idx]
                 ]
             )
-            dataset[i] = {"E": dataset[i]["E"] - energy}
-
+            dataset[i] = {"E": dataset.properties_of_interest["E"][i] - energy}
         return dataset
 
     def train_dataloader(self) -> DataLoader:

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -970,8 +970,13 @@ class DataModule(pl.LightningDataModule):
 
         log.info("Removing self energies from the dataset")
         for i in tqdm(range(len(dataset)), desc="Removing Self Energies"):
+            start_idx = dataset.single_atom_start_idxs_by_conf[i]
+            end_idx = dataset.single_atom_end_idxs_by_conf[i]
+
             energy = torch.sum(
-                self_energies.ase_tensor_for_indexing[dataset[i]["atomic_numbers"]]
+                self_energies.ase_tensor_for_indexing[
+                    dataset.properties_of_interest["atomic_numbers"][start_idx:end_idx]
+                ]
             )
             dataset[i] = {"E": dataset[i]["E"] - energy}
 

--- a/modelforge/dataset/utils.py
+++ b/modelforge/dataset/utils.py
@@ -462,7 +462,7 @@ def random_record_split(
     record_indices = torch.randperm(sum(lengths), generator=generator).tolist()  # type: ignore[arg-type, call-overload]
 
     indices_by_split: List[List[int]] = []
-    for offset, length in zip(torch._utils._accumulate(lengths), lengths):
+    for offset, length in zip(np.cumsum(lengths), lengths):
         indices = []
         for record_idx in record_indices[offset - length : offset]:
             indices.extend(dataset.get_series_mol_idxs(record_idx))


### PR DESCRIPTION
Further speed up to _subtract_self_energies in DataModule by directly indexing into the atomic_numbers tensor to avoid additional overhead.  Reduces

As further described in Issue #120 , the overhead of `__getitem__` seems to be an additional factor.  We only are using the atomic numbers, so all the other data returned when indexing into the dataset are not needing and just slowing things down.  I just directly indexed into the tensor to get the relevant atomic numbers, and that seems to give some further substantial speed ups (reducing cost about ~50%).  Update: Overlooked that I was using the getter to retrieve energy.  Speed up is even better (see timings below). 


This will additionally address issue #124, swapping in np.cumsum for torch._utils._accumulate in the record splitting routine. 

## Status
- [ ] Ready to go