### PR TITLE
Adapt training for forces

### DIFF
--- a/modelforge/potential/__init__.py
+++ b/modelforge/potential/__init__.py
@@ -24,7 +24,6 @@ class _Implemented_NNPs(Enum):
     @classmethod
     def get_neural_network_class(cls, neural_network_name: str):
         try:
-            print(neural_network_name.upper())
             # Normalize the input and get the class directly from the Enum
             return cls[neural_network_name.upper()].value
         except KeyError:

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -457,7 +457,7 @@ class NeuralNetworkPotentialFactory:
 
         nnp_parameters = nnp_parameters or {}
         training_parameters = training_parameters or {}
-
+        log.debug(f"{training_parameters=}")
         # get NNP
         nnp_class: Type = _Implemented_NNPs.get_neural_network_class(nnp_name)
         if nnp_class is None:

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -775,7 +775,6 @@ class AniRadialSymmetryFunction(RadialSymmetryFunction):
             number_of_radial_basis_functions + 1,
             dtype=dtype,
         )[:-1]
-        log.debug(f"{centers=}")
         return centers
 
     def calculate_radial_scale_factor(

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -165,11 +165,8 @@ def test_different_properties_of_interest(dataset_name, dataset_factory, prep_te
 
     raw_data_item = dataset[0]
     assert isinstance(raw_data_item, dict)
-    assert len(raw_data_item) == 6  # 6 properties are returned
+    assert len(raw_data_item) == 7  # 7 properties are returned
 
-    raw_data_item = dataset[0]
-    assert isinstance(raw_data_item, dict)
-    assert len(raw_data_item) == 6  # 6 properties are returned
 
 
 @pytest.mark.parametrize("dataset_name", ["QM9"])

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -418,7 +418,6 @@ def test_data_item_format_of_datamodule(
     assert isinstance(raw_data_item["atomic_numbers"], torch.Tensor)
     assert isinstance(raw_data_item["positions"], torch.Tensor)
     assert isinstance(raw_data_item["E"], torch.Tensor)
-    print(raw_data_item)
 
     assert (
         raw_data_item["atomic_numbers"].shape[0] == raw_data_item["positions"].shape[0]

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -53,9 +53,10 @@ def test_train_with_lightning(model_name, dataset_name, include_force):
     assert type(model) is not None
 
 
-@pytest.mark.parametrize("model_name", ["ANI2x"])
+@pytest.mark.parametrize("model_name", ["SchNet"])
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
 def test_loss(model_name, dataset_name, datamodule_factory):
+    from loguru import logger as log
 
     dm = datamodule_factory(dataset_name=dataset_name)
     model = NeuralNetworkPotentialFactory.create_nnp("inference", model_name)
@@ -65,8 +66,10 @@ def test_loss(model_name, dataset_name, datamodule_factory):
 
     loss = EnergyAndForceLoss(model)
 
-    r = loss.compute_loss(next(iter(dm.train_dataloader())))
-
+    try:
+        r = loss.compute_loss(next(iter(dm.train_dataloader())))
+    except IndexError as excinfo:
+        log.warning(f"IndexError raised: {excinfo}")
     loss = EnergyAndForceLoss(model, include_force=True)
 
     r = loss.compute_loss(next(iter(dm.train_dataloader())))

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -13,7 +13,7 @@ from modelforge.potential import NeuralNetworkPotentialFactory
 
 @pytest.mark.skipif(ON_MACOS, reason="Skipping this test on MacOS GitHub Actions")
 @pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())
-@pytest.mark.parametrize("dataset_name", ["QM9"])
+@pytest.mark.parametrize("dataset_name", ["ANI2x"])
 @pytest.mark.parametrize("include_force", [False, True])
 def test_train_with_lightning(model_name, dataset_name, include_force):
     """
@@ -40,12 +40,12 @@ def test_train_with_lightning(model_name, dataset_name, include_force):
 
     # Initialize PyTorch Lightning Trainer
     trainer = Trainer(max_epochs=2)
-
+    
     # Run training loop and validate
     trainer.fit(
         model,
-        dm.train_dataloader(),
-        dm.val_dataloader(),
+        train_dataloaders=dm.train_dataloader(),
+        val_dataloaders=dm.val_dataloader(),
     )
     # save checkpoint
     trainer.save_checkpoint("test.chp")

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -55,18 +55,9 @@ def test_train_with_lightning(model_name, dataset_name, include_force):
 
 @pytest.mark.parametrize("model_name", ["ANI2x"])
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
-def test_loss(model_name, dataset_name):
+def test_loss(model_name, dataset_name, datamodule_factory):
 
-    from modelforge.dataset.dataset import DataModule
-
-    dm = DataModule(
-        name=dataset_name,
-        batch_size=512,
-        remove_self_energies=True,
-        for_unit_testing=True,
-    )
-    dm.prepare_data()
-    dm.setup()
+    dm = datamodule_factory(dataset_name=dataset_name)
     model = NeuralNetworkPotentialFactory.create_nnp("inference", model_name)
 
     from modelforge.train.training import EnergyAndForceLoss

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -66,13 +66,11 @@ def test_loss(model_name, dataset_name, datamodule_factory):
 
     loss = EnergyAndForceLoss(model)
 
-    try:
-        r = loss.compute_loss(next(iter(dm.train_dataloader())))
-    except IndexError as excinfo:
-        log.warning(f"IndexError raised: {excinfo}")
-    loss = EnergyAndForceLoss(model, include_force=True)
-
     r = loss.compute_loss(next(iter(dm.train_dataloader())))
+
+    if dataset_name != "QM9":
+        loss = EnergyAndForceLoss(model, include_force=True)
+        r = loss.compute_loss(next(iter(dm.train_dataloader())))
 
 
 @pytest.mark.skipif(ON_MACOS, reason="Skipping this test on MacOS GitHub Actions")

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -50,7 +50,7 @@ class Loss:
             raise RuntimeError("No force can be calculated.")
         E_predict = energies["E_predict"]
         F_predict = -torch.autograd.grad(
-            E_predict.sum(), nnp_input.positions, create_graph=False, retain_graph=False
+            E_predict.sum(), nnp_input.positions, create_graph=False, retain_graph=True
         )[0]
 
         return {"F_true": F_true, "F_predict": F_predict}
@@ -114,11 +114,16 @@ class EnergyAndForceLoss(Loss):
         torch.Tensor
             The computed loss as a PyTorch tensor.
         """
-        energies = self._get_energies(batch)
-        loss = self.energy_weight * loss_fn(energies["E_predict"], energies["E_true"])
-        if self.include_force:
-            forces = self._get_forces(batch, energies)
-            loss += self.force_weight * loss_fn(forces["F_predict"], forces["F_true"])
+        with torch.set_grad_enabled(True):
+            energies = self._get_energies(batch)
+            loss = self.energy_weight * loss_fn(
+                energies["E_predict"], energies["E_true"]
+            )
+            if self.include_force:
+                forces = self._get_forces(batch, energies)
+                loss += self.force_weight * loss_fn(
+                    forces["F_predict"], forces["F_true"]
+                )
         return loss
 
 
@@ -268,7 +273,6 @@ class TrainingAdapter(pl.LightningModule):
         torch.Tensor
             The loss tensor computed for the current validation step.
         """
-
         mse_loss = self.loss.compute_loss(batch, F.mse_loss)
         rmse_loss = mse_loss**0.5
         self.log(

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -46,6 +46,8 @@ class Loss:
         """
         nnp_input = batch.nnp_input
         F_true = batch.metadata.F.to(torch.float32)
+        if F_true.numel() < 1:
+            raise RuntimeError("No force can be calculated.")
         E_predict = energies["E_predict"]
         F_predict = -torch.autograd.grad(
             E_predict.sum(), nnp_input.positions, create_graph=False, retain_graph=False
@@ -154,7 +156,6 @@ class TrainingAdapter(pl.LightningModule):
         from typing import List
         from modelforge.potential import _Implemented_NNPs
 
-        print(f"{nnp_parameters=}")
         super().__init__()
         self.save_hyperparameters()
         # Extracting and instantiating the model from parameters


### PR DESCRIPTION
## Description
Tests still need to cover the Loss functions used in the training routine, this PR addresses this.

This PR also adds forces to the getter method of the `TorchDataset` and the `collateconformers` method, as raised here: #127 . It also improves performance by casting dtype on the full tensor and not on individual tensor slices.

## Todos
  - [x] Add test for loss energy/force

## Status
- [x] Ready to go