### PR TITLE
Bugfix: training set was not shuffled at each epoch

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -989,6 +989,7 @@ class DataModule(pl.LightningDataModule):
             batch_size=self.batch_size,
             collate_fn=collate_conformers,
             num_workers=4,
+            shuffle=True,
         )
 
     def val_dataloader(self) -> DataLoader:
@@ -1051,7 +1052,7 @@ def collate_conformers(conf_list: List[Dict[str, torch.Tensor]]) -> "BatchData":
     atomic_numbers_cat = torch.cat(Z_list)
     total_charge_cat = torch.cat(Q_list)
     positions_cat = torch.cat(R_list).requires_grad_(True)
-    forces_cat = torch.cat(F_list)
+    F_cat = torch.cat(F_list).to(torch.float64)
     E_stack = torch.stack(E_list)
     nnp_input = NNPInput(
         atomic_numbers=atomic_numbers_cat,
@@ -1063,7 +1064,7 @@ def collate_conformers(conf_list: List[Dict[str, torch.Tensor]]) -> "BatchData":
     )
     metadata = Metadata(
         E=E_stack,
-        F=torch.tensor(forces_cat, dtype=torch.float64),
+        F=F_cat,
         atomic_subsystem_counts=torch.tensor(
             atomic_subsystem_counts, dtype=torch.int32
         ),


### PR DESCRIPTION
## Description
I was making a wrong assumption about the PyTorch dataset class's default behavior, which does not shuffle by default. This PR sets `shuffle=True` for the training set. 


## Status
- [x] Ready to go