### PR TITLE
Refactoring pairs calculation to be more memory efficient.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup
+
+setup(
+    name="modelforge",
+    version="0.1",
+    packages=["modelforge"],
+    package_data={"modelforge": ["dataset/yaml_files/*", "curation/yaml_files/*"]},
+    url="https://github.com/choderalab/modelforge",
+    license="MIT",
+    author="Chodera lab, Christopher Iacovella, Marcus Wieder",
+    author_email="",
+    description="A library for building and training neural network potentials",
+    include_package_data=True,
+)


### PR DESCRIPTION
## Description
This relates to issue #134 .  Basically, the initial code allocated tensors of size (n*(n-1)) in the process of identifying particle pairs, where n is the total number of atoms in all the molecules. After these pairs are enumerate, they were filtered by whether or not they are in the same molecule.  For larger datasets, this allocates large arrays, which were too large for me to run locally or on the readily available 2080s.   

To address this, I just wrapped the same basic code in a for loop, so we are instead allocating tensors of size (n-1), and just performing the calculation n times, effectively reducing memory allocation by a factor of n.  In each iteration of the loop, we do the filtering by whether pairs are on the same molecule and accumulate those pairs.  

As noted in the issue, we could further improve this if we end up with other memory issues, but this seems more than sufficient. 

## Status
- [x] Ready to go