### PR TITLE
Remove unused cutoff parameter

### DIFF
--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -454,9 +454,7 @@ class ANI2xCore(CoreNetwork):
         self.num_species = 7
 
         log.debug("Initializing ANI model.")
-        super().__init__(
-            cutoff=radial_max_distance
-        )
+        super().__init__()
 
         # Initialize representation block
         self.ani_representation_module = ANIRepresentation(

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -702,14 +702,17 @@ class CoreNetwork(Module, ABC):
         """
         return self.readout_module(atom_specific_values, index)
 
-    def forward(self, data: NNPInput, pairlist_output) -> EnergyOutput:
+    def forward(self, data: NNPInput, pairlist_output: PairListOutputs) -> EnergyOutput:
         """
         Defines the forward pass of the neural network potential.
 
         Parameters
         ----------
         data : NNPInput
-            The input data for the model, containing atomic numbers, positions, and other relevant fields.
+            Contains input data for the batch obtained directly from the dataset, including atomic numbers, positions,
+            and other relevant fields.
+        pairlist_output : PairListOutputs
+            Contains the indices for the selected pairs and their associated distances and displacement vectors.
 
         Returns
         -------

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -194,11 +194,6 @@ class Neighborlist(Pairlist):
     """Manage neighbor list calculations with a specified cutoff distance.
 
     This class extends Pairlist to consider a cutoff distance for neighbor calculations.
-
-    Attributes
-    ----------
-    cutoff : unit.Quantity
-        Cutoff distance for neighbor list calculations.
     """
 
     def __init__(self, cutoff: unit.Quantity, only_unique_pairs: bool = False):
@@ -229,8 +224,6 @@ class Neighborlist(Pairlist):
             Atom positions. Shape: [nr_systems, nr_atoms, 3].
         atomic_subsystem_indices : torch.Tensor
             Indices identifying atoms in subsystems. Shape: [nr_atoms].
-        only_unique_pairs : bool, optional
-            If True, considers only unique pairs of atoms. Default is False.
 
         Returns
         -------
@@ -414,7 +407,8 @@ from modelforge.potential.processing import AtomicSelfEnergies
 
 class NeuralNetworkPotentialFactory:
     """
-    Factory class for creating instances of neural network potentials (NNP) that are traceable/scriptable and can be exported to torchscript.
+    Factory class for creating instances of neural network potentials (NNP) that are traceable/scriptable and can be
+    exported to torchscript.
 
     This factory allows for the creation of specific NNP instances configured for either
     training or inference purposes based on the given parameters.
@@ -595,18 +589,13 @@ class CoreNetwork(Module, ABC):
 
     Attributes
     ----------
-    cutoff : unit.Quantity
-        Cutoff distance for neighbor list calculations.
-    calculate_distances_and_pairlist : Neighborlist
-        Module for calculating distances and pairlist with a given cutoff.
     readout_module : FromAtomToMoleculeReduction
         Module for reading out per molecule properties from atomic properties.
+    postprocessing : EnergyScaling
+        Module for postprocessing the raw energies computed by the readout module.
     """
 
-    def __init__(
-        self,
-        cutoff: unit.Quantity,
-    ):
+    def __init__(self):
         """
         Initializes the neural network potential class with specified parameters.
 
@@ -619,9 +608,9 @@ class CoreNetwork(Module, ABC):
         # initialize the per molecule readout module
         from .processing import EnergyScaling, FromAtomToMoleculeReduction
 
-        self.postprocessing = EnergyScaling()
-
         self.readout_module = FromAtomToMoleculeReduction()
+
+        self.postprocessing = EnergyScaling()
 
     @abstractmethod
     def _model_specific_input_preparation(
@@ -645,7 +634,7 @@ class CoreNetwork(Module, ABC):
             The initial inputs to the neural network model, including atomic numbers,
             positions, and other relevant data.
         pairlist : PairListOutputs
-            The outputs of a pair list calculation, including pair indices, distances,
+            The outputs of a pairlist calculation, including pair indices, distances,
             and displacement vectors.
 
         Returns
@@ -673,7 +662,7 @@ class CoreNetwork(Module, ABC):
 
         Parameters
         ----------
-        inputs : The processed input data, specific to the model's requirements.
+        data : The processed input data, specific to the model's requirements.
 
         Returns
         -------

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -93,7 +93,7 @@ class PaiNNCore(CoreNetwork):
     ):
 
         log.debug("Initializing PaiNN model.")
-        super().__init__(cutoff=cutoff)
+        super().__init__()
 
         self.number_of_interaction_modules = number_of_interaction_modules
         self.number_of_atom_features = number_of_atom_features

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -436,7 +436,7 @@ class PhysNetCore(CoreNetwork):
 
         log.debug("Initializing PhysNet model.")
 
-        super().__init__(cutoff=cutoff)
+        super().__init__()
 
         # embedding
         from modelforge.potential.utils import Embedding

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -87,7 +87,7 @@ class SAKECore(CoreNetwork):
         from .processing import FromAtomToMoleculeReduction
 
         log.debug("Initializing SAKE model.")
-        super().__init__(cutoff=cutoff)
+        super().__init__()
         self.nr_interaction_blocks = number_of_interaction_modules
         self.nr_heads = number_of_spatial_attention_heads
         self.max_Z = max_Z

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -112,7 +112,7 @@ class SchNetCore(CoreNetwork):
         from .utils import Dense, ShiftedSoftplus
 
         log.debug("Initializing SchNet model.")
-        super().__init__(cutoff)
+        super().__init__()
         self.number_of_atom_features = number_of_atom_features
         self.number_of_filters = number_of_filters or self.number_of_atom_features
         self.number_of_radial_basis_functions = number_of_radial_basis_functions

--- a/modelforge/potential/tensornet.py
+++ b/modelforge/potential/tensornet.py
@@ -36,7 +36,7 @@ class TensorNetCore(CoreNetwork):
         radial_min_distanc: unit.Quantity,
         number_of_radial_basis_functions: int,
     ):
-        super().__init__(cutoff=radial_max_distance)
+        super().__init__()
 
         # Initialize representation block
         self.tensornet_representation_module = TensorNetRepresentation(


### PR DESCRIPTION
## Description
The `CoreNetwork` constructor has an unused parameter named `cutoff`. This PR removes this parameter from the constructor signature and all calls to it.

## Status
- [x] Ready to go