### PR TITLE
Fixed error in spice2.yaml file.  

### DIFF
--- a/modelforge/dataset/yaml_files/spice2.yaml
+++ b/modelforge/dataset/yaml_files/spice2.yaml
@@ -4,29 +4,29 @@ latest_test: nc_1000_v0
 full_dataset_v0:
   version: 0
   gz_data_file:
-    length: 26313472231
-    md5: 244a559a6062bbec5c9cb49af036ff7d
-    name: SPICE2_dataset.hdf5.gz
+    length: 26313472234
+    md5: 59d9f80d72ed25bb3b271d5e77994b46
+    name: SPICE2_dataset_v0.hdf5.gz
   hdf5_data_file:
-    md5: 9659a0f18050b9e7b122c0046b705480
-    name: SPICE2_dataset.hdf5
+    md5: 653d430eb42ac631b45a22da45e4026f
+    name: SPICE2_dataset_v0.hdf5
   processed_data_file:
     md5: null
-    name: SPICE2_dataset_processed.npz
-  url: https://www.dropbox.com/scl/fi/yvzxsbk2j8z4z5b5ww7rn/spice_2_dataset_v0.hdf5.gz?rlkey=t3ebtgc2ktm45v8mowqlytg6d&st=mw5vq1vf&dl=1
+    name: SPICE2_dataset_v0_processed.npz
+  url: https://www.dropbox.com/scl/fi/yvzxsbk2j8z4z5b5ww7rn/spice_2_dataset_v0.hdf5.gz?rlkey=t3ebtgc2ktm45v8mowqlytg6d&st=r9zgdiq0&dl=1
 nc_1000_v0:
   version: 0
   gz_data_file:
-    length: 26751220
-    md5: 04063f08a7ec93abfc661c22b12ceeb0
-    name: SPICE2_dataset_nc_1000.hdf5.gz
+    length: 26751223
+    md5: 86579601617309feeb13d30ad130a774
+    name: SPICE2_dataset_v0_nc_1000.hdf5.gz
   hdf5_data_file:
     md5: 0a2554d0dba4f289dd93670686e4842e
-    name: SPICE2_dataset_nc_1000.hdf5
+    name: SPICE2_dataset_v0_nc_1000.hdf5
   processed_data_file:
     md5: null
-    name: SPICE2_dataset_nc_1000_processed.npz
-  url: https://www.dropbox.com/scl/fi/feb54dn1y1tvzkl7d6dmi/spice_2_dataset_v0_ntc_1000.hdf5.gz?rlkey=p9uqdgva7k7385sp6udjnoyy4&st=qlkra62d&dl=1
+    name: SPICE2_dataset_v0_nc_1000_processed.npz
+  url: https://www.dropbox.com/scl/fi/feb54dn1y1tvzkl7d6dmi/spice_2_dataset_v0_ntc_1000.hdf5.gz?rlkey=p9uqdgva7k7385sp6udjnoyy4&st=1ydq2ipd&dl=1
 full_dataset_v0_HCNOFClS:
   version: 0
   gz_data_file:

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -6,6 +6,28 @@ from typing import Optional, Dict
 from dataclasses import dataclass
 
 
+# let us setup a few pytest options
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run_data_download",
+        action="store_true",
+        default=False,
+        help="run slow data download tests",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run_data_download"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_data_download = pytest.mark.skip(
+        reason="need --run_data_download option to run"
+    )
+    for item in items:
+        if "data_download" in item.keywords:
+            item.add_marker(skip_data_download)
+
+
 from modelforge.potential.utils import BatchData
 
 

--- a/modelforge/tests/pytest.ini
+++ b/modelforge/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers=
+    data_download: marks a test as a data download test that will be skipped by default (use --run-data-download to run)

--- a/modelforge/tests/test_dataset_downloads.py
+++ b/modelforge/tests/test_dataset_downloads.py
@@ -1,0 +1,53 @@
+import pytest
+from modelforge.dataset.dataset import DatasetFactory
+from modelforge.dataset import _ImplementedDatasets
+from modelforge.dataset.qm9 import QM9Dataset
+
+
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("data_download_tests")
+    return fn
+
+
+dataset_versions = {
+    "QM9": ["nc_1000_v0", "full_dataset_v0"],
+    "ANI1X": ["nc_1000_v0", "full_dataset_v0"],
+    "ANI2X": ["nc_1000_v0", "full_dataset_v0"],
+    "SPICE114": [
+        "nc_1000_v0",
+        "full_dataset_v0",
+        "full_dataset_v0_HCNOFClS",
+        "nc_1000_v0_HCNOFClS",
+    ],
+    "SPICE2": [
+        "nc_1000_v0",
+        "full_dataset_v0",
+        "full_dataset_v0_HCNOFClS",
+        "nc_1000_v0_HCNOFClS",
+    ],
+    "SPICE114_OPENFF": [
+        "nc_1000_v0",
+        "full_dataset_v0",
+        "full_dataset_v0_HCNOFClS",
+        "nc_1000_v0_HCNOFClS",
+    ],
+    "PHALKETHOH": ["nc_1000_v0", "full_dataset_v0"],
+}
+
+dataset_and_version = []
+for name in _ImplementedDatasets.get_all_dataset_names():
+    for version in dataset_versions[name]:
+        dataset_and_version.append((name, version))
+
+
+@pytest.mark.parametrize("dataset_name, version", dataset_and_version)
+@pytest.mark.data_download
+def test_download_download(dataset_name, version, prep_temp_dir):
+    local_cache_dir = "/home/cri/downloads"  # str(prep_temp_dir)
+
+    # if version in dataset_versions[dataset_name]:
+    data = _ImplementedDatasets.get_dataset_class(dataset_name)(
+        version_select=version, local_cache_dir=local_cache_dir, force_download=True
+    )
+    data._download()

--- a/scripts/perform_training.py
+++ b/scripts/perform_training.py
@@ -43,10 +43,8 @@ def perform_training(
     dm.prepare_data()
     dm.setup()
 
-
     model.model.core_module.readout_module.E_i_mean = dm.dataset_statistics.E_i_mean
     model.model.core_module.readout_module.E_i_stddev = dm.dataset_statistics.E_i_stddev
-
 
     # from modelforge.utils.misc import visualize_model
 
@@ -68,7 +66,8 @@ def perform_training(
 if __name__ == "__main__":
     from modelforge.potential import _Implemented_NNPs
 
-    for model_name in ['SchNet']:
+    print(_Implemented_NNPs)
+    for model_name in ["SCHNET"]:
 
         dataset_name = "QM9"
         nr_of_repeats = 5
@@ -76,5 +75,5 @@ if __name__ == "__main__":
         for i in range(nr_of_repeats):
             print("Running training iteration:", i)
             perform_training(
-                model_name, dataset_name, nr_of_epochs=1000, accelerator="cpu"
+                model_name, dataset_name, nr_of_epochs=1000, accelerator="gpu"
             )


### PR DESCRIPTION
Added in test to check dataset download.  The tests will be skipped ( only will run if --run_data_download is passed to the CLI).  This test will take a lot of time so I'm sure this is not something we would want to do with any frequency. It might be worth creating separate tests (instead of parameterize) to make it easier to just specifically test a given dataset. 

It might also be better to make this NOT a pytest test and just a separate piece of code that gives more options to check/test very specific datasets and versions and give more descriptive outputs.  Having something like that in the dataset module, where people can more easily query available datasets and versions. 


## Status
- [x] Ready to go