### PR TITLE
Splitting pairlist and neighborlist calculation

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - "ref-toml"
   schedule:
     # Weekly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -1038,7 +1038,7 @@ class DataModule(pl.LightningDataModule):
                 ],
                 atomic_subsystem_indices=torch.zeros(
                     end_idx - start_idx,
-                    dtype=torch.float32,
+                    dtype=torch.int16,
                 ),
             )
 

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -1030,8 +1030,10 @@ class DataModule(pl.LightningDataModule):
 
             # perform pairlist calculation
             pairlist_output = self.calculate_distances_and_pairlist(
-                dataset.properties_of_interest["positions"][start_idx:end_idx],
-                torch.zeros(
+                positions=dataset.properties_of_interest["positions"][
+                    start_idx:end_idx
+                ],
+                atomic_subsystem_indices=torch.zeros(
                     end_idx - start_idx,
                     dtype=torch.float32,
                 ),

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -93,7 +93,9 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
             )
 
         self.number_of_records = len(dataset["atomic_subsystem_counts"])
+        self.properties_of_interest["pair_ list"] = None
         self.number_of_atoms = len(dataset["atomic_numbers"])
+
         single_atom_start_idxs_by_rec = np.concatenate(
             [[0], np.cumsum(dataset["atomic_subsystem_counts"])]
         )
@@ -209,11 +211,12 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
         ]
         E = self.properties_of_interest["E"][idx]
         F = self.properties_of_interest["F"][series_atom_start_idx:series_atom_end_idx]
-
+        pair_list = self.properties_of_interest["pair_list"][idx]
         Q = self.properties_of_interest["Q"][idx]
 
         return {
             "atomic_numbers": atomic_numbers,
+            "pair_list": pair_list,
             "positions": positions,
             "total_charge": Q,
             "E": E,
@@ -732,6 +735,7 @@ class DatasetFactory:
 
 
 from torch import nn
+from openff.units import unit
 
 
 class DataModule(pl.LightningDataModule):
@@ -740,6 +744,7 @@ class DataModule(pl.LightningDataModule):
         self,
         name: Literal["QM9", "ANI1X", "ANI2X", "SPICE114", "SPICE2", "SPICE114_OPENFF"],
         splitting_strategy: SplittingStrategy = RandomRecordSplittingStrategy(),
+        neighborlist_cutoff: unit.Quantity = 7.0 * unit.angstrom,
         batch_size: int = 64,
         remove_self_energies: bool = True,
         atomic_self_energies: Optional[Dict[str, float]] = None,
@@ -802,6 +807,11 @@ class DataModule(pl.LightningDataModule):
         # make sure we can handle a path with a ~ in it
         self.local_cache_dir = os.path.expanduser(local_cache_dir)
         self.regenerate_cache = regenerate_cache
+        from modelforge.potential.models import Neighborlist
+
+        self.calculate_distances_and_pairlist = Neighborlist(
+            neighborlist_cutoff, only_unique_pairs=False
+        )
 
     def prepare_data(
         self,
@@ -837,15 +847,16 @@ class DataModule(pl.LightningDataModule):
 
         atomic_self_energies = AtomicSelfEnergies(atomic_self_energies)
 
-        # remove the self energies if requested
-        if self.remove_self_energies:
-            log.debug("Remove self energies ...")
-            self._process_self_energies(torch_dataset, atomic_self_energies)
+        log.debug("Process dataset ...")
+        self._process_dataset(torch_dataset, atomic_self_energies)
 
+        # # calculate neighborlist
+        # self._calculating_pairwise_properties(torch_dataset)
         # calculate the dataset statistic of the dataset
         # This is done __after__ self energies are removed (if requested)
         from modelforge.dataset.utils import calculate_mean_and_variance
 
+        # FIXME: this wont work for a setup on multiple devices
         stats = calculate_mean_and_variance(torch_dataset)
         self.dataset_statistics = DatasetStatistics(
             E_i_stddev=stats["Ei_stddev"],
@@ -861,7 +872,7 @@ class DataModule(pl.LightningDataModule):
         """Create a PyTorch dataset from the provided dataset instance."""
         return DatasetFactory().create_dataset(dataset)
 
-    def _process_self_energies(
+    def _process_dataset(
         self, torch_dataset: TorchDataset, atomic_self_energies: "AtomicSelfEnergies"
     ) -> None:
         """Calculate and subtract self energies from the dataset."""
@@ -871,7 +882,7 @@ class DataModule(pl.LightningDataModule):
             atomic_self_energies = AtomicSelfEnergies(
                 self.calculate_self_energies(torch_dataset)
             )
-        self._subtract_self_energies(torch_dataset, atomic_self_energies)
+        self._per_datapoint_operations(torch_dataset, atomic_self_energies)
         self._save_self_energies(atomic_self_energies)
 
     def _normalize_dataset(self, torch_dataset, stats: Dict[str, float]) -> None:
@@ -968,7 +979,26 @@ class DataModule(pl.LightningDataModule):
             torch_dataset=torch_dataset, collate_fn=collate_fn
         )
 
-    def _subtract_self_energies(
+    # def _calculating_pairwise_properties(self, dataset):
+    #     from tqdm import tqdm
+
+    #     log.info(
+    #         f"Calculate neighborlist with {self.calculate_distances_and_pairlist} cutoff"
+    #     )
+    #     print(dataset.properties_of_interest.keys())
+    #     for i in tqdm(range(len(dataset)), desc="Calculate neighborlist"):
+    #         a = dataset[i]
+    #         start_idx = dataset.single_atom_start_idxs_by_conf[i]
+    #         end_idx = dataset.single_atom_end_idxs_by_conf[i]
+    #         pairlist_output = self.calculate_distances_and_pairlist(
+    #             dataset.properties_of_interest["positions"][start_idx:end_idx],
+    #             torch.zeros(
+    #                 end_idx - start_idx,
+    #                 dtype=torch.float32,
+    #             ),
+    #         )
+
+    def _per_datapoint_operations(
         self, dataset, self_energies: "AtomicSelfEnergies"
     ) -> None:
         """
@@ -983,17 +1013,51 @@ class DataModule(pl.LightningDataModule):
 
         from tqdm import tqdm
 
-        log.info("Removing self energies from the dataset")
-        for i in tqdm(range(len(dataset)), desc="Removing Self Energies"):
+        # remove the self energies if requested
+        if self.remove_self_energies:
+            log.info("Removing self energies from the dataset")
+
+        all_pairs = []
+        nr_of_pairs = []
+        for i in tqdm(range(len(dataset)), desc="Process dataset"):
             start_idx = dataset.single_atom_start_idxs_by_conf[i]
             end_idx = dataset.single_atom_end_idxs_by_conf[i]
-
             energy = torch.sum(
                 self_energies.ase_tensor_for_indexing[
                     dataset.properties_of_interest["atomic_numbers"][start_idx:end_idx]
                 ]
             )
-            dataset[i] = {"E": dataset.properties_of_interest["E"][i] - energy}
+
+            # perform pairlist calculation
+            pairlist_output = self.calculate_distances_and_pairlist(
+                dataset.properties_of_interest["positions"][start_idx:end_idx],
+                torch.zeros(
+                    end_idx - start_idx,
+                    dtype=torch.float32,
+                ),
+            )
+
+            pair_list = pairlist_output.pair_indices.to(dtype=torch.int16)
+
+            nr_of_pairs.append(pair_list.shape[1])
+            all_pairs.append(pair_list)
+
+            if self.remove_self_energies:
+                dataset[i] = {"E": dataset.properties_of_interest["E"][i] - energy}
+
+        # Determine N (number of tensors) and K (maximum M)
+        N = len(all_pairs)
+        K = max(nr_of_pairs)
+
+        # Initialize the padded tensor with shape (N, 2, K) filled with -1
+        padded_pair_list = torch.full((N, 2, K), -1, dtype=torch.int16)
+
+        # Copy each tensor into the appropriate slice of the padded tensor
+        for i, ij in enumerate(all_pairs):
+            M = ij.size(1)
+            padded_pair_list[i, :, :M] = ij
+
+        dataset.properties_of_interest["pair_list"] = padded_pair_list
 
     def train_dataloader(
         self, num_workers: int = 4, shuffle: bool = True, pin_memory: bool = False
@@ -1058,10 +1122,22 @@ def collate_conformers(conf_list: List[Dict[str, torch.Tensor]]) -> "BatchData":
     F_list = []  # forces
     E_list = []  # total energy
     Q_list = []  # total charge
+    ij_list = []
     atomic_subsystem_counts = []
     atomic_subsystem_indices = []
     atomic_subsystem_indices_referencing_dataset = []
+    offset = torch.tensor([0], dtype=torch.int32)
     for idx, conf in enumerate(conf_list):
+        ## pairlist
+        # generate pairlist mask
+        pair_list_mask = conf["pair_list"] != -1
+        # generate pairlist without padded values
+        pair_list = (
+            conf["pair_list"][pair_list_mask].view(2, -1).to(dtype=torch.int32) + offset
+        )
+        # update offset (for making sure the pair_list indices are pointing to the correct molecule)
+        offset += conf["atomic_numbers"].shape[0]
+        ij_list.append(pair_list)
         Z_list.append(conf["atomic_numbers"])
         R_list.append(conf["positions"])
         E_list.append(conf["E"])
@@ -1076,6 +1152,7 @@ def collate_conformers(conf_list: List[Dict[str, torch.Tensor]]) -> "BatchData":
     total_charge_cat = torch.cat(Q_list)
     positions_cat = torch.cat(R_list).requires_grad_(True)
     F_cat = torch.cat(F_list).to(torch.float64)
+    IJ_cat = torch.cat(ij_list, dim=1)
     E_stack = torch.stack(E_list)
     nnp_input = NNPInput(
         atomic_numbers=atomic_numbers_cat,
@@ -1084,6 +1161,7 @@ def collate_conformers(conf_list: List[Dict[str, torch.Tensor]]) -> "BatchData":
         atomic_subsystem_indices=torch.tensor(
             atomic_subsystem_indices, dtype=torch.int32
         ),
+        pair_list=IJ_cat,
     )
     metadata = Metadata(
         E=E_stack,

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -79,49 +79,43 @@ class Pairlist(Module):
         atomic_subsystem_indices : torch.Tensor, shape (nr_atoms_per_systems)
             Atom indices to indicate which atoms belong to which molecule
         """
-        # generate index grid
-        n = len(atomic_subsystem_indices)
 
         # get device that passed tensors lives on, initialize on the same device
         device = atomic_subsystem_indices.device
 
-        i_final_pairs = torch.tensor([], dtype=torch.int64, device=device)
-        j_final_pairs = torch.tensor([], dtype=torch.int64, device=device)
+        # atomic_subsystem_indices are numbered from 0 to n_molecules - 1
+        #  we can use bincount to get the number of atoms in each molecule
+        # which we can use to construct smaller tensors
+        repeats = torch.bincount(atomic_subsystem_indices)
+        offsets = torch.cat(
+            (torch.tensor([0], device=device), torch.cumsum(repeats, dim=0)[:-1])
+        )
 
-        # to avoid allocating very large tensors, we will wrap this in a loop where we allocate tensors of size n-1
-        # and concatenate the results, rather than allocating tensors of size n*(n-1).
-
-        for ii in range(0, n):
-            # Repeat each number n-1 times for i_indices
-            i_indices = torch.repeat_interleave(
-                torch.tensor(ii, device=device),
-                repeats=n - 1,
-            )
-
-            # Correctly construct j_indices
-            j_indices = torch.cat(
-                (
-                    torch.arange(ii, device=device),
-                    torch.arange(ii + 1, n, device=device),
+        i_indices = torch.cat(
+            [
+                torch.repeat_interleave(
+                    torch.arange(o, o + r, device=device), repeats=r
                 )
-            )
+                for r, o in zip(repeats, offsets)
+            ]
+        )
+        j_indices = torch.cat(
+            [
+                torch.cat([torch.arange(o, o + r, device=device) for _ in range(r)])
+                for r, o in zip(repeats, offsets)
+            ]
+        )
 
-            # filter pairs to only keep those belonging to the same molecule
-            same_molecule_mask = (
-                atomic_subsystem_indices[i_indices]
-                == atomic_subsystem_indices[j_indices]
-            )
-            i_final_pairs_temp = i_indices[same_molecule_mask]
-            j_final_pairs_temp = j_indices[same_molecule_mask]
-
-            if self.only_unique_pairs:
-                # filter out pairs that are not unique
-                unique_pairs_mask = i_final_pairs_temp < j_final_pairs_temp
-                i_final_pairs_temp = i_final_pairs_temp[unique_pairs_mask]
-                j_final_pairs_temp = j_final_pairs_temp[unique_pairs_mask]
-
-            i_final_pairs = torch.cat((i_final_pairs, i_final_pairs_temp), dim=0)
-            j_final_pairs = torch.cat((j_final_pairs, j_final_pairs_temp), dim=0)
+        if self.only_unique_pairs:
+            # filter out pairs that are not unique
+            unique_pairs_mask = i_indices < j_indices
+            i_final_pairs = i_indices[unique_pairs_mask]
+            j_final_pairs = j_indices[unique_pairs_mask]
+        else:
+            # filter out identical values
+            unique_pairs_mask = i_indices != j_indices
+            i_final_pairs = i_indices[unique_pairs_mask]
+            j_final_pairs = j_indices[unique_pairs_mask]
 
         # concatenate to form final (2, n_pairs) tensor
         pair_indices = torch.stack((i_final_pairs, j_final_pairs))

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -215,8 +215,10 @@ class Neighborlist(Pairlist):
 
     def forward(
         self,
+        *,
         positions: torch.Tensor,
         atomic_subsystem_indices: torch.Tensor,
+        pair_indices: Optional[torch.Tensor] = None,
     ) -> PairListOutputs:
         """
         Forward pass to compute neighbor list considering a cutoff distance.
@@ -238,9 +240,11 @@ class Neighborlist(Pairlist):
             A NamedTuple containing 'pair_indices', 'd_ij' (distances), and 'r_ij' (displacement vectors).
         """
 
-        pair_indices = self.enumerate_all_pairs(
-            atomic_subsystem_indices,
-        )
+        if not pair_indices:
+            pair_indices = self.enumerate_all_pairs(
+                atomic_subsystem_indices,
+            )
+
         r_ij = self.calculate_r_ij(pair_indices, positions)
         d_ij = self.calculate_d_ij(r_ij)
 
@@ -536,7 +540,9 @@ class InputPreparation(torch.nn.Module):
         atomic_subsystem_indices = data.atomic_subsystem_indices
 
         pairlist_output = self.calculate_distances_and_pairlist(
-            positions, atomic_subsystem_indices
+            positions=positions,
+            atomic_subsystem_indices=atomic_subsystem_indices,
+            pair_indices=data.pair_list,
         )
 
         return pairlist_output

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -535,12 +535,18 @@ class InputPreparation(torch.nn.Module):
         # general input manipulation
         positions = data.positions
         atomic_subsystem_indices = data.atomic_subsystem_indices
-
-        pairlist_output = self.calculate_distances_and_pairlist(
-            positions=positions,
-            atomic_subsystem_indices=atomic_subsystem_indices,
-            pair_indices=data.pair_list.to(torch.int64),
-        )
+        if data.pair_list is None:
+            pairlist_output = self.calculate_distances_and_pairlist(
+                positions=positions,
+                atomic_subsystem_indices=atomic_subsystem_indices,
+                pair_indices=None,
+            )
+        else:
+            pairlist_output = self.calculate_distances_and_pairlist(
+                positions=positions,
+                atomic_subsystem_indices=atomic_subsystem_indices,
+                pair_indices=data.pair_list.to(torch.int64),
+            )
 
         return pairlist_output
 

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -551,7 +551,7 @@ class InputPreparation(torch.nn.Module):
         pairlist_output = self.calculate_distances_and_pairlist(
             positions=positions,
             atomic_subsystem_indices=atomic_subsystem_indices,
-            pair_indices=data.pair_list,
+            pair_indices=data.pair_list.to(torch.int64),
         )
 
         return pairlist_output

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1,5 +1,15 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Mapping, NamedTuple, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Mapping,
+    NamedTuple,
+    Tuple,
+    Type,
+    Union,
+    Optional,
+)
 
 import lightning as pl
 import torch
@@ -215,7 +225,6 @@ class Neighborlist(Pairlist):
 
     def forward(
         self,
-        *,
         positions: torch.Tensor,
         atomic_subsystem_indices: torch.Tensor,
         pair_indices: Optional[torch.Tensor] = None,
@@ -240,7 +249,7 @@ class Neighborlist(Pairlist):
             A NamedTuple containing 'pair_indices', 'd_ij' (distances), and 'r_ij' (displacement vectors).
         """
 
-        if not pair_indices:
+        if pair_indices is None:
             pair_indices = self.enumerate_all_pairs(
                 atomic_subsystem_indices,
             )

--- a/modelforge/potential/processing.py
+++ b/modelforge/potential/processing.py
@@ -14,8 +14,8 @@ class FromAtomToMoleculeReduction(torch.nn.Module):
         """
         super().__init__()
         # turn the following parameters in torch buffer
-        self.register_buffer("E_i_mean", torch.tensor([0.0]))
-        self.register_buffer("E_i_stddev", torch.tensor([1.0]))
+        self.E_i_mean = torch.tensor([0.0])
+        self.E_i_stddev = torch.tensor([1.0])
 
     def forward(
         self, x: torch.Tensor, atomic_subsystem_indices: torch.Tensor

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -78,7 +78,6 @@ class NNPInput:
         self.atomic_numbers = self.atomic_numbers.to(torch.int32)
         self.atomic_subsystem_indices = self.atomic_subsystem_indices.to(torch.int32)
         self.total_charge = self.total_charge.to(torch.int32)
-        self.pair_list = self.pair_list.to(torch.int32)
 
         # Unit conversion for positions
         if isinstance(self.positions, Quantity):

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -44,13 +44,15 @@ class NNPInput:
     total_charge : torch.Tensor
         A tensor with the total charge of molecule.
         Shape: [num_systems], where `num_systems` is the number of molecules.
+    pair_list : Optional[torch.Tensor]
+        An optional tensor containing pairs of indices or other relevant information.
     """
 
     atomic_numbers: torch.Tensor
     positions: Union[torch.Tensor, Quantity]
     atomic_subsystem_indices: torch.Tensor
     total_charge: torch.Tensor
-    pair_list: torch.Tensor
+    pair_list: Optional[torch.Tensor] = None
 
     def to(
         self,

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -93,7 +93,7 @@ def single_batch(batch_size: int = 64):
         batch_size=batch_size,
         version_select="nc_1000_v0",
     )
-    return next(iter(data_module.train_dataloader()))
+    return next(iter(data_module.train_dataloader(shuffle=False)))
 
 
 @pytest.fixture(scope="session")

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -106,10 +106,12 @@ def test_modelforge_ani(setup_two_methanes):
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/ani2x_defaults.toml"
-    )
+    file_path = resources.files(potential_defaults) / f"ani2x_defaults.toml"
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -317,10 +319,12 @@ def test_representation(setup_methane):
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/ani2x_defaults.toml"
-    )
+    file_path = resources.files(potential_defaults) / f"ani2x_defaults.toml"
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -116,7 +116,8 @@ def test_modelforge_ani(setup_two_methanes):
     potential_parameters = config["potential"].get("potential_parameters", {})
 
     _, _, _, mf_input = setup_two_methanes
-    model = mf_ANI2x(**potential_parameters)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = mf_ANI2x(**potential_parameters).to(device=device)
     energy = model(mf_input)
     derivative = torch.autograd.grad(energy.E.sum(), mf_input.positions)[0]
     force = -derivative

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -193,7 +193,7 @@ def test_different_properties_of_interest(dataset_name, dataset_factory, prep_te
 
     raw_data_item = dataset[0]
     assert isinstance(raw_data_item, dict)
-    assert len(raw_data_item) == 7  # 7 properties are returned
+    assert len(raw_data_item) == 8  # 8 properties are returned
 
 
 @pytest.mark.parametrize("dataset_name", ["QM9"])

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -447,6 +447,38 @@ def test_data_item_format_of_datamodule(
     )
 
 
+from modelforge.potential import _Implemented_NNPs
+
+
+@pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())
+@pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
+def test_dataset_neighborlist(model_name, dataset_name, datamodule_factory):
+    """Test the splitting of the dataset."""
+
+    dataset = datamodule_factory(dataset_name=dataset_name)
+    train_dataloader = dataset.train_dataloader()
+    batch = next(iter(train_dataloader))
+
+    # test that the neighborlist is correctly generated
+    # cast input and model to torch.float64
+    from modelforge.train.training import return_toml_config
+
+    config = return_toml_config(
+        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    )
+    # Extract parameters
+    potential_parameters = config["potential"].get("potential_parameters", {})
+    from modelforge.potential.models import NeuralNetworkPotentialFactory
+
+    model = NeuralNetworkPotentialFactory.create_nnp(
+        use="inference",
+        model_type=model_name,
+        simulation_environment="PyTorch",
+        model_parameters=potential_parameters,
+    )
+    model(batch.nnp_input)
+
+
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
 def test_dataset_generation(dataset_name, datamodule_factory):
     """Test the splitting of the dataset."""

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -469,10 +469,14 @@ def test_dataset_neighborlist(model_name, dataset_name, datamodule_factory):
     # test that the neighborlist is correctly generated
     # cast input and model to torch.float64
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    file_path = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
     from modelforge.potential.models import NeuralNetworkPotentialFactory

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -455,7 +455,14 @@ from modelforge.potential import _Implemented_NNPs
 def test_dataset_neighborlist(model_name, dataset_name, datamodule_factory):
     """Test the splitting of the dataset."""
 
-    dataset = datamodule_factory(dataset_name=dataset_name)
+    if dataset_name.lower().startswith("spice"):
+        print("using subset")
+        dataset = datamodule_factory(
+            dataset_name=dataset_name, version_select="nc_1000_v0_HCNOFClS"
+        )
+    else:
+        dataset = datamodule_factory(dataset_name=dataset_name)
+
     train_dataloader = dataset.train_dataloader()
     batch = next(iter(train_dataloader))
 

--- a/modelforge/tests/test_dataset_downloads.py
+++ b/modelforge/tests/test_dataset_downloads.py
@@ -37,8 +37,9 @@ dataset_versions = {
 
 dataset_and_version = []
 for name in _ImplementedDatasets.get_all_dataset_names():
-    for version in dataset_versions[name]:
-        dataset_and_version.append((name, version))
+    if name in dataset_versions.keys():
+        for version in dataset_versions[name]:
+            dataset_and_version.append((name, version))
 
 
 @pytest.mark.parametrize("dataset_name, version", dataset_and_version)

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -398,7 +398,7 @@ def test_pairlist():
     from modelforge.potential.models import Pairlist, Neighborlist
     import torch
 
-    atomic_subsystem_indices = torch.tensor([80, 80, 80, 11, 11, 11])
+    atomic_subsystem_indices = torch.tensor([0, 0, 0, 1, 1, 1])
     positions = torch.tensor(
         [
             [0.0, 0.0, 0.0],

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -258,8 +258,12 @@ def test_forward_pass(
     if "JAX" not in str(type(model)):
 
         # assert that the following tensor has equal values for dim=0 index 1 to 4 and 6 to 8
-        assert torch.allclose(output.E_i[1:4], output.E_i[1])
-        assert torch.allclose(output.E_i[6:8], output.E_i[6])
+        assert torch.allclose(output.E_i[1:4], output.E_i[1], atol=1e-5)
+        assert torch.allclose(output.E_i[6:8], output.E_i[6], atol=1e-5)
+
+        # make sure that the total energy is \sum E_i
+        assert torch.allclose(output.E[0], output.E_i[0:5].sum(dim=0), atol=1e-5)
+        assert torch.allclose(output.E[1], output.E_i[5:9].sum(dim=0), atol=1e-5)
 
 
 @pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -13,10 +13,15 @@ def test_JAX_wrapping(model_name, single_batch_with_batchsize_64):
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import potential_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    filename = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -49,10 +54,15 @@ def test_model_factory(model_name, simulation_environment):
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import potential_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    filename = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -67,9 +77,14 @@ def test_model_factory(model_name, simulation_environment):
         model_name.upper() in str(type(model)).upper()
         or "JAX" in str(type(model)).upper()
     )
-    config = return_toml_config(
-        f"modelforge/tests/data/training_defaults/{model_name.lower()}_qm9.toml"
-    )
+
+    from modelforge.tests.data import training_defaults
+    from importlib import resources
+
+    filename = resources.files(training_defaults) / f"{model_name.lower()}_qm9.toml"
+
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
     training_parameters = config["training"].get("training_parameters", {})
@@ -107,10 +122,12 @@ def test_energy_scaling_and_offset():
     # initialize model
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import potential_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/ani2x_defaults.toml"
-    )
+    filename = resources.files(potential_defaults) / "ani2x_defaults.toml"
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -147,10 +164,13 @@ def test_state_dict_saving_and_loading(model_name):
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import training_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/training_defaults/{model_name.lower()}_qm9.toml"
-    )
+    filename = resources.files(training_defaults) / f"{model_name.lower()}_qm9.toml"
+
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
     training_parameters = config["training"].get("training_parameters", {})
@@ -185,10 +205,14 @@ def test_energy_between_simulation_environments(
     # test the forward pass through each of the models
     # cast input and model to torch.float64
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import potential_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    filename = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -229,10 +253,14 @@ def test_forward_pass(
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import potential_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    filename = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -276,10 +304,15 @@ def test_calculate_energies_and_forces(
     """
     import torch
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import potential_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    filename = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -288,14 +321,6 @@ def test_calculate_energies_and_forces(
     nr_of_mols = nnp_input.atomic_subsystem_indices.unique().shape[0]
     nr_of_atoms_per_batch = nnp_input.atomic_subsystem_indices.shape[0]
 
-    # read default parameters
-    from modelforge.train.training import return_toml_config
-
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
-    )
-    # Extract parameters
-    potential_parameters = config["potential"].get("potential_parameters", {})
     # The inference_model fixture now returns a function that expects an environment
     model = NeuralNetworkPotentialFactory.create_nnp(
         use="inference",
@@ -557,10 +582,15 @@ def test_casting(model_name, single_batch_with_batchsize_64):
 
     # cast input and model to torch.float64
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import potential_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    filename = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -605,10 +635,15 @@ def test_equivariant_energies_and_forces(
 
     # cast input and model to torch.float64
     from modelforge.train.training import return_toml_config
+    from modelforge.tests.data import potential_defaults
+    from importlib import resources
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+    filename = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+
+    config = return_toml_config(filename)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -9,10 +9,12 @@ def test_PaiNN_init():
     """Test initialization of the PaiNN neural network potential."""
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/painn_defaults.toml"
-    )
+    file_path = resources.files(potential_defaults) / f"painn_defaults.toml"
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -70,10 +72,12 @@ def test_painn_interaction_equivariance(single_batch_with_batchsize_64):
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/painn_defaults.toml"
-    )
+    file_path = resources.files(potential_defaults) / f"painn_defaults.toml"
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 

--- a/modelforge/tests/test_physnet.py
+++ b/modelforge/tests/test_physnet.py
@@ -2,11 +2,16 @@ def test_physnet_init():
 
     from modelforge.potential.physnet import PhysNet
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
     model_name = "PhysNet"
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+
+    file_path = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -19,11 +24,16 @@ def test_physnet_forward(single_batch_with_batchsize_64):
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
     model_name = "PhysNet"
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+
+    file_path = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
     potential_parameters["number_of_modules"] = 1

--- a/modelforge/tests/test_sake.py
+++ b/modelforge/tests/test_sake.py
@@ -18,11 +18,16 @@ IN_MAC = platform == "darwin"
 def test_SAKE_init():
     """Test initialization of the SAKE neural network potential."""
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
     model_name = "SAKE"
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+
+    file_path = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -41,11 +46,16 @@ def test_sake_forward(single_batch_with_batchsize_64):
     methane = single_batch_with_batchsize_64.nnp_input
 
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
     model_name = "SAKE"
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+
+    file_path = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -103,11 +113,16 @@ def test_sake_layer_equivariance(h_atol, eq_atol, single_batch_with_batchsize_64
     rotation_matrix = torch.tensor([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
 
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
     model_name = "SAKE"
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+
+    file_path = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
     potential_parameters["number_of_atom_features"] = nr_atom_basis
@@ -581,11 +596,16 @@ def test_model_invariance(single_batch_with_batchsize_1):
     from dataclasses import replace
 
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
     model_name = "SAKE"
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+
+    file_path = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -8,11 +8,16 @@ def test_Schnet_init():
     from modelforge.potential.schnet import SchNet
 
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import potential_defaults
 
     model_name = "SchNet"
-    config = return_toml_config(
-        f"modelforge/tests/data/potential_defaults/{model_name.lower()}_defaults.toml"
+
+    file_path = (
+        resources.files(potential_defaults) / f"{model_name.lower()}_defaults.toml"
     )
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
     schnet = SchNet(**potential_parameters)

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -21,10 +21,15 @@ def test_train_with_lightning(model_name, dataset_name, include_force):
     """
 
     from modelforge.train.training import return_toml_config, perform_training
+    from importlib import resources
+    from modelforge.tests.data import training_defaults
 
-    config = return_toml_config(
-        f"modelforge/tests/data/training_defaults/{model_name.lower()}_{dataset_name.lower()}.toml"
+    file_path = (
+        resources.files(training_defaults)
+        / f"{model_name.lower()}_{dataset_name.lower()}.toml"
     )
+    config = return_toml_config(file_path)
+
     from pytorch_lightning.loggers import TensorBoardLogger
 
     logger = TensorBoardLogger("tb_logs", name="training")
@@ -63,10 +68,14 @@ def test_loss(model_name, dataset_name, datamodule_factory):
 
     # read default parameters
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import training_defaults
 
-    config = return_toml_config(
-        f"modelforge/tests/data/training_defaults/{model_name.lower()}_{dataset_name.lower()}.toml"
+    file_path = (
+        resources.files(training_defaults)
+        / f"{model_name.lower()}_{dataset_name.lower()}.toml"
     )
+    config = return_toml_config(file_path)
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
 
@@ -96,11 +105,15 @@ def test_loss(model_name, dataset_name, datamodule_factory):
 @pytest.mark.parametrize("dataset_name", ["QM9"])
 def test_hypterparameter_tuning_with_ray(model_name, dataset_name, datamodule_factory):
     from modelforge.train.training import return_toml_config
+    from importlib import resources
+    from modelforge.tests.data import training_defaults
+
+    file_path = resources.files(training_defaults) / f"{model_name.lower()}_qm9.toml"
 
     dm = datamodule_factory(dataset_name=dataset_name)
-    config = return_toml_config(
-        f"modelforge/tests/data/training_defaults/{model_name.lower()}_qm9.toml"
-    )
+
+    config = return_toml_config(file_path)
+
     # Extract parameters
     potential_parameters = config["potential"].get("potential_parameters", {})
     training_parameters = config["training"].get("training_parameters", {})

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,17 @@ setup(
     name="modelforge",
     version="0.1",
     packages=["modelforge"],
-    package_data={"modelforge": ["dataset/yaml_files/*", "curation/yaml_files/*"]},
+    package_data={
+        "modelforge": [
+            "dataset/yaml_files/*",
+            "curation/yaml_files/*",
+            "tests/data/potential_defaults/*",
+            "tests/data/training_defaults/*",
+        ]
+    },
     url="https://github.com/choderalab/modelforge",
     license="MIT",
-    author="Chodera lab, Christopher Iacovella, Marcus Wieder",
+    author="Chodera lab, Marcus Wieder, Christopher Iacovella, and others",
     author_email="",
     description="A library for building and training neural network potentials",
     include_package_data=True,


### PR DESCRIPTION
## Description
As discussed in issue #141 training takes too long and spends most of the compute time generating the pairlist. To move this from a per-epoch cost to a one-time cost this PR moves the calculation of the pairlist to the dataset and saves the pairlist. 
The pairlist is then passed, as an optional parameter, as input to the network. The Neighborlist class takes it as optional input and calculates distances to further filter it to the local neighborhood for each atom within a cutoff. 

## Todos.
  - [x] Cache pairlist calculation
  - [x] Add tests

## Status
- [x] Ready to go