### PR TITLE
Refactor pairlist representation

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -214,7 +214,9 @@ class TorchDataset(torch.utils.data.Dataset[Dict[str, torch.Tensor]]):
         if self.properties_of_interest["pair_list"] is None:
             pair_list = None
         else:
-            pair_list = self.properties_of_interest["pair_list"][idx]
+            pair_list_indices_start = self.properties_of_interest["number_of_pairs"][idx-1]
+            pair_list_indices_end = self.properties_of_interest["number_of_pairs"][idx]
+            pair_list = self.properties_of_interest["pair_list"][pair_list_indices_start:pair_list_indices_end]
         Q = self.properties_of_interest["Q"][idx]
 
         return {
@@ -1021,7 +1023,7 @@ class DataModule(pl.LightningDataModule):
             log.info("Removing self energies from the dataset")
 
         all_pairs = []
-        nr_of_pairs = []
+        nr_of_pairs = torch.zeros(size=(len(dataset.properties_of_interest["E"])+1,1))
         for i in tqdm(range(len(dataset)), desc="Process dataset"):
             start_idx = dataset.single_atom_start_idxs_by_conf[i]
             end_idx = dataset.single_atom_end_idxs_by_conf[i]
@@ -1044,25 +1046,17 @@ class DataModule(pl.LightningDataModule):
 
             pair_list = pairlist_output.pair_indices.to(dtype=torch.int16)
 
-            nr_of_pairs.append(pair_list.shape[1])
+            nr_of_pairs[i+1] = pair_list.shape[1]    # store the number of pairs for each molecule
+                                                    # starting at zero for indexing with [nr_of_pairs[i-1]:nr_of_pairs[i]]
             all_pairs.append(pair_list)
 
             if self.remove_self_energies:
                 dataset[i] = {"E": dataset.properties_of_interest["E"][i] - energy}
 
+        nr_of_pairs_in_dataset = torch.cumsum(nr_of_pairs, dim=0, dtype=torch.int64)
         # Determine N (number of tensors) and K (maximum M)
-        N = len(all_pairs)
-        K = max(nr_of_pairs)
-
-        # Initialize the padded tensor with shape (N, 2, K) filled with -1
-        padded_pair_list = torch.full((N, 2, K), -1, dtype=torch.int16)
-
-        # Copy each tensor into the appropriate slice of the padded tensor
-        for i, ij in enumerate(all_pairs):
-            M = ij.size(1)
-            padded_pair_list[i, :, :M] = ij
-
-        dataset.properties_of_interest["pair_list"] = padded_pair_list
+        dataset.properties_of_interest["pair_list"] = torch.cat(all_pairs, dim=1)
+        dataset.properties_of_interest["number_of_pairs"] = nr_of_pairs_in_dataset
 
     def train_dataloader(
         self, num_workers: int = 4, shuffle: bool = True, pin_memory: bool = False

--- a/modelforge/potential/processing.py
+++ b/modelforge/potential/processing.py
@@ -14,8 +14,8 @@ class FromAtomToMoleculeReduction(torch.nn.Module):
         """
         super().__init__()
         # turn the following parameters in torch buffer
-        self.E_i_mean = torch.tensor([0.0])
-        self.E_i_stddev = torch.tensor([1.0])
+        self.register_buffer("E_i_mean", torch.tensor([0.0]))
+        self.register_buffer("E_i_stddev", torch.tensor([1.0]))
 
     def forward(
         self, x: torch.Tensor, atomic_subsystem_indices: torch.Tensor

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -484,17 +484,89 @@ def test_dataset_neighborlist(model_name, single_batch_with_batchsize_64):
     # pairlist is in ascending order in row 0
     assert torch.all(pair_list[0, 1:] >= pair_list[0, :-1])
 
-    # first molecule is methane, check if bonds are correct
-    methan_bonds = pair_list[:, :16]
-    assert torch.any(torch.eq(
-        methan_bonds,
-        torch.tensor(
-            [
-                [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3],
-                [1, 2, 3, 4, 0, 2, 3, 4, 0, 1, 3, 4, 0, 1, 2, 3],
-            ]
-        ),
-    ) == False).item()
+    if model_name == "ANI1x":
+        # test the pairlist for the ANI potential (whith non-redundant atom pairs)
+        # TODO
+        pass
+    else:
+        # test the pairlist for message passing networks (with redundant atom pairs)
+        # first molecule is methane, check if bonds are correct
+        methan_bonds = pair_list[:, :20]
+
+        assert (
+            torch.any(
+                torch.eq(
+                    methan_bonds,
+                    torch.tensor(
+                        [
+                            [
+                                0,
+                                0,
+                                0,
+                                0,
+                                1,
+                                1,
+                                1,
+                                1,
+                                2,
+                                2,
+                                2,
+                                2,
+                                3,
+                                3,
+                                3,
+                                3,
+                                4,
+                                4,
+                                4,
+                                4,
+                            ],
+                            [
+                                1,
+                                2,
+                                3,
+                                4,
+                                0,
+                                2,
+                                3,
+                                4,
+                                0,
+                                1,
+                                3,
+                                4,
+                                0,
+                                1,
+                                2,
+                                4,
+                                0,
+                                1,
+                                2,
+                                3,
+                            ],
+                        ]
+                    ),
+                )
+                == False
+            ).item()
+            == False
+        )
+        # second molecule is ammonium, check if bonds are correct
+        ammonium_bonds = pair_list[:, 20:30]
+        assert (
+            torch.any(
+                torch.eq(
+                    ammonium_bonds,
+                    torch.tensor(
+                        [
+                            [5, 5, 5, 6, 6, 6, 7, 7, 7, 8],
+                            [6, 7, 8, 5, 7, 8, 5, 6, 8, 5],
+                        ]
+                    ),
+                )
+                == False
+            ).item()
+            == False
+        )
 
 
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -451,20 +451,11 @@ from modelforge.potential import _Implemented_NNPs
 
 
 @pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())
-@pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
-def test_dataset_neighborlist(model_name, dataset_name, datamodule_factory):
-    """Test the splitting of the dataset."""
+def test_dataset_neighborlist(model_name, single_batch_with_batchsize_64):
+    """Test the neighborlist."""
 
-    if dataset_name.lower().startswith("spice"):
-        print("using subset")
-        dataset = datamodule_factory(
-            dataset_name=dataset_name, version_select="nc_1000_v0_HCNOFClS"
-        )
-    else:
-        dataset = datamodule_factory(dataset_name=dataset_name)
-
-    train_dataloader = dataset.train_dataloader()
-    batch = next(iter(train_dataloader))
+    nnp_input = single_batch_with_batchsize_64.nnp_input
+    nr_of_mols = nnp_input.atomic_subsystem_indices.unique().shape[0]
 
     # test that the neighborlist is correctly generated
     # cast input and model to torch.float64
@@ -487,7 +478,23 @@ def test_dataset_neighborlist(model_name, dataset_name, datamodule_factory):
         simulation_environment="PyTorch",
         model_parameters=potential_parameters,
     )
-    model(batch.nnp_input)
+    model(nnp_input)
+
+    pair_list = nnp_input.pair_list
+    # pairlist is in ascending order in row 0
+    assert torch.all(pair_list[0, 1:] >= pair_list[0, :-1])
+
+    # first molecule is methane, check if bonds are correct
+    methan_bonds = pair_list[:, :16]
+    assert torch.any(torch.eq(
+        methan_bonds,
+        torch.tensor(
+            [
+                [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3],
+                [1, 2, 3, 4, 0, 2, 3, 4, 0, 1, 3, 4, 0, 1, 2, 3],
+            ]
+        ),
+    ) == False).item()
 
 
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())


### PR DESCRIPTION
## Description
Instead of padding the pair list to generate an (M,N,2) tensor with M number of molecules, N maximum number of pairs in the dataset, and 2 the pairlist dimension we can generate a (K,2) tensor with K as the total number of atom pairs in the dataset. This requires keeping track of index arrays to correctly retrieve atom pairs for a molecule.
 
## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Update atom pair representation, index arrays and offsets
  - [x] Add tests

## Status
- [x] Ready to go