### PR TITLE
Ref ani neighborlist

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -750,6 +750,7 @@ class DataModule(pl.LightningDataModule):
         name: Literal["QM9", "ANI1X", "ANI2X", "SPICE114", "SPICE2", "SPICE114_OPENFF"],
         splitting_strategy: SplittingStrategy = RandomRecordSplittingStrategy(),
         neighborlist_cutoff: unit.Quantity = 7.0 * unit.angstrom,
+        unique_pairs:bool = False,
         batch_size: int = 64,
         remove_self_energies: bool = True,
         atomic_self_energies: Optional[Dict[str, float]] = None,
@@ -815,7 +816,7 @@ class DataModule(pl.LightningDataModule):
         from modelforge.potential.models import Neighborlist
 
         self.calculate_distances_and_pairlist = Neighborlist(
-            neighborlist_cutoff, only_unique_pairs=False
+            neighborlist_cutoff, only_unique_pairs=unique_pairs
         )
 
     def prepare_data(

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -555,6 +555,7 @@ class InputPreparation(torch.nn.Module):
 
         super().__init__()
         from .models import Neighborlist
+
         self.only_unique_pairs = only_unique_pairs
         self.calculate_distances_and_pairlist = Neighborlist(cutoff, only_unique_pairs)
 
@@ -585,6 +586,7 @@ class InputPreparation(torch.nn.Module):
                 atomic_subsystem_indices=atomic_subsystem_indices,
                 pair_indices=None,
             )
+            pair_list = data.pair_list
         else:
             if self.only_unique_pairs:
                 i_indices = data.pair_list[0]
@@ -592,11 +594,12 @@ class InputPreparation(torch.nn.Module):
                 unique_pairs_mask = i_indices < j_indices
                 i_final_pairs = i_indices[unique_pairs_mask]
                 j_final_pairs = j_indices[unique_pairs_mask]
-            
+                pair_list = torch.stack((i_final_pairs, j_final_pairs))
+
             pairlist_output = self.calculate_distances_and_pairlist(
                 positions=positions,
                 atomic_subsystem_indices=atomic_subsystem_indices,
-                pair_indices=data.pair_list.to(torch.int64),
+                pair_indices=pair_list.to(torch.int64),
             )
 
         return pairlist_output

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -555,7 +555,7 @@ class InputPreparation(torch.nn.Module):
 
         super().__init__()
         from .models import Neighborlist
-
+        self.only_unique_pairs = only_unique_pairs
         self.calculate_distances_and_pairlist = Neighborlist(cutoff, only_unique_pairs)
 
     def prepare_inputs(self, data: Union[NNPInput, NamedTuple]):
@@ -586,6 +586,13 @@ class InputPreparation(torch.nn.Module):
                 pair_indices=None,
             )
         else:
+            if self.only_unique_pairs:
+                i_indices = data.pair_list[0]
+                j_indices = data.pair_list[1]
+                unique_pairs_mask = i_indices < j_indices
+                i_final_pairs = i_indices[unique_pairs_mask]
+                j_final_pairs = j_indices[unique_pairs_mask]
+            
             pairlist_output = self.calculate_distances_and_pairlist(
                 positions=positions,
                 atomic_subsystem_indices=atomic_subsystem_indices,

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -580,6 +580,7 @@ class InputPreparation(torch.nn.Module):
         # general input manipulation
         positions = data.positions
         atomic_subsystem_indices = data.atomic_subsystem_indices
+        # calculate pairlist if none is provided
         if data.pair_list is None:
             pairlist_output = self.calculate_distances_and_pairlist(
                 positions=positions,
@@ -588,6 +589,7 @@ class InputPreparation(torch.nn.Module):
             )
             pair_list = data.pair_list
         else:
+            # pairlist is provided, remove redundant pairs if requested
             if self.only_unique_pairs:
                 i_indices = data.pair_list[0]
                 j_indices = data.pair_list[1]
@@ -595,7 +597,9 @@ class InputPreparation(torch.nn.Module):
                 i_final_pairs = i_indices[unique_pairs_mask]
                 j_final_pairs = j_indices[unique_pairs_mask]
                 pair_list = torch.stack((i_final_pairs, j_final_pairs))
-
+            else:
+                pair_list = data.pair_list
+            # only calculate d_ij and r_ij
             pairlist_output = self.calculate_distances_and_pairlist(
                 positions=positions,
                 atomic_subsystem_indices=atomic_subsystem_indices,

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -455,7 +455,6 @@ def test_dataset_neighborlist(model_name, single_batch_with_batchsize_64):
     """Test the neighborlist."""
 
     nnp_input = single_batch_with_batchsize_64.nnp_input
-    nr_of_mols = nnp_input.atomic_subsystem_indices.unique().shape[0]
 
     # test that the neighborlist is correctly generated
     # cast input and model to torch.float64
@@ -484,89 +483,84 @@ def test_dataset_neighborlist(model_name, single_batch_with_batchsize_64):
     # pairlist is in ascending order in row 0
     assert torch.all(pair_list[0, 1:] >= pair_list[0, :-1])
 
-    if model_name == "ANI1x":
-        # test the pairlist for the ANI potential (whith non-redundant atom pairs)
-        # TODO
-        pass
-    else:
-        # test the pairlist for message passing networks (with redundant atom pairs)
-        # first molecule is methane, check if bonds are correct
-        methan_bonds = pair_list[:, :20]
+    # test the pairlist for message passing networks (with redundant atom pairs)
+    # first molecule is methane, check if bonds are correct
+    methan_bonds = pair_list[:, :20]
 
-        assert (
-            torch.any(
-                torch.eq(
-                    methan_bonds,
-                    torch.tensor(
+    assert (
+        torch.any(
+            torch.eq(
+                methan_bonds,
+                torch.tensor(
+                    [
                         [
-                            [
-                                0,
-                                0,
-                                0,
-                                0,
-                                1,
-                                1,
-                                1,
-                                1,
-                                2,
-                                2,
-                                2,
-                                2,
-                                3,
-                                3,
-                                3,
-                                3,
-                                4,
-                                4,
-                                4,
-                                4,
-                            ],
-                            [
-                                1,
-                                2,
-                                3,
-                                4,
-                                0,
-                                2,
-                                3,
-                                4,
-                                0,
-                                1,
-                                3,
-                                4,
-                                0,
-                                1,
-                                2,
-                                4,
-                                0,
-                                1,
-                                2,
-                                3,
-                            ],
-                        ]
-                    ),
-                )
-                == False
-            ).item()
-            == False
-        )
-        # second molecule is ammonium, check if bonds are correct
-        ammonium_bonds = pair_list[:, 20:30]
-        assert (
-            torch.any(
-                torch.eq(
-                    ammonium_bonds,
-                    torch.tensor(
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            1,
+                            1,
+                            1,
+                            2,
+                            2,
+                            2,
+                            2,
+                            3,
+                            3,
+                            3,
+                            3,
+                            4,
+                            4,
+                            4,
+                            4,
+                        ],
                         [
-                            [5, 5, 5, 6, 6, 6, 7, 7, 7, 8],
-                            [6, 7, 8, 5, 7, 8, 5, 6, 8, 5],
-                        ]
-                    ),
-                )
-                == False
-            ).item()
+                            1,
+                            2,
+                            3,
+                            4,
+                            0,
+                            2,
+                            3,
+                            4,
+                            0,
+                            1,
+                            3,
+                            4,
+                            0,
+                            1,
+                            2,
+                            4,
+                            0,
+                            1,
+                            2,
+                            3,
+                        ],
+                    ]
+                ),
+            )
             == False
-        )
+        ).item()
+        == False
+    )
+    # second molecule is ammonium, check if bonds are correct
+    ammonium_bonds = pair_list[:, 20:30]
+    assert (
+        torch.any(
+            torch.eq(
+                ammonium_bonds,
+                torch.tensor(
+                    [
+                        [5, 5, 5, 6, 6, 6, 7, 7, 7, 8],
+                        [6, 7, 8, 5, 7, 8, 5, 6, 8, 5],
+                    ]
+                ),
+            )
+            == False
+        ).item()
+        == False
+    )
 
 
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -485,12 +485,12 @@ def test_dataset_neighborlist(model_name, single_batch_with_batchsize_64):
 
     # test the pairlist for message passing networks (with redundant atom pairs)
     # first molecule is methane, check if bonds are correct
-    methan_bonds = pair_list[:, :20]
+    methane_bonds = pair_list[:, :20]
 
     assert (
         torch.any(
             torch.eq(
-                methan_bonds,
+                methane_bonds,
                 torch.tensor(
                     [
                         [


### PR DESCRIPTION
## Description

This PR makes sure that the ANI model reduces a pairlist/neighborlist with redundant atom pairs (i.e., atom indices for the pair atom 1 and atom 2 are ((1,2),(2,1))). For ANI, we require non-redudant atom pairs. 
There are multiple points where the different pairlist could be implemented. 
I opted for:
(1) a keyword provided to the dataset generation that controls whether to include redundant pairs or not
(2) inside the ANI model an additional indexing step that will reduce a redundant to a non redundant pairlist

## Status
- [x] Ready to go