### PR TITLE
Generating the precomputed pairlist in parallel

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -1099,7 +1099,7 @@ class DataModule(pl.LightningDataModule):
             return {
                 "energy": energies,
                 "idx": torch.tensor([item["idx"] for item in batch]),
-                "pair_list": pair_list,
+                "pair_list": all_pairs,
                 "nr_of_pairs_in_batch": nr_of_pairs,
             }
 
@@ -1124,6 +1124,7 @@ class DataModule(pl.LightningDataModule):
                     dataset[idx] = {"E": E}
             nr_of_pairs.extend(list(batch['nr_of_pairs_in_batch']))
             all_pairs.append(batch['pair_list'])
+            a = 7
 
         
         nr_of_pairs = torch.tensor(nr_of_pairs, dtype=torch.int32)

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -451,11 +451,32 @@ from modelforge.potential import _Implemented_NNPs
 
 
 @pytest.mark.parametrize("model_name", _Implemented_NNPs.get_all_neural_network_names())
-def test_dataset_neighborlist(model_name, single_batch_with_batchsize_64):
+def test_dataset_processing(model_name, single_batch_with_batchsize_64):
     """Test the neighborlist."""
 
-    nnp_input = single_batch_with_batchsize_64.nnp_input
+    data = single_batch_with_batchsize_64
+
+    # make sure that energies are correct
+    energies = torch.tensor(
+        [[-1656.8302], [-1158.3522], [-891.5176], [-1612.8878], [-1262.7533]],
+        dtype=torch.float64,
+    )
+
+    assert torch.allclose(data.metadata.E[:5], energies, atol=1e-4)
+    # make sure that atomic_subsystem_counts are right
+    assert not torch.any(
+        torch.eq(
+            data.metadata.atomic_subsystem_counts[:5],
+            torch.tensor([5, 4, 3, 4, 3], dtype=torch.int32),
+        )
+        == False
+    )
+
+    nnp_input = data.nnp_input
     nr_of_mols = nnp_input.atomic_subsystem_indices.unique().shape[0]
+
+    # test that the ase are always the same
+    a = 7
 
     # test that the neighborlist is correctly generated
     # cast input and model to torch.float64


### PR DESCRIPTION
## Description
The pairlist is pre-computed, which takes about 40 minutes for the ANI2x dataset (the largest dataset in the collection). We can use the DataLoader logic to prepare these in parallel on multiple CPUs. 

This is unfortunately not as simple as I initially anticipated, since we are also removing self energies in the same pass. I will expand this PR with more information as soon as I have a better understanding of the DataLoader logic. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go