### PR TITLE
Remove pyg dependency

### DIFF
--- a/devtools/conda-envs/doc_env.yaml
+++ b/devtools/conda-envs/doc_env.yaml
@@ -2,7 +2,6 @@ name: test
 channels:
   - conda-forge
   - pytorch
-  - pyg
 dependencies:
   # Base depends
   - python
@@ -22,7 +21,6 @@ dependencies:
   - rdkit
   - retry
   - sqlitedict
-  - pytorch_scatter
 
   # Testing
   - pytest>=2.1

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -2,7 +2,6 @@ name: test
 channels:
   - conda-forge
   - pytorch
-  - pyg
 dependencies:
   # Base depends
   - python
@@ -22,7 +21,6 @@ dependencies:
   - rdkit
   - retry
   - sqlitedict
-  - pytorch_scatter
 
   # Testing
   - pytest>=2.1

--- a/devtools/conda-envs/test_env_mac.yaml
+++ b/devtools/conda-envs/test_env_mac.yaml
@@ -2,7 +2,6 @@ name: test
 channels:
   - conda-forge
   - pytorch
-  - pyg
 dependencies:
   # Base depends
   - python
@@ -21,7 +20,6 @@ dependencies:
   - rdkit
   - retry
   - sqlitedict
-  - pytorch_scatter
   - jax
 
   # Testing

--- a/modelforge/dataset/utils.py
+++ b/modelforge/dataset/utils.py
@@ -247,12 +247,6 @@ class SplittingStrategy(ABC):
 class RandomSplittingStrategy(SplittingStrategy):
     """
     Strategy to split a dataset randomly.
-
-    Examples
-    --------
-    >>> dataset = [1, 2, 3, 4, 5]
-    >>> strategy = RandomSplittingStrategy(seed=42)
-    >>> train_idx, val_idx, test_idx = strategy.split(dataset)
     """
 
     def __init__(self, seed: int = 42, split: List[float] = [0.8, 0.1, 0.1]):
@@ -277,8 +271,9 @@ class RandomSplittingStrategy(SplittingStrategy):
 
         Examples
         --------
-        >>> random_strategy_default = RandomSplittingStrategy()
-        >>> random_strategy_custom = RandomSplittingStrategy(seed=123, split=[0.7, 0.2, 0.1])
+        >>> dataset = [1, 2, 3, 4, 5]
+        >>> random_split = RandomSplittingStrategy(seed=123, split=[0.7, 0.2, 0.1])
+        >>> train_idx, val_idx, test_idx = random_split.split(dataset)
         """
 
         super().__init__(seed=seed, split=split)
@@ -329,17 +324,9 @@ class RandomRecordSplittingStrategy(SplittingStrategy):
     """
     Strategy to split a dataset randomly, keeping all conformers in a record in the same split.
 
-    Examples
-    --------
-    >>> dataset = [1, 2, 3, 4, 5]
-    >>> strategy = RandomSplittingStrategy(seed=42)
-    >>> train_idx, val_idx, test_idx = strategy.split(dataset)
     """
-
     def __init__(self, seed: int = 42, split: List[float] = [0.8, 0.1, 0.1]):
         """
-        Initializes the RandomSplittingStrategy with a specified seed and split ratios.
-
         This strategy splits a dataset randomly based on provided ratios for training, validation,
         and testing subsets. The sum of split ratios should be 1.0.
 
@@ -358,8 +345,9 @@ class RandomRecordSplittingStrategy(SplittingStrategy):
 
         Examples
         --------
-        >>> random_strategy_default = RandomRecordSplittingStrategy()
-        >>> random_strategy_custom = RandomRecordSplittingStrategy(seed=123, split=[0.7, 0.2, 0.1])
+        >>> dataset = [1, 2, 3, 4, 5]
+        >>> random_split = RandomRecordSplittingStrategy(seed=123, split=[0.7, 0.2, 0.1])
+        >>> train_idx, val_idx, test_idx = random_split.split(dataset)
         """
 
         super().__init__(split=split, seed=seed)
@@ -520,65 +508,9 @@ class FirstComeFirstServeSplittingStrategy(SplittingStrategy):
         return (train_d, val_d, test_d)
 
 
-def _download_from_gdrive(id: str, raw_dataset_file: str):
-    """
-    Downloads a dataset from Google Drive.
 
-    Parameters
-    ----------
-    id : str
-        Google Drive ID for the dataset.
-
-    raw_dataset_file : str
-        Path to save the downloaded dataset.
-
-    Examples
-    --------
-    >>> _download_from_gdrive("1v2gV3sG9JhMZ5QZn3gFB9j5ZIs0Xjxz8", "data_file.hdf5.gz")
-    """
-    import gdown
-
-    url = f"https://drive.google.com/uc?id={id}"
-    gdown.download(url, raw_dataset_file, quiet=False)
-
-
-def _to_file_cache(
-    data: OrderedDict[str, List[np.ndarray]], processed_dataset_file: str
-) -> None:
-    """
-    Save processed data to a numpy (.npz) file.
-
-    Parameters
-    ----------
-    data : OrderedDict[str, List[np.ndarray]]
-        Dictionary containing processed data to be saved.
-    processed_dataset_file : str
-        Path to save the processed dataset.
-
-    Examples
-    --------
-    >>> data = {"a": [1, 2, 3], "b": [4, 5, 6]}
-    >>> _to_file_cache(data, "data_file.npz")
-    """
-
-    for prop_key in data:
-        if prop_key not in data:
-            raise ValueError(f"Property {prop_key} not found in data")
-        if prop_key == "geometry":  # NOTE: here a 2d tensor is padded
-            logger.debug(prop_key)
-            data[prop_key] = pad_molecules(data[prop_key])
-        else:
-            logger.debug(data[prop_key])
-            logger.debug(prop_key)
-            try:
-                max_len_species = max(len(arr) for arr in data[prop_key])
-            except TypeError:
-                continue
-            data[prop_key] = pad_to_max_length(data[prop_key], max_len_species)
-
-    logger.debug(f"Writing data cache to {processed_dataset_file}")
-
-    np.savez(
-        processed_dataset_file,
-        **data,
-    )
+REGISTERED_SPLITTING_STRATEGIES = {
+    "first_come_first_serve": FirstComeFirstServeSplittingStrategy,
+    "random_record_splitting_strategy": RandomRecordSplittingStrategy,
+    "random_conformer_splitting_strategy": RandomSplittingStrategy,
+}

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -300,7 +300,9 @@ class ANIRepresentation(nn.Module):
         r_ij12 = r_ij.index_select(0, pair_index12.view(-1)).view(
             2, -1, 3
         ) * sign12.unsqueeze(-1)
-        species12_ = torch.where(torch.eq(sign12, 1), species12_small[1], species12_small[0])
+        species12_ = torch.where(
+            torch.eq(sign12, 1), species12_small[1], species12_small[0]
+        )
         return {
             "angular_r_ij": r_ij12,
             "central_atom_index": central_atom_index,
@@ -443,10 +445,29 @@ class ANI2xCore(CoreNetwork):
         angle_sections: int = 4,
     ) -> None:
         """
-        Initialize the ANi NNP architeture.
-
+        ANI2x Neural Network Model.
         Parameters
         ----------
+        radial_max_distance : Union[unit.Quantity, str]
+            The maximum radial distance for the radial basis functions.
+        radial_min_distance : Union[unit.Quantity, str]
+            The minimum radial distance for the radial basis functions.
+        number_of_radial_basis_functions : int
+            The number of radial basis functions to use.
+        angular_max_distance : Union[unit.Quantity, str]
+            The maximum angular distance for the angular basis functions.
+        angular_min_distance : Union[unit.Quantity, str]
+            The minimum angular distance for the angular basis functions.
+        angular_dist_divisions : int
+            The number of divisions for the angular distance.
+        angle_sections : int
+            The number of angle sections to use.
+        processing_operation : List[Dict[str, str]]
+            A list of processing operations to apply to the input data.
+        readout_operation : List[Dict[str, str]]
+            A list of readout operations to apply to the output data.
+        dataset_statistic : Optional[Dict[str, float]], optional
+            Optional dataset statistics to use for normalization, by default None.
         """
         # number of elements in ANI2x
         self.num_species = 7

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -535,11 +535,11 @@ class NeuralNetworkPotentialFactory:
         Parameters
         ----------
         use : str
-            The use case for the NNP instance.
+            The use case for the model instance, either 'training' or 'inference'.
         simulation_environment : str
             The ML framework to use, either 'PyTorch' or 'JAX'.
-        nnp_parameters : dict, optional
-            Parameters specific to the NNP model, by default {}.
+        model_parameter : dict, optional
+            Parameters specific to the model, by default {}.
         training_parameter : dict, optional
             Parameters for configuring the training, by default {}.
 
@@ -594,10 +594,14 @@ class NeuralNetworkPotentialFactory:
 class InputPreparation(torch.nn.Module):
     def __init__(self, cutoff: unit.Quantity, only_unique_pairs: bool = True):
         """
+        A module for preparing input data, including the calculation of pair lists, distances (d_ij), and displacement vectors (r_ij) for molecular simulations.
         Parameters
         ----------
+        cutoff : unit.Quantity
+            The cutoff distance for neighbor list calculations.
         only_unique_pairs : bool, optional
-            Whether to only use unique pairs in the pair list calculation, by default True.
+            Whether to only use unique pairs in the pair list calculation, by default True. This should be set to True for all message passing networks.
+
         """
 
         super().__init__()
@@ -615,13 +619,13 @@ class InputPreparation(torch.nn.Module):
 
         Parameters
         ----------
-        data : NNPInput
-            The input data provided by the dataset, containing atomic numbers, positions,
-            and other necessary information.
+        data : Union[NNPInput, NamedTuple]
+            The input data provided by the dataset, containing atomic numbers, positions, and other necessary information.
 
         Returns
         -------
-        The processed input data, ready for the models forward pass.
+        PairListOutputs
+            A namedtuple containing the pair indices, Euclidean distances (d_ij), and displacement vectors (r_ij).
         """
         # ---------------------------
         # general input manipulation
@@ -686,6 +690,9 @@ from torch.nn import ModuleDict
 
 
 class PostProcessing(torch.nn.Module):
+    """
+    A module for handling post-processing operations on model outputs, including normalization, calculation of atomic self-energies, and reduction operations to compute per-molecule properties from per-atom properties.
+    """
 
     _SUPPORTED_PROPERTIES = ["per_atom_energy", "general_postprocessing_operation"]
     _SUPPORTED_OPERATIONS = ["normalize", "from_atom_to_molecule_reduction"]
@@ -700,7 +707,7 @@ class PostProcessing(torch.nn.Module):
         ----------
         postprocessing_parameter: Dict[str, Dict[str, bool]] # TODO: update
         dataset_statistic : Dict[str, float]
-            The dataset statistics.
+            A dictionary containing the dataset statistics for normalization and other calculations.
         """
         super().__init__()
 

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -264,9 +264,9 @@ class PaiNNRepresentation(nn.Module):
         Parameters
         ----------
         inputs (Dict[str, torch.Tensor]): A dictionary containing the input tensors.
-            - "d_ij" (torch.Tensor): Pairwise distances between atoms. Shape: (n_pairs, 1).
-            - "r_ij" (torch.Tensor): Displacement vector between atoms. Shape: (n_pairs, 3).
-            - "atomic_embedding" (torch.Tensor): Embeddings of atomic numbers. Shape: (n_atoms, embedding_dim).
+            - "d_ij" (torch.Tensor): Pairwise distances between atoms. Shape: (n_pairs, 1, 1).
+            - "r_ij" (torch.Tensor): Displacement vector between atoms. Shape: (n_pairs, 1, 3).
+            - "atomic_embedding" (torch.Tensor): Embeddings of atomic numbers. Shape: (n_atoms, 1, embedding_dim).
 
         Returns
         ----------
@@ -282,6 +282,7 @@ class PaiNNRepresentation(nn.Module):
         # compute normalized pairwise distances
         d_ij = data.d_ij
         r_ij = data.r_ij
+        # normalize the direction vectors
         dir_ij = r_ij / d_ij
 
         f_ij = self.radial_symmetry_function_module(d_ij)
@@ -300,7 +301,7 @@ class PaiNNRepresentation(nn.Module):
         q = atomic_embedding[:, None]  # nr_of_atoms, 1, nr_atom_basis
         q_shape = q.shape
         mu = torch.zeros(
-            (q_shape[0], 3, q_shape[2]), device=q.device
+            (q_shape[0], 3, q_shape[2]), device=q.device, dtype=q.dtype
         )  # nr_of_atoms, 3, nr_atom_basis
 
         return {"filters": filter_list, "dir_ij": dir_ij, "q": q, "mu": mu}
@@ -339,9 +340,9 @@ class PaiNNInteraction(nn.Module):
 
     def forward(
         self,
-        q: torch.Tensor,  # shape [nr_of_atoms, nr_atom_basis]
-        mu: torch.Tensor,  # shape [nr_of_atoms, nr_atom_basis]
-        W_ij: torch.Tensor,  # shape
+        q: torch.Tensor,
+        mu: torch.Tensor,
+        W_ij: torch.Tensor,
         dir_ij: torch.Tensor,
         pairlist: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -364,33 +365,56 @@ class PaiNNInteraction(nn.Module):
         Tuple[torch.Tensor, torch.Tensor]
             Updated scalar and vector representations (q, mu).
         """
-        # inter-atomic
+        # perform the scalar operations (same as in SchNet)
         idx_i, idx_j = pairlist[0], pairlist[1]
 
-        x = self.interatomic_net(q)
-        nr_of_atoms = q.shape[0]
+        x_per_atom = self.interatomic_net(q)  # per atom
 
-        xj = x[idx_j]
-        muj = mu[idx_j]  # shape (nr_of_pairs, nr_atom_basis)
-        W_ij = W_ij.unsqueeze(1)
-        x = W_ij * xj
+        x_j = x_per_atom[idx_j]  # per pair
+        x_per_pair = W_ij.unsqueeze(1) * x_j  # per_pair
 
-        dq, dmuR, dmumu = torch.split(x, self.nr_atom_basis, dim=-1)
-        from torch_scatter import scatter_add
+        # split the output into dq, dmuR, dmumu to excchange information between the scalar and vector outputs
+        dq_per_pair, dmuR, dmumu = torch.split(x_per_pair, self.nr_atom_basis, dim=-1)
 
-        dq = scatter_add(
-            dq, idx_i, dim=0
-        )  # dq: (nr_of_pairs, nr_atom_basis); idx_i: (nr_of_pairs)
-        ##########
-        dmuR * dir_ij[..., None]
-        dmumu * muj
-        dmu = (
-            dmuR * dir_ij[..., None] + dmumu * muj
+        # for scalar output only dq is used
+        # scatter the dq to the atoms (reducton from pairs to atoms)
+        dq_per_atom = torch.zeros_like(q)  # Shape: (nr_of_pairs, 1, nr_atom_basis)
+        # Expand idx_i to match the shape of dq for scatter_add operation
+        expanded_idx_i = idx_i.unsqueeze(-1).expand(-1, dq_per_pair.size(2))
+
+        dq_per_atom.scatter_add_(0, expanded_idx_i.unsqueeze(1), dq_per_pair)
+
+        q = q + dq_per_atom
+
+        # ----------------- vector output -----------------
+        # for vector output dmuR and dmumu are used
+        # dmuR: (nr_of_pairs, 1, nr_atom_basis)
+        # dir_ij: (nr_of_pairs, 3)
+        # dmumu: (nr_of_pairs, 1, nr_atom_basis)
+        # muj: (nr_of_pairs, 1, nr_atom_basis)
+        # idx_i: (nr_of_pairs)
+        # mu: (nr_of_atoms, 3, nr_atom_basis)
+
+        muj = mu[idx_j]  # shape (nr_of_pairs, 1, nr_atom_basis)
+
+        dmu_per_pair = (
+            dmuR * dir_ij.unsqueeze(-1) + dmumu * muj
         )  # shape (nr_of_pairs, 3, nr_atom_basis)
-        dmu = scatter_add(dmu, idx_i, dim=0)  # nr_of_atoms, 3, nr_atom_basis
 
-        q = q + dq
-        mu = mu + dmu
+        # Create a tensor to store the result, matching the size of `mu`
+        dmu_per_atom = torch.zeros_like(mu)  # Shape: (nr_of_atoms, 3, nr_atom_basis)
+
+        # Expand idx_i to match the shape of dmu for scatter_add operation
+        expanded_idx_i = (
+            idx_i.unsqueeze(-1)
+            .unsqueeze(-1)
+            .expand(-1, dmu_per_atom.size(1), dmu_per_atom.size(2))
+        )
+
+        # Perform scatter_add_ operation
+        dmu_per_atom.scatter_add_(0, expanded_idx_i, dmu_per_pair)
+
+        mu = mu + dmu_per_atom
 
         return q, mu
 

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -5,7 +5,6 @@ import torch
 from loguru import logger as log
 from openff.units import unit
 from torch import nn
-from torch_scatter import scatter_add
 from .models import InputPreparation, NNPInput, BaseNetwork, CoreNetwork
 
 from modelforge.potential.utils import NeuralNetworkData
@@ -297,7 +296,10 @@ class PhysNetInteractionModule(nn.Module):
         # Multiply the gathered features by g
         x_j_modulated = x_j * g
         # Aggregate modulated contributions for each atom i
-        x_j_prime = scatter_add(x_j_modulated, idx_i, dim=0, dim_size=x.shape[0])
+        x_j_prime = torch.zeros_like(x_i)
+        x_j_prime.scatter_add_(
+            0, idx_i.unsqueeze(-1).expand(-1, x_j_modulated.size(-1)), x_j_modulated
+        )
 
         # Draft proto message v_tilde
         m = x_i + x_j_prime

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -212,9 +212,6 @@ class SchNetCore(CoreNetwork):
         }
 
 
-from torch_scatter import scatter_add
-
-
 class SchNETInteractionModule(nn.Module):
     def __init__(
         self,
@@ -300,9 +297,11 @@ class SchNETInteractionModule(nn.Module):
         # Perform continuous-filter convolution
         x_j = x[idx_j]
         x_ij = x_j * W_ij
-        x = scatter_add(x_ij, idx_i, dim=0, dim_size=x.size(0))
+        
+        out = torch.zeros_like(x)
+        out.scatter_add_(0, idx_i.unsqueeze(-1).expand_as(x_ij), x_ij)
 
-        return self.feature_to_output(x)
+        return self.feature_to_output(out)
 
 
 class SchNETRepresentation(nn.Module):

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -834,39 +834,6 @@ def pair_list(
 
     return pair_indices.to(device)
 
-    def forward(
-        self,
-        coordinates: torch.Tensor,  # in nanometer
-        atomic_subsystem_indices: torch.Tensor,
-    ) -> torch.Tensor:
-        """Compute all pairs of atoms and their distances.
-
-        Parameters
-        ----------
-        coordinates : torch.Tensor, shape (nr_atoms_per_systems, 3), in nanometer
-        atomic_subsystem_indices : torch.Tensor, shape (nr_atoms_per_systems)
-            Atom indices to indicate which atoms belong to which molecule
-        """
-        positions = coordinates
-        pair_indices = self.pair_list(atomic_subsystem_indices)
-
-        # create pair_coordinates tensor
-        pair_coordinates = positions[pair_indices.T]
-        pair_coordinates = pair_coordinates.view(-1, 2, 3)
-
-        # Calculate distances
-        distances = (pair_coordinates[:, 0, :] - pair_coordinates[:, 1, :]).norm(
-            p=2, dim=-1
-        )
-
-        # Find pairs within the cutoff
-        in_cutoff = (distances <= self.cutoff).nonzero(as_tuple=False).squeeze()
-
-        # Get the atom indices within the cutoff
-        pair_indices_within_cutoff = pair_indices[:, in_cutoff]
-
-        return pair_indices_within_cutoff
-
 
 def scatter_softmax(
     src: torch.Tensor,

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -239,6 +239,7 @@ class CosineCutoff(nn.Module):
     def __init__(self, cutoff: unit.Quantity):
         """
         Behler-style cosine cutoff module.
+        NOTE: The cutoff is converted to nanometer and the input MUST be in nanomter too.
 
         Parameters:
         ----------
@@ -258,12 +259,12 @@ class CosineCutoff(nn.Module):
         Parameters
         ----------
         d_ij : Tensor
-            Pairwise distance tensor. Shape: [n_pairs, distance]
+            Pairwise distance tensor in nanometer. Shape: [n_pairs, 1]
 
         Returns
         -------
         Tensor
-            The cosine cutoff tensor. Shape: [..., N]
+            Cosine cutoff tensor. Shape: [n_pairs, 1]
         """
         # Compute values of cutoff function
         input_cut = 0.5 * (

--- a/modelforge/tests/data/training_defaults/default.toml
+++ b/modelforge/tests/data/training_defaults/default.toml
@@ -34,3 +34,7 @@ verbose = true
 monitor = "val/per_molecule_energy/rmse"
 min_delta = 0.001
 patience = 50
+
+[training.splitting_strategy]
+name = "random_record_splitting_strategy"
+data_split = [0.8, 0.1, 0.1]

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -44,7 +44,8 @@ def test_equivariance(single_batch_with_batchsize_64):
     painn = PaiNN(
         **config["potential"]["core_parameter"],
         postprocessing_parameter=config["potential"]["postprocessing_parameter"],
-    ).to(torch.float64)
+    ).double()
+    
     methane_input = single_batch_with_batchsize_64.nnp_input.to(dtype=torch.float64)
     perturbed_methane_input = replace(methane_input)
     perturbed_methane_input.positions = torch.matmul(

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -99,18 +99,24 @@ def test_cosine_cutoff():
     # NOTE: Cutoff function doesn't care about the units as long as they are the same
     assert np.isclose(actual_output, expected_output)
 
+    # input in angstrom
+    cutoff = 2.0 * unit.angstrom
+    expected_output = torch.tensor([0.5, 0.0, 0.0])
+    cosine_cutoff_module = CosineCutoff(cutoff)
 
 def test_cosine_cutoff_module():
     # Test CosineCutoff module
     from openff.units import unit
 
     # test the cutoff on this distance vector (NOTE: it is in angstrom)
-    d_ij_angstrom = torch.tensor([1.0, 2.0, 3.0])
+    d_ij_angstrom = torch.tensor([1.0, 2.0, 3.0]).unsqueeze(1)
     # the expected outcome is that entry 1 and 2 become zero
     # and entry 0 becomes 0.5 (since the cutoff is 2.0 angstrom)
+    # input in angstrom
+    cutoff = 2.0 * unit.angstrom
 
-    cutoff = unit.Quantity(2.0, unit.angstrom)
-    expected_output = torch.tensor([0.5, 0.0, 0.0])
+
+    expected_output = torch.tensor([0.5, 0.0, 0.0]).unsqueeze(1)
     cosine_cutoff_module = CosineCutoff(cutoff)
 
     output = cosine_cutoff_module(d_ij_angstrom / 10)  # input is in nanometer


### PR DESCRIPTION
## Description
We have used `scatter_sum` instead of `Tensor.scatter_add_`. The `scatter_sum` operation from `pyg` performs tensor initialization to store the sum, broadcasting and other operations (setting dtype, device) under the hood. In some cases, this can lead to unexpected behavior. The main reason for the move to the native scatter operations is the need to install a separate package, `torch_scatter,`, which leads to a larger dependencies graph.

## Todos
  - [x] remove `torch_scatter` operations
  - [x] move to native Tensor.scatter_*
  
## Status
- [x] Ready to go