### PR TITLE
Moving call to input preparation to BaseNetwork

### DIFF
--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -247,7 +247,9 @@ class ANIRepresentation(nn.Module):
     ) -> Dict[str, torch.tensor]:
         radial_feature_vector = radial_feature_vector.squeeze(1)
         number_of_atoms = data.number_of_atoms
-        radial_sublength = self.radial_symmetry_functions.number_of_radial_basis_functions
+        radial_sublength = (
+            self.radial_symmetry_functions.number_of_radial_basis_functions
+        )
         radial_length = radial_sublength * self.nr_of_supported_elements
 
         radial_aev = radial_feature_vector.new_zeros(
@@ -570,12 +572,16 @@ class ANI2x(BaseNetwork):
         postprocessing_parameter: Dict[str, Dict[str, bool]],
         dataset_statistic: Optional[Dict[str, float]] = None,
     ) -> None:
+
+        from modelforge.utils.units import _convert
+
+        self.only_unique_pairs = True  # NOTE: need to be set before super().__init__
+
         super().__init__(
             dataset_statistic=dataset_statistic,
             postprocessing_parameter=postprocessing_parameter,
+            cutoff=_convert(radial_max_distance),
         )
-
-        from modelforge.utils.units import _convert
 
         self.core_module = ANI2xCore(
             _convert(radial_max_distance),
@@ -585,11 +591,6 @@ class ANI2x(BaseNetwork):
             _convert(angular_min_distance),
             angular_dist_divisions,
             angle_sections,
-        )
-        self.only_unique_pairs = True  # NOTE: for pairlist
-        self.input_preparation = InputPreparation(
-            cutoff=_convert(radial_max_distance),
-            only_unique_pairs=self.only_unique_pairs,
         )
 
     def _config_prior(self):

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -895,7 +895,7 @@ class BaseNetwork(Module):
         *,
         postprocessing_parameter: Dict[str, Dict[str, bool]],
         dataset_statistic,
-        cutoff: Union[unit.Quantity, str],
+        cutoff: unit.Quantity,
     ):
         """
         The BaseNetwork wraps the input preparation (including pairlist calculation, d_ij and r_ij calculation), the actual model as well as the output preparation in a wrapper class.

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -782,7 +782,6 @@ class PostProcessing(torch.nn.Module):
             CalculateAtomicSelfEnergy,
         )
 
-
         for property, operations in postprocessing_parameter.items():
             # register properties for which postprocessing should be performed
             if property.lower() in self._SUPPORTED_PROPERTIES:
@@ -791,7 +790,7 @@ class PostProcessing(torch.nn.Module):
                 raise ValueError(
                     f"Property {property} is not supported. Supported properties are {self._SUPPORTED_PROPERTIES}"
                 )
-    
+
             # register operations that are performed for the property
             postprocessing_sequence = torch.nn.Sequential()
             prostprocessing_sequence_names = []
@@ -892,7 +891,11 @@ class PostProcessing(torch.nn.Module):
 
 class BaseNetwork(Module):
     def __init__(
-        self, *, postprocessing_parameter: Dict[str, Dict[str, bool]], dataset_statistic
+        self,
+        *,
+        postprocessing_parameter: Dict[str, Dict[str, bool]],
+        dataset_statistic,
+        cutoff: Union[unit.Quantity, str],
     ):
         """
         The BaseNetwork wraps the input preparation (including pairlist calculation, d_ij and r_ij calculation), the actual model as well as the output preparation in a wrapper class.
@@ -905,8 +908,19 @@ class BaseNetwork(Module):
         """
 
         super().__init__()
+        from modelforge.utils.units import _convert
+
         self.postprocessing = PostProcessing(
             postprocessing_parameter, dataset_statistic
+        )
+
+        # check if self.only_unique_pairs is set in child class
+        if not hasattr(self, "only_unique_pairs"):
+            raise RuntimeError(
+                "The only_unique_pairs attribute is not set in the child class. Please set it to True or False before calling super().__init__."
+            )
+        self.input_preparation = InputPreparation(
+            cutoff=_convert(cutoff), only_unique_pairs=self.only_unique_pairs
         )
 
     def load_state_dict(
@@ -952,6 +966,7 @@ class BaseNetwork(Module):
         super().load_state_dict(filtered_state_dict, strict=strict, assign=assign)
 
     def prepare_input(self, data):
+
         self.input_preparation._input_checks(data)
         return self.input_preparation.prepare_inputs(data)
 

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -506,11 +506,16 @@ class PaiNN(BaseNetwork):
         dataset_statistic: Optional[Dict[str, float]] = None,
         epsilon: float = 1e-8,
     ) -> None:
+
+        from modelforge.utils.units import _convert
+
+        self.only_unique_pairs = False  # NOTE: for pairlist
+
         super().__init__(
             dataset_statistic=dataset_statistic,
             postprocessing_parameter=postprocessing_parameter,
+            cutoff=_convert(cutoff),
         )
-        from modelforge.utils.units import _convert
 
         self.core_module = PaiNNCore(
             max_Z=max_Z,
@@ -521,10 +526,6 @@ class PaiNN(BaseNetwork):
             shared_interactions=shared_interactions,
             shared_filters=shared_filters,
             epsilon=epsilon,
-        )
-        self.only_unique_pairs = False  # NOTE: for pairlist
-        self.input_preparation = InputPreparation(
-            cutoff=_convert(cutoff), only_unique_pairs=self.only_unique_pairs
         )
 
     def _config_prior(self):

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -596,11 +596,13 @@ class PhysNet(BaseNetwork):
 
 
         """
+        from modelforge.utils.units import _convert
+        self.only_unique_pairs = False  # NOTE: for pairlist
         super().__init__(
             dataset_statistic=dataset_statistic,
             postprocessing_parameter=postprocessing_parameter,
+            cutoff=_convert(cutoff),
         )
-        from modelforge.utils.units import _convert
 
         self.core_module = PhysNetCore(
             max_Z=max_Z,
@@ -609,10 +611,6 @@ class PhysNet(BaseNetwork):
             number_of_radial_basis_functions=number_of_radial_basis_functions,
             number_of_interaction_residual=number_of_interaction_residual,
             number_of_modules=number_of_modules,
-        )
-        self.only_unique_pairs = False  # NOTE: for pairlist
-        self.input_preparation = InputPreparation(
-            cutoff=_convert(cutoff), only_unique_pairs=self.only_unique_pairs
         )
 
     def _config_prior(self):

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -558,11 +558,13 @@ class SAKE(BaseNetwork):
         dataset_statistic: Optional[Dict[str, float]] = None,
         epsilon: float = 1e-8,
     ):
+        from modelforge.utils.units import _convert
+        self.only_unique_pairs = False  # NOTE: for pairlist
         super().__init__(
             dataset_statistic=dataset_statistic,
             postprocessing_parameter=postprocessing_parameter,
+            cutoff=_convert(cutoff),
         )
-        from modelforge.utils.units import _convert
 
         self.core_module = SAKECore(
             max_Z=max_Z,
@@ -574,10 +576,6 @@ class SAKE(BaseNetwork):
             epsilon=epsilon,
         )
 
-        self.only_unique_pairs = False  # NOTE: for pairlist
-        self.input_preparation = InputPreparation(
-            cutoff=_convert(cutoff), only_unique_pairs=self.only_unique_pairs
-        )
 
     def _config_prior(self):
         log.info("Configuring SAKE model hyperparameter prior distribution")

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -206,7 +206,7 @@ class SchNetCore(CoreNetwork):
         E_i = self.energy_layer(x).squeeze(1)
 
         return {
-            'per_atom_energy': E_i,
+            "per_atom_energy": E_i,
             "scalar_representation": x,
             "atomic_subsystem_indices": data.atomic_subsystem_indices,
         }
@@ -297,7 +297,7 @@ class SchNETInteractionModule(nn.Module):
         # Perform continuous-filter convolution
         x_j = x[idx_j]
         x_ij = x_j * W_ij
-        
+
         out = torch.zeros_like(x)
         out.scatter_add_(0, idx_i.unsqueeze(-1).expand_as(x_ij), x_ij)
 
@@ -396,11 +396,15 @@ class SchNet(BaseNetwork):
         cutoff : openff.units.unit.Quantity, default=5*unit.angstrom
             The cutoff distance for interactions.
         """
+        from modelforge.utils.units import _convert
+
+        self.only_unique_pairs = False  # NOTE: need to be set before super().__init__
+
         super().__init__(
             dataset_statistic=dataset_statistic,
             postprocessing_parameter=postprocessing_parameter,
+            cutoff=_convert(cutoff),
         )
-        from modelforge.utils.units import _convert
 
         self.core_module = SchNetCore(
             max_Z=max_Z,
@@ -409,10 +413,6 @@ class SchNet(BaseNetwork):
             number_of_interaction_modules=number_of_interaction_modules,
             number_of_filters=number_of_filters,
             shared_interactions=shared_interactions,
-        )
-        self.only_unique_pairs = False  # NOTE: for pairlist
-        self.input_preparation = InputPreparation(
-            cutoff=_convert(cutoff), only_unique_pairs=self.only_unique_pairs
         )
 
     def _config_prior(self):


### PR DESCRIPTION
## Description
I noticed that each model includes the initialization of the `InputPreparation` class  (which handles the calculation of the neighborlist and pairwise distances) in its implementation. The better location for this initialization is the super class (`BaseNetwork`).

## Todos
  - [x] Relocate initialization of `InputPreparation`

## Status
- [x] Ready to go