### PR TITLE
fix inconsistency in weight/bias initialization

### DIFF
--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -253,14 +253,15 @@ class Dense(nn.Linear):
         bias_init : Callable, optional
             Function to initialize the bias. Default is zeros_.
         """
-
-        super().__init__(in_features, out_features, bias)
-
+        # NOTE: these two variables need to come before the initi
         self.weight_init_distribution = weight_init
         self.bias_init_distribution = bias_init
+
+        super().__init__(
+            in_features, out_features, bias
+        )  # NOTE: the `reseet_paramters` method is called in the super class
+
         self.activation = activation or nn.Identity()
-        # initialize weights and bias from passed distributions
-        self.reset_parameters()
 
     def reset_parameters(self):
         """

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -207,6 +207,20 @@ class Dense(nn.Linear):
     """
     Fully connected linear layer with activation function.
 
+    Attributes
+    ----------
+    weight_init_distribution : Callable
+        distribution used to initialize the weights.
+    bias_init_distribution : Callable
+        Distribution used to initialize the bias.
+
+    Methods
+    -------
+    reset_parameters()
+        Reset the weights and bias using the specified initialization distributions.
+    forward(input)
+        Forward pass of the layer.
+
     """
 
     def __init__(
@@ -221,26 +235,56 @@ class Dense(nn.Linear):
         bias_init: Callable = zeros_,
     ):
         """
-        Args:
-            in_features: number of input feature :math:`x`.
-            out_features: umber of output features :math:`y`.
-            bias: If False, the layer will not adapt bias :math:`b`.
-            activation: if None, no activation function is used.
-            weight_init: weight initializer from current weight.
-            bias_init: bias initializer from current bias.
+        __init__ _summary_
+
+
+        Parameters
+        ----------
+        in_features : int
+            Number of input features.
+        out_features : int
+            Number of output features.
+        bias : bool, optional
+            If set to False, the layer will not learn an additive bias. Default is True.
+        activation : nn.Module or Callable[[torch.Tensor], torch.Tensor], optional
+            Activation function to be applied. Default is None, which applies the identity function and makes this a linear transformation.
+        weight_init : Callable, optional
+            Callable to initialize the weights. Default is xavier_uniform_.
+        bias_init : Callable, optional
+            Function to initialize the bias. Default is zeros_.
         """
-        self.weight_init = weight_init
-        self.bias_init = bias_init
+
         super().__init__(in_features, out_features, bias)
 
+        self.weight_init_distribution = weight_init
+        self.bias_init_distribution = bias_init
         self.activation = activation or nn.Identity()
+        # initialize weights and bias from passed distributions
+        self.reset_parameters()
 
     def reset_parameters(self):
-        self.weight_init(self.weight)
+        """
+        Reset the weights and bias using the specified initialization distributions.
+        """
+        self.weight_init_distribution(self.weight)
         if self.bias is not None:
-            self.bias_init(self.bias)
+            self.bias_init_distribution(self.bias)
 
     def forward(self, input: torch.Tensor):
+        """
+        Forward pass of the layer.
+
+        Parameters
+        ----------
+        input : torch.Tensor
+            Input tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor after applying the linear transformation and activation function.
+
+        """
         y = F.linear(input, self.weight, self.bias)
         return self.activation(y)
 


### PR DESCRIPTION
## Description
As @ArnNag noticed, the `Dense` implementation was inconsistent in how weights and biases are initialized vs how these are reset. During initialization and resetting, the implementation used different distributions to draw values.

## Todos
  - [x] call `reset_parameter` in `init`

## Questions
- [ ] I'd prefer to use the same activation function in each model. Since we are normalizing the atomic energies anyway, I don't think there is an issue with `nn.SiLu`. However, we need to empirically validate that this doesn't violate assumptions in some model architectures.

## Status
- [ ] Ready to go