### PR TITLE
Smaller refactoring changes

### DIFF
--- a/modelforge/dataset/utils.py
+++ b/modelforge/dataset/utils.py
@@ -143,9 +143,9 @@ def _calculate_self_energies(torch_dataset, collate_fn) -> Dict[str, unit.Quanti
     # Determine the size of the counts tensor
     num_molecules = torch_dataset.number_of_records
     # Determine up to which Z we detect elements
-    max_atomic_number = 100
+    maximum_atomic_number = 100
     # Initialize the counts tensor
-    counts = torch.zeros(num_molecules, max_atomic_number + 1, dtype=torch.int16)
+    counts = torch.zeros(num_molecules, maximum_atomic_number + 1, dtype=torch.int16)
     # save energies in list
     energy_array = torch.zeros(torch_dataset.number_of_records, dtype=torch.float64)
     # for filling in the element count matrix

--- a/modelforge/dataset/utils.py
+++ b/modelforge/dataset/utils.py
@@ -143,9 +143,9 @@ def _calculate_self_energies(torch_dataset, collate_fn) -> Dict[str, unit.Quanti
     # Determine the size of the counts tensor
     num_molecules = torch_dataset.number_of_records
     # Determine up to which Z we detect elements
-    maximum_atomic_number = 100
+    highest_atomic_number = 100
     # Initialize the counts tensor
-    counts = torch.zeros(num_molecules, maximum_atomic_number + 1, dtype=torch.int16)
+    counts = torch.zeros(num_molecules, highest_atomic_number + 1, dtype=torch.int16)
     # save energies in list
     energy_array = torch.zeros(torch_dataset.number_of_records, dtype=torch.float64)
     # for filling in the element count matrix

--- a/modelforge/dataset/utils.py
+++ b/modelforge/dataset/utils.py
@@ -143,9 +143,9 @@ def _calculate_self_energies(torch_dataset, collate_fn) -> Dict[str, unit.Quanti
     # Determine the size of the counts tensor
     num_molecules = torch_dataset.number_of_records
     # Determine up to which Z we detect elements
-    highest_atomic_number = 100
+    maximum_atomic_number = 100
     # Initialize the counts tensor
-    counts = torch.zeros(num_molecules, highest_atomic_number + 1, dtype=torch.int16)
+    counts = torch.zeros(num_molecules, maximum_atomic_number + 1, dtype=torch.int16)
     # save energies in list
     energy_array = torch.zeros(torch_dataset.number_of_records, dtype=torch.float64)
     # for filling in the element count matrix

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -515,8 +515,8 @@ class ANI2xCore(CoreNetwork):
         # Create a tensor for direct lookup. The size of this tensor will be
         # # the max atomic number in map. Initialize with a default value (e.g., -1 for not found).
 
-        highest_atomic_number = max(ATOMIC_NUMBER_TO_INDEX_MAP.keys())
-        lookup_tensor = torch.full((highest_atomic_number + 1,), -1, dtype=torch.long)
+        maximum_atomic_number = max(ATOMIC_NUMBER_TO_INDEX_MAP.keys())
+        lookup_tensor = torch.full((maximum_atomic_number + 1,), -1, dtype=torch.long)
 
         # Populate the lookup tensor with indices from your map
         for atomic_number, index in ATOMIC_NUMBER_TO_INDEX_MAP.items():

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -515,8 +515,8 @@ class ANI2xCore(CoreNetwork):
         # Create a tensor for direct lookup. The size of this tensor will be
         # # the max atomic number in map. Initialize with a default value (e.g., -1 for not found).
 
-        maximum_atomic_number = max(ATOMIC_NUMBER_TO_INDEX_MAP.keys())
-        lookup_tensor = torch.full((maximum_atomic_number + 1,), -1, dtype=torch.long)
+        highest_atomic_number = max(ATOMIC_NUMBER_TO_INDEX_MAP.keys())
+        lookup_tensor = torch.full((highest_atomic_number + 1,), -1, dtype=torch.long)
 
         # Populate the lookup tensor with indices from your map
         for atomic_number, index in ATOMIC_NUMBER_TO_INDEX_MAP.items():

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1003,13 +1003,15 @@ class BaseNetwork(Module):
 
 
 from modelforge.potential.utils import ActivationFunction
+from typing import Type
+import torch.nn as nn
 
 
-def get_activation_function(activation_name: str) -> torch.nn.Module:
+def get_activation_function(activation_name: str) -> Type[nn.Module]:
     try:
         # Convert the string to the corresponding Enum member
         activation_function = ActivationFunction[activation_name]
-        return activation_function.value()
+        return activation_function.value
     except KeyError:
         raise ValueError(f"Unknown activation function: {activation_name}")
 
@@ -1025,7 +1027,7 @@ class CoreNetwork(Module, ABC):
 
         super().__init__()
         # initialize the activation funtion
-        activation_function_class = get_activation_function(
+        self.activation_function_class = get_activation_function(
             activation_name=activation_name
         )
 

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1002,22 +1002,11 @@ class BaseNetwork(Module):
         return processed_output
 
 
-from modelforge.potential.utils import ActivationFunction
-from typing import Type
-import torch.nn as nn
-
-
-def get_activation_function(activation_name: str) -> Type[nn.Module]:
-    try:
-        # Convert the string to the corresponding Enum member
-        activation_function = ActivationFunction[activation_name]
-        return activation_function.value
-    except KeyError:
-        raise ValueError(f"Unknown activation function: {activation_name}")
+from modelforge.potential.utils import ACTIVATION_FUNCTIONS
 
 
 class CoreNetwork(Module, ABC):
-    def __init__(self, activation_name: str):
+    def __init__(self, activation_function: str):
         """
         The CoreNetwork implements methods that are used by all neural network potentials. Every network inherits from CoreNetwork.
         Networks are taking in a NNPInput and pairlist and returning a dictionary of **atomic** properties.
@@ -1027,9 +1016,10 @@ class CoreNetwork(Module, ABC):
 
         super().__init__()
         # initialize the activation funtion
-        self.activation_function_class = get_activation_function(
-            activation_name=activation_name
-        )
+        activation_function_class = ACTIVATION_FUNCTIONS.get(activation_function, None)
+        if activation_function_class is None:
+            raise ValueError(f"Unknown activation function: {activation_function}")
+        self.activation_function_class = activation_function_class
 
     @abstractmethod
     def _model_specific_input_preparation(

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1002,11 +1002,20 @@ class BaseNetwork(Module):
         return processed_output
 
 
-from modelforge.potential.utils import ACTIVATION_FUNCTIONS
+from modelforge.potential.utils import ActivationFunction
+
+
+def get_activation_function(activation_name: str) -> torch.nn.Module:
+    try:
+        # Convert the string to the corresponding Enum member
+        activation_function = ActivationFunction[activation_name]
+        return activation_function.value()
+    except KeyError:
+        raise ValueError(f"Unknown activation function: {activation_name}")
 
 
 class CoreNetwork(Module, ABC):
-    def __init__(self, activation_function: str):
+    def __init__(self, activation_name: str):
         """
         The CoreNetwork implements methods that are used by all neural network potentials. Every network inherits from CoreNetwork.
         Networks are taking in a NNPInput and pairlist and returning a dictionary of **atomic** properties.
@@ -1016,10 +1025,9 @@ class CoreNetwork(Module, ABC):
 
         super().__init__()
         # initialize the activation funtion
-        activation_function_class = ACTIVATION_FUNCTIONS.get(activation_function, None)
-        if activation_function_class is None:
-            raise ValueError(f"Unknown activation function: {activation_function}")
-        self.activation_function_class = activation_function_class
+        activation_function_class = get_activation_function(
+            activation_name=activation_name
+        )
 
     @abstractmethod
     def _model_specific_input_preparation(

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -1,20 +1,13 @@
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union, List
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from loguru import logger as log
 from openff.units import unit
-from .models import NNPInput, BaseNetwork, CoreNetwork
+from .models import NNPInput, BaseNetwork, CoreNetwork, PairListOutputs
 
 from .utils import Dense
-from typing import List
-
-if TYPE_CHECKING:
-    from .models import PairListOutputs
-    from modelforge.dataset.dataset import NNPInput
-
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from modelforge.potential.utils import NeuralNetworkData
 
@@ -25,48 +18,6 @@ class PaiNNNeuralNetworkData(NeuralNetworkData):
     A dataclass designed to structure the inputs for PaiNN neural network potentials, ensuring
     an efficient and structured representation of atomic systems for energy computation and
     property prediction within the PaiNN framework.
-
-    Attributes
-    ----------
-    atomic_numbers : torch.Tensor
-        Atomic numbers for each atom in the system(s). Shape: [num_atoms].
-    positions : torch.Tensor
-        XYZ coordinates of each atom. Shape: [num_atoms, 3].
-    atomic_subsystem_indices : torch.Tensor
-        Maps each atom to its respective subsystem or molecule, useful for systems with multiple
-        molecules. Shape: [num_atoms].
-    total_charge : torch.Tensor
-        Total charge of each system or molecule. Shape: [num_systems].
-    pair_indices : torch.Tensor
-        Indicates indices of atom pairs, essential for computing pairwise features. Shape: [2, num_pairs].
-    d_ij : torch.Tensor
-        Distances between each pair of atoms, derived from `pair_indices`. Shape: [num_pairs, 1].
-    r_ij : torch.Tensor
-        Displacement vectors between atom pairs, providing directional context. Shape: [num_pairs, 3].
-    number_of_atoms : int
-        Total number of atoms in the batch, facilitating batch-wise operations.
-    atomic_embedding : torch.Tensor
-        Embeddings or features for each atom, potentially derived from atomic numbers or learned. Shape: [num_atoms, embedding_dim].
-
-    Notes
-    -----
-    The `PaiNNNeuralNetworkInput` dataclass encapsulates essential inputs required by the PaiNN neural network
-    model for accurately predicting system energies and properties. It includes atomic positions, atomic types,
-    and connectivity information, crucial for a detailed representation of atomistic systems.
-
-    Examples
-    --------
-    >>> painn_input = PaiNNNeuralNetworkData(
-    ...     atomic_numbers=torch.tensor([1, 6, 6, 8]),
-    ...     positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]]),
-    ...     atomic_subsystem_indices=torch.tensor([0, 0, 0, 0]),
-    ...     total_charge=torch.tensor([0.0]),
-    ...     pair_indices=torch.tensor([[0, 1], [0, 2], [1, 2]]).T,
-    ...     d_ij=torch.tensor([[1.0], [1.0], [1.0]]),
-    ...     r_ij=torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
-    ...     number_of_atoms=4,
-    ...     atomic_embedding=torch.randn(4, 5)  # Example atomic embeddings
-    ... )
     """
 
     atomic_embedding: torch.Tensor
@@ -85,28 +36,50 @@ class PaiNNCore(CoreNetwork):
         self,
         featurization_config: Dict[str, Union[List[str], int]],
         number_of_radial_basis_functions: int,
-        cutoff: unit.Quantity,
+        maximum_interaction_radius: unit.Quantity,
         number_of_interaction_modules: int,
         shared_interactions: bool,
         shared_filters: bool,
+        activation_function: str,
         epsilon: float = 1e-8,
     ):
+        """
+        Initialize the PaiNNCore network.
+
+        Parameters
+        ----------
+        featurization_config : Dict[str, Union[List[str], int]]
+            Configuration for atomic featurization.
+        number_of_radial_basis_functions : int
+            Number of radial basis functions.
+        maximum_interaction_radius : unit.Quantity
+            Maximum interaction radius.
+        number_of_interaction_modules : int
+            Number of interaction modules.
+        shared_interactions : bool
+            Whether to share interactions across modules.
+        shared_filters : bool
+            Whether to share filters across modules.
+        activation_function : str
+            Activation function to use.
+        epsilon : float, optional
+            Stability constant added in norm to prevent numerical instabilities. Default is 1e-8.
+        """
+        from modelforge.potential.utils import FeaturizeInput
         log.debug("Initializing the PaiNN architecture.")
-        super().__init__()
+        super().__init__(activation_function)
 
         self.number_of_interaction_modules = number_of_interaction_modules
-        self.shared_filters = shared_filters
 
         # featurize the atomic input
-        from modelforge.potential.utils import FeaturizeInput
 
         self.featurize_input = FeaturizeInput(featurization_config)
-        number_of_per_atom_features = featurization_config[
-            "number_of_per_atom_features"
-        ]
+        number_of_per_atom_features = int(
+            featurization_config["number_of_per_atom_features"]
+        )
         # initialize representation block
         self.representation_module = PaiNNRepresentation(
-            cutoff,
+            maximum_interaction_radius,
             number_of_radial_basis_functions,
             number_of_interaction_modules,
             number_of_per_atom_features,
@@ -114,20 +87,44 @@ class PaiNNCore(CoreNetwork):
         )
 
         # initialize the interaction and mixing networks
-        self.interaction_modules = nn.ModuleList(
-            PaiNNInteraction(number_of_per_atom_features, activation=F.silu)
-            for _ in range(number_of_interaction_modules)
-        )
+        if shared_interactions:
+            self.interaction_modules = nn.ModuleList(
+                [
+                    PaiNNInteraction(
+                        number_of_per_atom_features,
+                        activation_function=self.activation_function_class(),
+                    )
+                ]
+                * number_of_interaction_modules
+            )
+        else:
+            self.interaction_modules = nn.ModuleList(
+                [
+                    PaiNNInteraction(
+                        number_of_per_atom_features,
+                        activation_function=self.activation_function_class(),
+                    )
+                    for _ in range(number_of_interaction_modules)
+                ]
+            )
+
         self.mixing_modules = nn.ModuleList(
-            PaiNNMixing(number_of_per_atom_features, activation=F.silu, epsilon=epsilon)
-            for _ in range(number_of_interaction_modules)
+            [
+                PaiNNMixing(
+                    number_of_per_atom_features,
+                    activation_function=self.activation_function_class(),
+                    epsilon=epsilon,
+                )
+                for _ in range(number_of_interaction_modules)
+            ]
         )
 
+        # reduce per-atom features to per atom scalar
         self.energy_layer = nn.Sequential(
             Dense(
                 number_of_per_atom_features,
                 number_of_per_atom_features,
-                activation=nn.ReLU(),
+                activation_function=self.activation_function_class(),
             ),
             Dense(
                 number_of_per_atom_features,
@@ -136,8 +133,23 @@ class PaiNNCore(CoreNetwork):
         )
 
     def _model_specific_input_preparation(
-        self, data: "NNPInput", pairlist_output: "PairListOutputs"
+        self, data: NNPInput, pairlist_output: PairListOutputs
     ) -> PaiNNNeuralNetworkData:
+        """
+        Prepare the model-specific input for the PaiNN network.
+
+        Parameters
+        ----------
+        data : NNPInput
+            The input data.
+        pairlist_output : PairListOutputs
+            The pairlist output.
+
+        Returns
+        -------
+        PaiNNNeuralNetworkData
+            The prepared model-specific input.
+        """
         # Perform atomic embedding
 
         number_of_atoms = data.atomic_numbers.shape[0]
@@ -159,22 +171,20 @@ class PaiNNCore(CoreNetwork):
     def compute_properties(
         self,
         data: PaiNNNeuralNetworkData,
-    ):
+    ) -> Dict[str, torch.Tensor]:
         """
         Compute atomic representations/embeddings.
 
         Parameters
         ----------
-        data : PaiNNNeuralNetworkInput(NamedTuple)
-        atomic_embedding : torch.Tensor
-            Tensor containing atomic number embeddings.
+        data : PaiNNNeuralNetworkData
+            The input data.
 
         Returns
         -------
         Dict[str, torch.Tensor]
             Dictionary containing scalar and vector representations.
         """
-
         # initialize filters, q and mu
         transformed_input = self.representation_module(data)
 
@@ -207,48 +217,61 @@ class PaiNNCore(CoreNetwork):
         }
 
 
-from openff.units import unit
-
-
 class PaiNNRepresentation(nn.Module):
     """PaiNN representation module"""
 
     def __init__(
         self,
-        cutoff: unit.Quantity = 5 * unit.angstrom,
-        number_of_radial_basis_functions: int = 16,
-        nr_interaction_blocks: int = 3,
-        nr_atom_basis: int = 8,
-        shared_filters: bool = False,
+        maximum_interaction_radius: unit.Quantity,
+        number_of_radial_basis_functions: int,
+        nr_interaction_blocks: int,
+        nr_atom_basis: int,
+        shared_filters: bool,
     ):
+        """
+        Initialize the PaiNNRepresentation module.
+
+        Parameters
+        ----------
+        maximum_interaction_radius : unit.Quantity
+            Maximum interaction radius.
+        number_of_radial_basis_functions : int
+            Number of radial basis functions.
+        nr_interaction_blocks : int
+            Number of interaction blocks.
+        nr_atom_basis : int
+            Number of features to describe atomic environments.
+        shared_filters : bool
+            Whether to share filters across blocks.
+        """
+        from .utils import SchnetRadialBasisFunction
+
         super().__init__()
 
         # cutoff
         from modelforge.potential import CosineCutoff
 
-        self.cutoff_module = CosineCutoff(cutoff)
+        self.cutoff_module = CosineCutoff(maximum_interaction_radius)
 
         # radial symmetry function
-        from .utils import SchnetRadialBasisFunction
 
         self.radial_symmetry_function_module = SchnetRadialBasisFunction(
             number_of_radial_basis_functions=number_of_radial_basis_functions,
-            max_distance=cutoff,
+            max_distance=maximum_interaction_radius,
             dtype=torch.float32,
         )
 
         # initialize the filter network
         if shared_filters:
             filter_net = Dense(
-                number_of_radial_basis_functions,
-                3 * nr_atom_basis,
+                in_features=number_of_radial_basis_functions,
+                out_features=3 * nr_atom_basis,
             )
 
         else:
             filter_net = Dense(
-                number_of_radial_basis_functions,
-                nr_interaction_blocks * nr_atom_basis * 3,
-                activation=None,
+                in_features=number_of_radial_basis_functions,
+                out_features=nr_interaction_blocks * nr_atom_basis * 3,
             )
 
         self.filter_net = filter_net
@@ -257,48 +280,42 @@ class PaiNNRepresentation(nn.Module):
         self.nr_interaction_blocks = nr_interaction_blocks
         self.nr_atom_basis = nr_atom_basis
 
-    def forward(self, data: PaiNNNeuralNetworkData):
+    def forward(self, data: PaiNNNeuralNetworkData) -> Dict[str, torch.Tensor]:
         """
-        Transforms the input data for the PAInn potential model.
+        Transforms the input data for the PaiNN potential model.
 
         Parameters
         ----------
-        inputs (Dict[str, torch.Tensor]): A dictionary containing the input tensors.
-            - "d_ij" (torch.Tensor): Pairwise distances between atoms. Shape: (n_pairs, 1, 1).
-            - "r_ij" (torch.Tensor): Displacement vector between atoms. Shape: (n_pairs, 1, 3).
-            - "atomic_embedding" (torch.Tensor): Embeddings of atomic numbers. Shape: (n_atoms, 1, embedding_dim).
+        data : PaiNNNeuralNetworkData
+            The input data.
 
         Returns
-        ----------
-        Dict[str, torch.Tensor]:
+        -------
+        Dict[str, torch.Tensor]
             A dictionary containing the transformed input tensors.
-            - "mu" (torch.Tensor)
-                Zero-initialized tensor for atom features. Shape: (n_atoms, 3, nr_atom_basis).
-            - "dir_ij" (torch.Tensor)
-                Direction vectors between atoms. Shape: (n_pairs, 1, distance).
-            - "q" (torch.Tensor): Reshaped atomic number embeddings. Shape: (n_atoms, 1, embedding_dim).
         """
-
         # compute normalized pairwise distances
         d_ij = data.d_ij
-        r_ij = data.r_ij
-        # normalize the direction vectors
-        dir_ij = r_ij / d_ij
+        dir_ij = data.r_ij / d_ij
 
+        # featurize pairwise distances using RBF
         f_ij = self.radial_symmetry_function_module(d_ij)
-
+        # calculate the smoothing values
         fcut = self.cutoff_module(d_ij)
-
+        # pass the featurized distances through the filter network and apply cutoff based on distances
         filters = self.filter_net(f_ij) * fcut
 
+        # depending on whether we share filters or not
+        # filters have different shape at dim=1 (dim=0 is always the number of atom pairs)
+        # if we share filters, we copy the filters and use the same filters for all blocks
         if self.shared_filters:
             filter_list = [filters] * self.nr_interaction_blocks
+        # otherwise we index into subset of the calculated filters and provide each block with its own set of filters
         else:
             filter_list = torch.split(filters, 3 * self.nr_atom_basis, dim=-1)
 
         # generate q and mu
-        atomic_embedding = data.atomic_embedding
-        q = atomic_embedding[:, None]  # nr_of_atoms, 1, nr_atom_basis
+        q = data.atomic_embedding.unsqueeze(1)  # nr_of_atoms, 1, nr_atom_basis
         q_shape = q.shape
         mu = torch.zeros(
             (q_shape[0], 3, q_shape[2]), device=q.device, dtype=q.dtype
@@ -313,13 +330,15 @@ class PaiNNInteraction(nn.Module):
 
     """
 
-    def __init__(self, nr_atom_basis: int, activation: Callable):
+    def __init__(self, nr_atom_basis: int, activation_function: torch.nn.Module):
         """
+        Initialize the PaiNNInteraction module.
+
         Parameters
         ----------
         nr_atom_basis : int
             Number of features to describe atomic environments.
-        activation : Callable
+        activation_function : torch.nn.Module
             Activation function to use.
 
         Attributes
@@ -334,8 +353,10 @@ class PaiNNInteraction(nn.Module):
 
         # Initialize the intra-atomic neural network
         self.interatomic_net = nn.Sequential(
-            Dense(nr_atom_basis, nr_atom_basis, activation=activation),
-            Dense(nr_atom_basis, 3 * nr_atom_basis, activation=None),
+            Dense(
+                nr_atom_basis, nr_atom_basis, activation_function=activation_function
+            ),
+            Dense(nr_atom_basis, 3 * nr_atom_basis),
         )
 
     def forward(
@@ -373,7 +394,7 @@ class PaiNNInteraction(nn.Module):
         x_j = x_per_atom[idx_j]  # per pair
         x_per_pair = W_ij.unsqueeze(1) * x_j  # per_pair
 
-        # split the output into dq, dmuR, dmumu to excchange information between the scalar and vector outputs
+        # split the output into dq, dmuR, dmumu to exchange information between the scalar and vector outputs
         dq_per_pair, dmuR, dmumu = torch.split(x_per_pair, self.nr_atom_basis, dim=-1)
 
         # for scalar output only dq is used
@@ -422,13 +443,20 @@ class PaiNNInteraction(nn.Module):
 class PaiNNMixing(nn.Module):
     r"""PaiNN interaction block for mixing on atom features."""
 
-    def __init__(self, nr_atom_basis: int, activation: Callable, epsilon: float = 1e-8):
+    def __init__(
+        self,
+        nr_atom_basis: int,
+        activation_function: torch.nn.Module,
+        epsilon: float = 1e-8,
+    ):
         """
+        Initialize the PaiNNMixing module.
+
         Parameters
         ----------
         nr_atom_basis : int
             Number of features to describe atomic environments.
-        activation : Callable
+        activation_function : torch.nn.Module
             Activation function to use.
         epsilon : float, optional
             Stability constant added in norm to prevent numerical instabilities. Default is 1e-8.
@@ -449,16 +477,22 @@ class PaiNNMixing(nn.Module):
 
         # initialize the intra-atomic neural network
         self.intra_atomic_net = nn.Sequential(
-            Dense(2 * nr_atom_basis, nr_atom_basis, activation=activation),
-            Dense(nr_atom_basis, 3 * nr_atom_basis, activation=None),
+            Dense(
+                2 * nr_atom_basis,
+                nr_atom_basis,
+                activation_function=activation_function,
+            ),
+            Dense(nr_atom_basis, 3 * nr_atom_basis, activation_function=None),
         )
         # initialize the mu channel mixing network
         self.mu_channel_mix = Dense(nr_atom_basis, 2 * nr_atom_basis, bias=False)
         self.epsilon = epsilon
 
-    def forward(self, q: torch.Tensor, mu: torch.Tensor):
+    def forward(
+        self, q: torch.Tensor, mu: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
-        compute intratomic mixing
+        Compute intratomic mixing.
 
         Parameters
         ----------
@@ -490,7 +524,6 @@ class PaiNNMixing(nn.Module):
 
 
 from .models import ComputeInteractingAtomPairs, NNPInput, BaseNetwork
-from typing import List
 
 
 class PaiNN(BaseNetwork):
@@ -498,14 +531,37 @@ class PaiNN(BaseNetwork):
         self,
         featurization: Dict[str, Union[List[str], int]],
         number_of_radial_basis_functions: int,
-        cutoff: Union[unit.Quantity, str],
+        maximum_interaction_radius: Union[unit.Quantity, str],
         number_of_interaction_modules: int,
+        activation_function: str,
         shared_interactions: bool,
         shared_filters: bool,
         postprocessing_parameter: Dict[str, Dict[str, bool]],
         dataset_statistic: Optional[Dict[str, float]] = None,
         epsilon: float = 1e-8,
     ) -> None:
+        """
+        Initialize the PaiNN network.
+
+        Parameters
+        ----------
+        featurization : Dict[str, Union[List[str], int]]
+            Configuration for atomic featurization.
+        number_of_radial_basis_functions : int
+            Number of radial basis functions.
+        maximum_interaction_radius : Union[unit.Quantity, str]
+            Maximum interaction radius.
+        number_of_interaction_modules : int
+            Number of interaction modules.
+        activation_function : str
+            Activation function to use.
+        shared_interactions : bool
+            Whether to share interactions across modules.
+        shared_filters : bool
+            Whether to share filters across modules.
+            epsilon=epsilon,
+        )
+        """
 
         from modelforge.utils.units import _convert_str_to_unit
 
@@ -514,16 +570,17 @@ class PaiNN(BaseNetwork):
         super().__init__(
             dataset_statistic=dataset_statistic,
             postprocessing_parameter=postprocessing_parameter,
-            cutoff=_convert_str_to_unit(cutoff),
+            maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
         )
 
         self.core_module = PaiNNCore(
             featurization_config=featurization,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
-            cutoff=_convert_str_to_unit(cutoff),
+            maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
             number_of_interaction_modules=number_of_interaction_modules,
             shared_interactions=shared_interactions,
             shared_filters=shared_filters,
+            activation_function=activation_function,
             epsilon=epsilon,
         )
 
@@ -539,15 +596,10 @@ class PaiNN(BaseNetwork):
         prior = {
             "number_of_per_atom_features": tune.randint(2, 256),
             "number_of_interaction_modules": tune.randint(1, 5),
-            "cutoff": tune.uniform(5, 10),
+            "maximum_interaction_radius": tune.uniform(5, 10),
             "number_of_radial_basis_functions": tune.randint(8, 32),
             "shared_filters": tune.choice([True, False]),
             "shared_interactions": tune.choice([True, False]),
         }
         prior.update(shared_config_prior())
         return prior
-
-    def combine_per_atom_properties(
-        self, values: Dict[str, torch.Tensor]
-    ) -> torch.Tensor:
-        return values

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -40,7 +40,7 @@ class PaiNNCore(CoreNetwork):
         number_of_interaction_modules: int,
         shared_interactions: bool,
         shared_filters: bool,
-        activation_function: str,
+        activation_name: str,
         epsilon: float = 1e-8,
     ):
         """
@@ -60,14 +60,15 @@ class PaiNNCore(CoreNetwork):
             Whether to share interactions across modules.
         shared_filters : bool
             Whether to share filters across modules.
-        activation_function : str
+        activation_name : str
             Activation function to use.
         epsilon : float, optional
             Stability constant added in norm to prevent numerical instabilities. Default is 1e-8.
         """
         from modelforge.potential.utils import FeaturizeInput
+
         log.debug("Initializing the PaiNN architecture.")
-        super().__init__(activation_function)
+        super().__init__(activation_name)
 
         self.number_of_interaction_modules = number_of_interaction_modules
 
@@ -580,7 +581,7 @@ class PaiNN(BaseNetwork):
             number_of_interaction_modules=number_of_interaction_modules,
             shared_interactions=shared_interactions,
             shared_filters=shared_filters,
-            activation_function=activation_function,
+            activation_name=activation_function,
             epsilon=epsilon,
         )
 

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -2,10 +2,24 @@ from pydantic import BaseModel, field_validator, ConfigDict
 from openff.units import unit
 from typing import Union, List
 from modelforge.utils.units import _convert_str_to_unit
+from enum import Enum
 
 """
 This module contains pydantic models for storing the parameters of 
 """
+
+
+class ActivationFunction(str, Enum):
+    ReLU = "ReLU"
+    CeLU = "CeLU"
+    Sigmoid = "Sigmoid"
+    Softmax = "Softmax"
+    ShiftedSoftplus = "ShiftedSoftplus"
+    SiLU = "SiLU"
+    Tanh = "Tanh"
+    LeakyReLU = "LeakyReLU"
+    ELU = "ELU"
+
 
 
 # To avoid having to set config parameters for each class,
@@ -38,7 +52,7 @@ class ANI2xParameters(ParametersBase):
         maximum_interaction_radius_for_angular_features: Union[str, unit.Quantity]
         minimum_interaction_radius_for_angular_features: Union[str, unit.Quantity]
         angular_dist_divisions: int
-        activation_function: str
+        activation_function: ActivationFunction
 
         converted_units = field_validator(
             "maximum_interaction_radius",
@@ -70,7 +84,7 @@ class SchNetParameters(ParametersBase):
         number_of_interaction_modules: int
         number_of_filters: int
         shared_interactions: bool
-        activation_function: str
+        activation_function: ActivationFunction
         featurization: Featurization
 
         converted_units = field_validator("maximum_interaction_radius")(
@@ -101,7 +115,7 @@ class PaiNNParameters(ParametersBase):
         shared_interactions: bool
         shared_filters: bool
         featurization: Featurization
-        activation_function: str
+        activation_function: ActivationFunction
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit
@@ -130,7 +144,7 @@ class PhysNetParameters(ParametersBase):
         number_of_interaction_residual: int
         number_of_modules: int
         featurization: Featurization
-        activation_function: str
+        activation_function: ActivationFunction
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit
@@ -159,7 +173,7 @@ class SAKEParameters(ParametersBase):
         number_of_interaction_modules: int
         number_of_spatial_attention_heads: int
         featurization: Featurization
-        activation_function: str
+        activation_function: ActivationFunction
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -32,18 +32,19 @@ class PerAtomEnergy(ParametersBase):
 class ANI2xParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         angle_sections: int
-        radial_max_distance: Union[str, unit.Quantity]
-        radial_min_distance: Union[str, unit.Quantity]
+        maximum_interaction_radius: Union[str, unit.Quantity]
+        minimum_interaction_radius: Union[str, unit.Quantity]
         number_of_radial_basis_functions: int
-        angular_max_distance: Union[str, unit.Quantity]
-        angular_min_distance: Union[str, unit.Quantity]
+        maximum_interaction_radius_for_angular_features: Union[str, unit.Quantity]
+        minimum_interaction_radius_for_angular_features: Union[str, unit.Quantity]
         angular_dist_divisions: int
+        activation_function: str
 
         converted_units = field_validator(
-            "radial_max_distance",
-            "radial_min_distance",
-            "angular_max_distance",
-            "angular_min_distance",
+            "maximum_interaction_radius",
+            "minimum_interaction_radius",
+            "maximum_interaction_radius_for_angular_features",
+            "minimum_interaction_radius_for_angular_features",
         )(_convert_str_to_unit)
 
     class PostProcessingParameter(ParametersBase):
@@ -61,17 +62,20 @@ class SchNetParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            max_Z: int
+            maximum_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
-        cutoff: Union[str, unit.Quantity]
+        maximum_interaction_radius: Union[str, unit.Quantity]
         number_of_interaction_modules: int
         number_of_filters: int
         shared_interactions: bool
+        activation_function: str
         featurization: Featurization
 
-        converted_units = field_validator("cutoff")(_convert_str_to_unit)
+        converted_units = field_validator("maximum_interaction_radius")(
+            _convert_str_to_unit
+        )
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
@@ -88,17 +92,20 @@ class PaiNNParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            max_Z: int
+            maximum_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
-        cutoff: Union[str, unit.Quantity]
+        maximum_interaction_radius: Union[str, unit.Quantity]
         number_of_interaction_modules: int
         shared_interactions: bool
         shared_filters: bool
         featurization: Featurization
+        activation_function: str
 
-        converted_units = field_validator("cutoff")(_convert_str_to_unit)
+        converted_units = field_validator("maximum_interaction_radius")(
+            _convert_str_to_unit
+        )
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
@@ -115,16 +122,19 @@ class PhysNetParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            max_Z: int
+            maximum_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
-        cutoff: Union[str, unit.Quantity]
+        maximum_interaction_radius: Union[str, unit.Quantity]
         number_of_interaction_residual: int
         number_of_modules: int
         featurization: Featurization
+        activation_function: str
 
-        converted_units = field_validator("cutoff")(_convert_str_to_unit)
+        converted_units = field_validator("maximum_interaction_radius")(
+            _convert_str_to_unit
+        )
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
@@ -141,16 +151,19 @@ class SAKEParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            max_Z: int
+            maximum_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
-        cutoff: Union[str, unit.Quantity]
+        maximum_interaction_radius: Union[str, unit.Quantity]
         number_of_interaction_modules: int
         number_of_spatial_attention_heads: int
         featurization: Featurization
+        activation_function: str
 
-        converted_units = field_validator("cutoff")(_convert_str_to_unit)
+        converted_units = field_validator("maximum_interaction_radius")(
+            _convert_str_to_unit
+        )
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -62,7 +62,7 @@ class SchNetParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            maximum_atomic_number: int
+            highest_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
@@ -92,7 +92,7 @@ class PaiNNParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            maximum_atomic_number: int
+            highest_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
@@ -122,7 +122,7 @@ class PhysNetParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            maximum_atomic_number: int
+            highest_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
@@ -151,7 +151,7 @@ class SAKEParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            maximum_atomic_number: int
+            highest_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -62,7 +62,7 @@ class SchNetParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            highest_atomic_number: int
+            maximum_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
@@ -92,7 +92,7 @@ class PaiNNParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            highest_atomic_number: int
+            maximum_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
@@ -122,7 +122,7 @@ class PhysNetParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            highest_atomic_number: int
+            maximum_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int
@@ -151,7 +151,7 @@ class SAKEParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         class Featurization(ParametersBase):
             properties_to_featurize: List[str]
-            highest_atomic_number: int
+            maximum_atomic_number: int
             number_of_per_atom_features: int
 
         number_of_radial_basis_functions: int

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -454,7 +454,7 @@ class PhysNetCore(CoreNetwork):
         number_of_per_atom_features = int(
             featurization_config["number_of_per_atom_features"]
         )
-        highest_atomic_number = int(featurization_config["highest_atomic_number"])
+        maximum_atomic_number = int(featurization_config["maximum_atomic_number"])
         self.physnet_representation_module = PhysNetRepresentation(
             maximum_interaction_radius=maximum_interaction_radius,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
@@ -476,8 +476,8 @@ class PhysNetCore(CoreNetwork):
         )
 
         # learnable shift and bias that is applied per-element to ech atomic energy
-        self.atomic_scale = nn.Parameter(torch.ones(highest_atomic_number, 2))
-        self.atomic_shift = nn.Parameter(torch.zeros(highest_atomic_number, 2))
+        self.atomic_scale = nn.Parameter(torch.ones(maximum_atomic_number, 2))
+        self.atomic_shift = nn.Parameter(torch.zeros(maximum_atomic_number, 2))
 
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: "PairListOutputs"

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -454,7 +454,7 @@ class PhysNetCore(CoreNetwork):
         number_of_per_atom_features = int(
             featurization_config["number_of_per_atom_features"]
         )
-        maximum_atomic_number = int(featurization_config["maximum_atomic_number"])
+        highest_atomic_number = int(featurization_config["highest_atomic_number"])
         self.physnet_representation_module = PhysNetRepresentation(
             maximum_interaction_radius=maximum_interaction_radius,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
@@ -476,8 +476,8 @@ class PhysNetCore(CoreNetwork):
         )
 
         # learnable shift and bias that is applied per-element to ech atomic energy
-        self.atomic_scale = nn.Parameter(torch.ones(maximum_atomic_number, 2))
-        self.atomic_shift = nn.Parameter(torch.zeros(maximum_atomic_number, 2))
+        self.atomic_scale = nn.Parameter(torch.ones(highest_atomic_number, 2))
+        self.atomic_shift = nn.Parameter(torch.zeros(highest_atomic_number, 2))
 
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: "PairListOutputs"

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -59,8 +59,8 @@ class PhysNetNeuralNetworkData(NeuralNetworkData):
 class PhysNetRepresentation(nn.Module):
     def __init__(
         self,
-        cutoff: unit = 5 * unit.angstrom,
-        number_of_radial_basis_functions: int = 16,
+        maximum_interaction_radius: unit.Quantity,
+        number_of_radial_basis_functions: int,
     ):
         """
         Representation module for the PhysNet potential, handling the generation of
@@ -68,9 +68,9 @@ class PhysNetRepresentation(nn.Module):
 
         Parameters
         ----------
-        cutoff : openff.units.unit.Quantity, default=5*unit.angstrom
+        maximum_interaction_radius : openff.units.unit.Quantity
             The cutoff distance for interactions.
-        number_of_radial_basis_functions : int, default=16
+        number_of_radial_basis_functions : int
             Number of radial basis functions to use.
         """
 
@@ -79,14 +79,14 @@ class PhysNetRepresentation(nn.Module):
         # cutoff
         from modelforge.potential import CosineCutoff
 
-        self.cutoff_module = CosineCutoff(cutoff)
+        self.cutoff_module = CosineCutoff(maximum_interaction_radius)
 
         # radial symmetry function
         from .utils import PhysNetRadialBasisFunction
 
         self.radial_symmetry_function_module = PhysNetRadialBasisFunction(
             number_of_radial_basis_functions=number_of_radial_basis_functions,
-            max_distance=cutoff,
+            max_distance=maximum_interaction_radius,
             dtype=torch.float32,
         )
 
@@ -164,9 +164,16 @@ class PhysNetResidual(nn.Module):
         Dimensionality of the output feature vector, which typically matches the input dimension.
     """
 
-    def __init__(self, input_dim: int, output_dim: int):
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        activation_function_class: torch.nn.Module,
+    ):
         super().__init__()
-        self.dense = Dense(input_dim, output_dim, activation=ShiftedSoftplus())
+        self.dense = Dense(
+            input_dim, output_dim, activation_function=activation_function_class()
+        )
         self.residual = Dense(output_dim, output_dim)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -190,9 +197,10 @@ class PhysNetResidual(nn.Module):
 class PhysNetInteractionModule(nn.Module):
     def __init__(
         self,
-        number_of_per_atom_features: int = 64,
-        number_of_radial_basis_functions: int = 16,
-        number_of_interaction_residual: int = 3,
+        number_of_per_atom_features: int,
+        number_of_radial_basis_functions: int,
+        number_of_interaction_residual: int,
+        activation_function_class: torch.nn.Module,
     ):
         """
         Module to compute interaction terms based on atomic distances and features.
@@ -207,7 +215,9 @@ class PhysNetInteractionModule(nn.Module):
         """
 
         super().__init__()
-        from .utils import ShiftedSoftplus, Dense
+        from .utils import Dense
+
+        self.activation_function = activation_function_class()
 
         self.attention_mask = Dense(
             number_of_radial_basis_functions,
@@ -215,18 +225,17 @@ class PhysNetInteractionModule(nn.Module):
             bias=False,
             weight_init=torch.nn.init.zeros_,
         )
-        self.activation_function = ShiftedSoftplus()
 
         # Networks for processing atomic embeddings of i and j atoms
         self.interaction_i = Dense(
             number_of_per_atom_features,
             number_of_per_atom_features,
-            activation=self.activation_function,
+            activation_function=activation_function_class(),
         )
         self.interaction_j = Dense(
             number_of_per_atom_features,
             number_of_per_atom_features,
-            activation=self.activation_function,
+            activation_function=activation_function_class(),
         )
 
         self.process_v = Dense(number_of_per_atom_features, number_of_per_atom_features)
@@ -235,7 +244,9 @@ class PhysNetInteractionModule(nn.Module):
         self.residuals = nn.ModuleList(
             [
                 PhysNetResidual(
-                    number_of_per_atom_features, number_of_per_atom_features
+                    input_dim=number_of_per_atom_features,
+                    output_dim=number_of_per_atom_features,
+                    activation_function_class=activation_function_class,
                 )
                 for _ in range(number_of_interaction_residual)
             ]
@@ -314,8 +325,9 @@ class PhysNetOutput(nn.Module):
     def __init__(
         self,
         number_of_per_atom_features: int,
-        number_of_atomic_properties: int = 2,
-        number_of_residuals_in_output: int = 2,
+        number_of_atomic_properties: int,
+        number_of_residuals_in_output: int,
+        activation_function_class: torch.nn.Module,
     ):
         from .utils import Dense
 
@@ -323,7 +335,9 @@ class PhysNetOutput(nn.Module):
         self.residuals = nn.Sequential(
             *[
                 PhysNetResidual(
-                    number_of_per_atom_features, number_of_per_atom_features
+                    number_of_per_atom_features,
+                    number_of_per_atom_features,
+                    activation_function_class,
                 )
                 for _ in range(number_of_residuals_in_output)
             ]
@@ -343,14 +357,13 @@ class PhysNetOutput(nn.Module):
 class PhysNetModule(nn.Module):
     def __init__(
         self,
-        number_of_per_atom_features: int = 64,
-        number_of_radial_basis_functions: int = 16,
-        number_of_interaction_residual: int = 2,
+        number_of_per_atom_features: int,
+        number_of_radial_basis_functions: int,
+        number_of_interaction_residual: int,
+        activation_function_class: torch.nn.Module,
     ):
         """
-        Wrapper module that combines the PhysNetInteraction, PhysNetResidual, and
-        PhysNetOutput classes into a single module. This serves as the building
-        block for the PhysNet model.
+        Wrapper module that combines the PhysNetInteraction, PhysNetResidual, and PhysNetOutput classes into a single module. This serves as the building block for the PhysNet model.
 
         This is a skeletal implementation that needs to be expanded upon.
         """
@@ -364,10 +377,13 @@ class PhysNetModule(nn.Module):
             number_of_per_atom_features=number_of_per_atom_features,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
             number_of_interaction_residual=number_of_interaction_residual,
+            activation_function_class=activation_function_class,
         )
         self.output = PhysNetOutput(
             number_of_per_atom_features=number_of_per_atom_features,
             number_of_atomic_properties=2,
+            number_of_residuals_in_output=2,
+            activation_function_class=activation_function_class,
         )
 
     def forward(self, data: PhysNetNeuralNetworkData) -> Dict[str, torch.Tensor]:
@@ -410,10 +426,11 @@ class PhysNetCore(CoreNetwork):
     def __init__(
         self,
         featurization_config: Dict[str, Union[List[str], int]],
-        cutoff: unit.Quantity,
+        maximum_interaction_radius: unit.Quantity,
         number_of_radial_basis_functions: int,
         number_of_interaction_residual: int,
         number_of_modules: int,
+        activation_function: str,
     ) -> None:
         """
         Implementation of the PhysNet neural network potential.
@@ -422,23 +439,24 @@ class PhysNetCore(CoreNetwork):
         ----------
         featurization_config: Dict[str, Union[List[str], int]],
 
-        cutoff : openff.units.unit.Quantity
+        maximum_interaction_radius : openff.units.unit.Quantity
             The cutoff distance for interactions.
         number_of_modules : int
         """
 
         log.debug("Initializing the PhysNet architecture.")
-        super().__init__()
+        super().__init__(activation_function)
 
         # featurize the atomic input
         from modelforge.potential.utils import FeaturizeInput
 
         self.featurize_input = FeaturizeInput(featurization_config)
-        number_of_per_atom_features = featurization_config[
-            "number_of_per_atom_features"
-        ]
+        number_of_per_atom_features = int(
+            featurization_config["number_of_per_atom_features"]
+        )
+        maximum_atomic_number = int(featurization_config["maximum_atomic_number"])
         self.physnet_representation_module = PhysNetRepresentation(
-            cutoff=cutoff,
+            maximum_interaction_radius=maximum_interaction_radius,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
         )
 
@@ -451,14 +469,15 @@ class PhysNetCore(CoreNetwork):
                     number_of_per_atom_features,
                     number_of_radial_basis_functions,
                     number_of_interaction_residual,
+                    activation_function_class=self.activation_function_class,
                 )
                 for _ in range(number_of_modules)
             ]
         )
 
         # learnable shift and bias that is applied per-element to ech atomic energy
-        self.atomic_scale = nn.Parameter(torch.ones(featurization_config["max_Z"], 2))
-        self.atomic_shift = nn.Parameter(torch.zeros(featurization_config["max_Z"], 2))
+        self.atomic_scale = nn.Parameter(torch.ones(maximum_atomic_number, 2))
+        self.atomic_shift = nn.Parameter(torch.zeros(maximum_atomic_number, 2))
 
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: "PairListOutputs"
@@ -584,10 +603,11 @@ class PhysNet(BaseNetwork):
     def __init__(
         self,
         featurization: Dict[str, Union[List[str], int]],
-        cutoff: Union[unit.Quantity, str],
+        maximum_interaction_radius: Union[unit.Quantity, str],
         number_of_radial_basis_functions: int,
         number_of_interaction_residual: int,
         number_of_modules: int,
+        activation_function: str,
         postprocessing_parameter: Dict[str, Dict[str, bool]],
         dataset_statistic: Optional[Dict[str, float]] = None,
     ) -> None:
@@ -598,7 +618,7 @@ class PhysNet(BaseNetwork):
         ----------
         featurization : Dict[str, Union[List[str], int]]
             Configuration for atomic feature generation.
-        cutoff : Union[unit.Quantity, str]
+        maximum_interaction_radius : Union[unit.Quantity, str]
             The cutoff distance for interactions.
         number_of_radial_basis_functions : int
             The number of radial basis functions.
@@ -616,15 +636,16 @@ class PhysNet(BaseNetwork):
         super().__init__(
             dataset_statistic=dataset_statistic,
             postprocessing_parameter=postprocessing_parameter,
-            cutoff=_convert_str_to_unit(cutoff),
+            maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
         )
 
         self.core_module = PhysNetCore(
             featurization_config=featurization,
-            cutoff=_convert_str_to_unit(cutoff),
+            maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
             number_of_radial_basis_functions=number_of_radial_basis_functions,
             number_of_interaction_residual=number_of_interaction_residual,
             number_of_modules=number_of_modules,
+            activation_function=activation_function,
         )
 
     def _config_prior(self):
@@ -650,21 +671,3 @@ class PhysNet(BaseNetwork):
         }
         prior.update(shared_config_prior())
         return prior
-
-    def combine_per_atom_properties(
-        self, values: Dict[str, torch.Tensor]
-    ) -> torch.Tensor:
-        """
-        Combine the per-atom properties.
-
-        Parameters
-        ----------
-        values : Dict[str, torch.Tensor]
-            Dictionary of per-atom properties.
-
-        Returns
-        -------
-        torch.Tensor
-            Combined per-atom properties.
-        """
-        return values

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -430,7 +430,7 @@ class PhysNetCore(CoreNetwork):
         number_of_radial_basis_functions: int,
         number_of_interaction_residual: int,
         number_of_modules: int,
-        activation_function: str,
+        activation_name: str,
     ) -> None:
         """
         Implementation of the PhysNet neural network potential.
@@ -445,7 +445,7 @@ class PhysNetCore(CoreNetwork):
         """
 
         log.debug("Initializing the PhysNet architecture.")
-        super().__init__(activation_function)
+        super().__init__(activation_name)
 
         # featurize the atomic input
         from modelforge.potential.utils import FeaturizeInput
@@ -645,7 +645,7 @@ class PhysNet(BaseNetwork):
             number_of_radial_basis_functions=number_of_radial_basis_functions,
             number_of_interaction_residual=number_of_interaction_residual,
             number_of_modules=number_of_modules,
-            activation_function=activation_function,
+            activation_name=activation_function,
         )
 
     def _config_prior(self):

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -19,37 +19,12 @@ class PhysNetNeuralNetworkData(NeuralNetworkData):
 
     Attributes
     ----------
-    f_ij : Optional[torch.Tensor]
-        A tensor representing the radial basis function (RBF) expansion applied to distances between atom pairs,
-        capturing the local chemical environment. Will be added after initialization. Shape: [num_pairs, num_rbf].
-    number_of_atoms : int
-        An integer indicating the number of atoms in the batch.
     atomic_embedding : torch.Tensor
         A 2D tensor containing embeddings or features for each atom, derived from atomic numbers or other properties.
         Shape: [num_atoms, embedding_dim].
-
-    Notes
-    -----
-    The `PhysNetNeuralNetworkInput` class encapsulates essential geometric and chemical information required by
-    the PhysNet model to predict system energies and properties. It includes information on atomic positions, types,
-    and connectivity, alongside derived features such as radial basis functions (RBF) for detailed representation
-    of atomic environments. This structured input format ensures that all relevant data is readily available for
-    the PhysNet model, supporting its complex network architecture and computation requirements.
-
-    Examples
-    --------
-    >>> physnet_input = PhysNetNeuralNetworkInput(
-    ...     atomic_numbers=torch.tensor([1, 6, 6, 8]),
-    ...     positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]]),
-    ...     atomic_subsystem_indices=torch.tensor([0, 0, 0, 0]),
-    ...     total_charge=torch.tensor([0.0]),
-    ...     pair_indices=torch.tensor([[0, 1], [0, 2], [1, 2]]),
-    ...     d_ij=torch.tensor([1.0, 1.0, 1.0]),
-    ...     r_ij=torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
-    ...     f_ij=torch.randn(3, 4),  # Radial basis function expansion
-    ...     number_of_atoms=torch.tensor([4]),
-    ...     atomic_embedding=torch.randn(4, 5)  # Example atomic embeddings/features
-    ... )
+    f_ij : Optional[torch.Tensor]
+        A tensor representing the radial basis function (RBF) expansion applied to distances between atom pairs,
+        capturing the local chemical environment. Will be added after initialization. Shape: [num_pairs, num_rbf].
     """
 
     atomic_embedding: torch.Tensor
@@ -76,12 +51,12 @@ class PhysNetRepresentation(nn.Module):
 
         super().__init__()
 
-        # cutoff
+        # Initialize cutoff module
         from modelforge.potential import CosineCutoff
 
         self.cutoff_module = CosineCutoff(maximum_interaction_radius)
 
-        # radial symmetry function
+        # Initialize radial symmetry function module
         from .utils import PhysNetRadialBasisFunction
 
         self.radial_symmetry_function_module = PhysNetRadialBasisFunction(
@@ -115,12 +90,11 @@ class PhysNetRepresentation(nn.Module):
 class GatingModule(nn.Module):
     def __init__(self, number_of_atom_basis: int):
         """
-        Initializes a gating module that
-        optionally applies a sigmoid gating mechanism to input features.
+        Initializes a gating module that optionally applies a sigmoid gating mechanism to input features.
 
-        Parameters:
-        -----------
-        input_dim : int
+        Parameters
+        ----------
+        number_of_atom_basis : int
             The dimensionality of the input (and output) features.
         """
         super().__init__()
@@ -144,24 +118,23 @@ class GatingModule(nn.Module):
         return gating_signal * x
 
 
-from .utils import ShiftedSoftplus, Dense
+from .utils import Dense
 
 
 class PhysNetResidual(nn.Module):
     """
     Implements a preactivation residual block as described in Equation 4 of the PhysNet paper.
 
-    The block refines atomic feature vectors by adding a residual component computed through
-    two linear transformations and a non-linear activation function (Softplus). This setup
-    enhances gradient flow and supports effective deep network training by employing a
-    preactivation scheme.
+    The block refines atomic feature vectors by adding a residual component computed through two linear transformations and a non-linear activation function (Softplus). This setup enhances gradient flow and supports effective deep network training by employing a preactivation scheme.
 
-    Parameters:
-    -----------
-    input_dim: int
+    Parameters
+    ----------
+    input_dim : int
         Dimensionality of the input feature vector.
-    output_dim: int
+    output_dim : int
         Dimensionality of the output feature vector, which typically matches the input dimension.
+    activation_function_class : torch.nn.Module
+        The activation function class to be used in the residual block.
     """
 
     def __init__(
@@ -171,6 +144,7 @@ class PhysNetResidual(nn.Module):
         activation_function_class: torch.nn.Module,
     ):
         super().__init__()
+        # Initialize dense layers and residual connection
         self.dense = Dense(
             input_dim, output_dim, activation_function=activation_function_class()
         )
@@ -207,18 +181,23 @@ class PhysNetInteractionModule(nn.Module):
 
         Parameters
         ----------
-        number_of_per_atom_features : int, default=64
+        number_of_per_atom_features : int
             Dimensionality of the atomic embeddings.
-        number_of_radial_basis_functions : int, default=16
-            Specifies the number of basis functions for the Gaussian Logarithm Attention,
-            essentially defining the output feature dimension for attention-weighted interactions.
+        number_of_radial_basis_functions : int
+            Number of radial basis functions for the interaction.
+        number_of_interaction_residual : int
+            Number of residual blocks in the interaction module.
+        activation_function_class : torch.nn.Module
+            The activation function class to be used in the interaction module.
         """
 
         super().__init__()
         from .utils import Dense
 
+        # Initialize activation function
         self.activation_function = activation_function_class()
 
+        # Initialize attention mask
         self.attention_mask = Dense(
             number_of_radial_basis_functions,
             number_of_per_atom_features,
@@ -226,7 +205,7 @@ class PhysNetInteractionModule(nn.Module):
             weight_init=torch.nn.init.zeros_,
         )
 
-        # Networks for processing atomic embeddings of i and j atoms
+        # Initialize networks for processing atomic embeddings of i and j atoms
         self.interaction_i = Dense(
             number_of_per_atom_features,
             number_of_per_atom_features,
@@ -238,9 +217,10 @@ class PhysNetInteractionModule(nn.Module):
             activation_function=activation_function_class(),
         )
 
+        # Initialize processing network
         self.process_v = Dense(number_of_per_atom_features, number_of_per_atom_features)
 
-        # Residual block
+        # Initialize residual blocks
         self.residuals = nn.ModuleList(
             [
                 PhysNetResidual(
@@ -252,19 +232,19 @@ class PhysNetInteractionModule(nn.Module):
             ]
         )
 
-        # Gating
+        # Initialize gating and dropout
         self.gate = nn.Parameter(torch.ones(number_of_per_atom_features))
         self.dropout = nn.Dropout(p=0.05)
 
     def forward(self, data: PhysNetNeuralNetworkData) -> torch.Tensor:
         """
-        Processes input tensors through the interaction module, applying
-        Gaussian Logarithm Attention to modulate the influence of pairwise distances
-        on the interaction features, followed by aggregation to update atomic embeddings.
+        Processes input tensors through the interaction module, applying Gaussian Logarithm Attention to modulate
+        the influence of pairwise distances on the interaction features, followed by aggregation to update atomic embeddings.
 
         Parameters
         ----------
-        inputs : PhysNetNeuralNetworkInput
+        data : PhysNetNeuralNetworkData
+            Input data containing pair indices, distances, and atomic embeddings.
 
         Returns
         -------
@@ -287,8 +267,7 @@ class PhysNetInteractionModule(nn.Module):
         # # Apply activation to atomic embeddings
         xa = self.dropout(self.activation_function(x))
 
-        # calculate attention weights and
-        # transform to
+        # calculate attention weights and transform to
         # input shape: (number_of_pairs, number_of_radial_basis_functions)
         # output shape: (number_of_pairs, number_of_per_atom_features)
         g = self.attention_mask(f_ij)
@@ -329,9 +308,24 @@ class PhysNetOutput(nn.Module):
         number_of_residuals_in_output: int,
         activation_function_class: torch.nn.Module,
     ):
+        """
+        Output module for the PhysNet model.
+
+        Parameters
+        ----------
+        number_of_per_atom_features : int
+            Dimensionality of the atomic embeddings.
+        number_of_atomic_properties : int
+            Number of atomic properties to predict.
+        number_of_residuals_in_output : int
+            Number of residual blocks in the output module.
+        activation_function_class : torch.nn.Module
+            The activation function class to be used in the output module.
+        """
         from .utils import Dense
 
         super().__init__()
+        # Initialize residual blocks
         self.residuals = nn.Sequential(
             *[
                 PhysNetResidual(
@@ -342,6 +336,7 @@ class PhysNetOutput(nn.Module):
                 for _ in range(number_of_residuals_in_output)
             ]
         )
+        # Initialize output layer
         self.output = Dense(
             number_of_per_atom_features,
             number_of_atomic_properties,
@@ -350,11 +345,37 @@ class PhysNetOutput(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor containing atomic feature vectors.
+
+        Returns
+        -------
+        torch.Tensor
+            Predicted atomic properties.
+        """
         x = self.output(self.residuals(x))
         return x
 
 
 class PhysNetModule(nn.Module):
+    """
+    Wrapper module that combines the PhysNetInteraction, PhysNetResidual, and PhysNetOutput classes into a single module.
+
+    Parameters
+    ----------
+    number_of_per_atom_features : int
+        Dimensionality of the atomic embeddings.
+    number_of_radial_basis_functions : int
+        Number of radial basis functions for the interaction.
+    number_of_interaction_residual : int
+        Number of residual blocks in the interaction module.
+    activation_function_class : torch.nn.Module
+        The activation function class to be used in the modules.
+    """
+
     def __init__(
         self,
         number_of_per_atom_features: int,
@@ -362,23 +383,17 @@ class PhysNetModule(nn.Module):
         number_of_interaction_residual: int,
         activation_function_class: torch.nn.Module,
     ):
-        """
-        Wrapper module that combines the PhysNetInteraction, PhysNetResidual, and PhysNetOutput classes into a single module. This serves as the building block for the PhysNet model.
-
-        This is a skeletal implementation that needs to be expanded upon.
-        """
 
         super().__init__()
 
-        # this class combines the PhysNetInteraction, PhysNetResidual and
-        # PhysNetOutput class
-
+        # Initialize interaction module
         self.interaction = PhysNetInteractionModule(
             number_of_per_atom_features=number_of_per_atom_features,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
             number_of_interaction_residual=number_of_interaction_residual,
             activation_function_class=activation_function_class,
         )
+        # Initialize output module
         self.output = PhysNetOutput(
             number_of_per_atom_features=number_of_per_atom_features,
             number_of_atomic_properties=2,
@@ -389,8 +404,17 @@ class PhysNetModule(nn.Module):
     def forward(self, data: PhysNetNeuralNetworkData) -> Dict[str, torch.Tensor]:
         """
         Forward pass for the PhysNet module.
-        """
 
+        Parameters
+        ----------
+        data : PhysNetNeuralNetworkData
+            Input data containing atomic features and pairwise information.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            Dictionary containing predictions and updated embeddings.
+        """
         # The PhysNet module is a sequence of interaction modules and residual modules.
         #              x_1, ..., x_N
         #                     |
@@ -423,6 +447,25 @@ class PhysNetModule(nn.Module):
 
 
 class PhysNetCore(CoreNetwork):
+    """
+    Core network class for the PhysNet neural network potential.
+
+    Parameters
+    ----------
+    featurization_config : Dict[str, Union[List[str], int]]
+        Configuration for atomic feature generation.
+    maximum_interaction_radius : openff.units.unit.Quantity
+        The cutoff distance for interactions.
+    number_of_radial_basis_functions : int
+        Number of radial basis functions.
+    number_of_interaction_residual : int
+        Number of interaction residual blocks.
+    number_of_modules : int
+        Number of PhysNet modules.
+    activation_name : str
+        Name of the activation function to use.
+    """
+
     def __init__(
         self,
         featurization_config: Dict[str, Union[List[str], int]],
@@ -432,24 +475,12 @@ class PhysNetCore(CoreNetwork):
         number_of_modules: int,
         activation_name: str,
     ) -> None:
-        """
-        Implementation of the PhysNet neural network potential.
-
-        Parameters
-        ----------
-        featurization_config: Dict[str, Union[List[str], int]],
-
-        maximum_interaction_radius : openff.units.unit.Quantity
-            The cutoff distance for interactions.
-        number_of_modules : int
-        """
 
         log.debug("Initializing the PhysNet architecture.")
         super().__init__(activation_name)
 
         # featurize the atomic input
         from modelforge.potential.utils import FeaturizeInput
-
         self.featurize_input = FeaturizeInput(featurization_config)
         number_of_per_atom_features = int(
             featurization_config["number_of_per_atom_features"]
@@ -482,7 +513,21 @@ class PhysNetCore(CoreNetwork):
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: "PairListOutputs"
     ) -> PhysNetNeuralNetworkData:
-        # Perform atomic embedding
+        """
+        Prepare model-specific input data.
+
+        Parameters
+        ----------
+        data : NNPInput
+            Input data containing atomic information.
+        pairlist_output : PairListOutputs
+            Output from the pairlist calculation.
+
+        Returns
+        -------
+        PhysNetNeuralNetworkData
+            Prepared input data for the PhysNet model.
+        """
         atomic_embedding = self.featurize_input(data)
         #         Z_i, ..., Z_N
         #
@@ -513,15 +558,17 @@ class PhysNetCore(CoreNetwork):
         self, data: PhysNetNeuralNetworkData
     ) -> Dict[str, torch.Tensor]:
         """
-        Calculate the energy for a given input batch.
+        Compute properties for a given input batch.
+
         Parameters
         ----------
-        inputs : PhysNetNeutralNetworkInput
+        data : PhysNetNeuralNetworkData
+            Input data containing atomic features and pairwise information.
 
         Returns
         -------
-        torch.Tensor
-            Calculated energies; shape (nr_systems,).
+        Dict[str, torch.Tensor]
+            Calculated properties including per-atom energies.
         """
 
         # Computed representation
@@ -600,6 +647,28 @@ from modelforge.potential.utils import shared_config_prior
 
 
 class PhysNet(BaseNetwork):
+    """
+    Implementation of the PhysNet neural network potential.
+
+    Parameters
+    ----------
+    featurization : Dict[str, Union[List[str], int]]
+        Configuration for atomic feature generation.
+    maximum_interaction_radius : Union[unit.Quantity, str]
+        The cutoff distance for interactions.
+    number_of_radial_basis_functions : int
+        Number of radial basis functions.
+    number_of_interaction_residual : int
+        Number of interaction residual blocks.
+    number_of_modules : int
+        Number of PhysNet modules.
+    activation_function : str
+        Name of the activation function to use.
+    postprocessing_parameter : Dict[str, Dict[str, bool]]
+        Configuration for postprocessing parameters.
+    dataset_statistic : Optional[Dict[str, float]], optional
+        Statistics of the dataset, by default None.
+    """
     def __init__(
         self,
         featurization: Dict[str, Union[List[str], int]],
@@ -611,26 +680,6 @@ class PhysNet(BaseNetwork):
         postprocessing_parameter: Dict[str, Dict[str, bool]],
         dataset_statistic: Optional[Dict[str, float]] = None,
     ) -> None:
-        """
-        Implementation of the PhysNet neural network potential.
-
-        Parameters
-        ----------
-        featurization : Dict[str, Union[List[str], int]]
-            Configuration for atomic feature generation.
-        maximum_interaction_radius : Union[unit.Quantity, str]
-            The cutoff distance for interactions.
-        number_of_radial_basis_functions : int
-            The number of radial basis functions.
-        number_of_interaction_residual : int
-            The number of interaction residuals.
-        number_of_modules : int
-            The number of PhysNet modules.
-        postprocessing_parameter : Dict[str, Dict[str, bool]]
-            Configuration for postprocessing parameters.
-        dataset_statistic : Optional[Dict[str, float]], optional
-            Statistics of the dataset, by default None.
-        """
 
         self.only_unique_pairs = False  # NOTE: for pairlist
         super().__init__(

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -78,7 +78,8 @@ class SAKECore(CoreNetwork):
         number_of_interaction_modules: int,
         number_of_spatial_attention_heads: int,
         number_of_radial_basis_functions: int,
-        cutoff: unit.Quantity,
+        maximum_interaction_radius: unit.Quantity,
+        activation_function: str,
         epsilon: float = 1e-8,
     ):
         """
@@ -94,17 +95,17 @@ class SAKECore(CoreNetwork):
             Number of spatial attention heads.
         number_of_radial_basis_functions : int
             Number of radial basis functions.
-        cutoff : unit.Quantity
+        maximum_interaction_radius : unit.Quantity
             Cutoff distance.
         epsilon : float, optional
             Small value to avoid division by zero, by default 1e-8.
         """
         log.debug("Initializing the SAKE architecture.")
-        super().__init__()
+        super().__init__(activation_function)
         self.nr_interaction_blocks = number_of_interaction_modules
-        number_of_per_atom_features = featurization_config[
-            "number_of_per_atom_features"
-        ]
+        number_of_per_atom_features = int(
+            featurization_config["number_of_per_atom_features"]
+        )
         self.nr_heads = number_of_spatial_attention_heads
         self.number_of_per_atom_features = number_of_per_atom_features
         # featurize the atomic input
@@ -113,7 +114,7 @@ class SAKECore(CoreNetwork):
         self.featurize_input = FeaturizeInput(featurization_config)
         self.energy_layer = nn.Sequential(
             Dense(number_of_per_atom_features, number_of_per_atom_features),
-            nn.SiLU(),
+            self.activation_function_class(),
             Dense(number_of_per_atom_features, 1),
         )
         # initialize the interaction networks
@@ -128,8 +129,8 @@ class SAKECore(CoreNetwork):
                 nr_atom_basis_velocity=number_of_per_atom_features,
                 nr_coefficients=(self.nr_heads * number_of_per_atom_features),
                 nr_heads=self.nr_heads,
-                activation=torch.nn.SiLU(),
-                cutoff=cutoff,
+                activation=self.activation_function_class(),
+                maximum_interaction_radius=maximum_interaction_radius,
                 number_of_radial_basis_functions=number_of_radial_basis_functions,
                 epsilon=epsilon,
                 scale_factor=(1.0 * unit.nanometer),  # TODO: switch to angstrom
@@ -158,12 +159,6 @@ class SAKECore(CoreNetwork):
         # Perform atomic embedding
 
         number_of_atoms = data.atomic_numbers.shape[0]
-
-        # atomic_embedding = self.embedding(
-        #     F.one_hot(data.atomic_numbers.long(), num_classes=self.max_Z).to(
-        #         self.embedding.weight.dtype
-        #     )
-        # )
 
         nnp_input = SAKENeuralNetworkInput(
             pair_indices=pairlist_output.pair_indices,
@@ -226,7 +221,7 @@ class SAKEInteraction(nn.Module):
         nr_coefficients: int,
         nr_heads: int,
         activation: nn.Module,
-        cutoff: unit.Quantity,
+        maximum_interaction_radius: unit.Quantity,
         number_of_radial_basis_functions: int,
         epsilon: float,
         scale_factor: unit.Quantity,
@@ -252,7 +247,7 @@ class SAKEInteraction(nn.Module):
             Number of coefficients for spatial attention.
         activation : Callable
             Activation function to use.
-        cutoff : unit.Quantity
+        maximum_interaction_radius : unit.Quantity
             Distance parameter for setting scale factors in radial basis functions.
         number_of_radial_basis_functions: int
             Number of radial basis functions.
@@ -275,7 +270,7 @@ class SAKEInteraction(nn.Module):
         self.epsilon = epsilon
         self.radial_symmetry_function_module = PhysNetRadialBasisFunction(
             number_of_radial_basis_functions=number_of_radial_basis_functions,
-            max_distance=cutoff,
+            max_distance=maximum_interaction_radius,
             dtype=torch.float32,
         )
 
@@ -285,21 +280,25 @@ class SAKEInteraction(nn.Module):
                 + self.nr_heads * self.nr_edge_basis
                 + self.nr_atom_basis_spatial,
                 self.nr_atom_basis_hidden,
-                activation=activation,
+                activation_function=activation,
             ),
-            Dense(self.nr_atom_basis_hidden, self.nr_atom_basis, activation=activation),
+            Dense(
+                self.nr_atom_basis_hidden,
+                self.nr_atom_basis,
+                activation_function=activation,
+            ),
         )
 
         self.post_norm_mlp = nn.Sequential(
             Dense(
                 self.nr_coefficients,
                 self.nr_atom_basis_spatial_hidden,
-                activation=activation,
+                activation_function=activation,
             ),
             Dense(
                 self.nr_atom_basis_spatial_hidden,
                 self.nr_atom_basis_spatial,
-                activation=activation,
+                activation_function=activation,
             ),
         )
 
@@ -311,23 +310,25 @@ class SAKEInteraction(nn.Module):
             Dense(
                 self.nr_atom_basis * 2 + number_of_radial_basis_functions + 1,
                 self.nr_edge_basis_hidden,
-                activation=activation,
+                activation_function=activation,
             ),
             nn.Linear(nr_edge_basis_hidden, nr_edge_basis),
         )
 
         self.semantic_attention_mlp = Dense(
-            self.nr_edge_basis, self.nr_heads, activation=nn.CELU(alpha=2.0)
+            self.nr_edge_basis, self.nr_heads, activation_function=nn.CELU(alpha=2.0)
         )
 
         self.velocity_mlp = nn.Sequential(
             Dense(
-                self.nr_atom_basis, self.nr_atom_basis_velocity, activation=activation
+                self.nr_atom_basis,
+                self.nr_atom_basis_velocity,
+                activation_function=activation,
             ),
             Dense(
                 self.nr_atom_basis_velocity,
                 1,
-                activation=lambda x: 2.0 * F.sigmoid(x),
+                activation_function=lambda x: 2.0 * F.sigmoid(x),
                 bias=False,
             ),
         )
@@ -336,7 +337,7 @@ class SAKEInteraction(nn.Module):
             self.nr_heads * self.nr_edge_basis,
             self.nr_coefficients,
             bias=False,
-            activation=nn.Tanh(),
+            activation_function=nn.Tanh(),
         )
 
         self.v_mixing_mlp = Dense(self.nr_coefficients, 1, bias=False)
@@ -597,7 +598,8 @@ class SAKE(BaseNetwork):
         number_of_interaction_modules: int,
         number_of_spatial_attention_heads: int,
         number_of_radial_basis_functions: int,
-        cutoff: unit.Quantity,
+        maximum_interaction_radius: unit.Quantity,
+        activation_function: str,
         postprocessing_parameter: Dict[str, Dict[str, bool]],
         dataset_statistic: Optional[Dict[str, float]] = None,
         epsilon: float = 1e-8,
@@ -608,7 +610,7 @@ class SAKE(BaseNetwork):
         super().__init__(
             dataset_statistic=dataset_statistic,
             postprocessing_parameter=postprocessing_parameter,
-            cutoff=_convert_str_to_unit(cutoff),
+            maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
         )
 
         self.core_module = SAKECore(
@@ -616,7 +618,8 @@ class SAKE(BaseNetwork):
             number_of_interaction_modules=number_of_interaction_modules,
             number_of_spatial_attention_heads=number_of_spatial_attention_heads,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
-            cutoff=_convert_str_to_unit(cutoff),
+            maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
+            activation_function=activation_function,
             epsilon=epsilon,
         )
 
@@ -633,13 +636,8 @@ class SAKE(BaseNetwork):
             "number_of_per_atom_features": tune.randint(2, 256),
             "number_of_modules": tune.randint(3, 8),
             "number_of_spatial_attention_heads": tune.randint(2, 5),
-            "cutoff": tune.uniform(5, 10),
+            "maximum_interaction_radius": tune.uniform(5, 10),
             "number_of_radial_basis_functions": tune.randint(8, 32),
         }
         prior.update(shared_config_prior())
         return prior
-
-    def combine_per_atom_properties(
-        self, values: Dict[str, torch.Tensor]
-    ) -> torch.Tensor:
-        return values

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -79,7 +79,7 @@ class SAKECore(CoreNetwork):
         number_of_spatial_attention_heads: int,
         number_of_radial_basis_functions: int,
         maximum_interaction_radius: unit.Quantity,
-        activation_function: str,
+        activation_name: str,
         epsilon: float = 1e-8,
     ):
         """
@@ -101,7 +101,7 @@ class SAKECore(CoreNetwork):
             Small value to avoid division by zero, by default 1e-8.
         """
         log.debug("Initializing the SAKE architecture.")
-        super().__init__(activation_function)
+        super().__init__(activation_name)
         self.nr_interaction_blocks = number_of_interaction_modules
         number_of_per_atom_features = int(
             featurization_config["number_of_per_atom_features"]
@@ -619,7 +619,7 @@ class SAKE(BaseNetwork):
             number_of_spatial_attention_heads=number_of_spatial_attention_heads,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
             maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
-            activation_function=activation_function,
+            activation_name=activation_function,
             epsilon=epsilon,
         )
 

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -90,7 +90,7 @@ class SchNetCore(CoreNetwork):
         number_of_interaction_modules: int,
         number_of_filters: int,
         shared_interactions: bool,
-        activation_function: str,
+        activation_name: str,
         maximum_interaction_radius: unit.Quantity,
     ) -> None:
         """
@@ -115,7 +115,7 @@ class SchNetCore(CoreNetwork):
         log.debug("Initializing the SchNet architecture.")
         from modelforge.potential.utils import FeaturizeInput, Dense
 
-        super().__init__(activation_function)
+        super().__init__(activation_name)
         self.number_of_filters = number_of_filters or int(
             featurization_config["number_of_per_atom_features"]
         )
@@ -137,7 +137,7 @@ class SchNetCore(CoreNetwork):
                         number_of_per_atom_features,
                         self.number_of_filters,
                         number_of_radial_basis_functions,
-                        activation_function=self.activation_function_class,
+                        activation_function=self.activation_function_class(),
                     )
                 ]
                 * number_of_interaction_modules
@@ -478,7 +478,7 @@ class SchNet(BaseNetwork):
             number_of_interaction_modules=number_of_interaction_modules,
             number_of_filters=number_of_filters,
             shared_interactions=shared_interactions,
-            activation_function=activation_function,
+            activation_name=activation_function,
             maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
         )
 

--- a/modelforge/potential/tensornet.py
+++ b/modelforge/potential/tensornet.py
@@ -25,7 +25,7 @@ class TensorNet(BaseNetwork):
         )
         self.only_unique_pairs = True  # NOTE: for pairlist
         self.input_preparation = ComputeInteractingAtomPairs(
-            cutoff=radial_max_distance, only_unique_pairs=self.only_unique_pairs
+            maximum_interaction_radius=radial_max_distance, only_unique_pairs=self.only_unique_pairs
         )
 
 

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -12,6 +12,31 @@ from modelforge.dataset.dataset import NNPInput
 
 @dataclass
 class NeuralNetworkData:
+    """
+    A dataclass to structure the inputs specifically for SchNet-based neural network potentials, including the necessary geometric and chemical information, along with the radial symmetry function expansion (`f_ij`) and the cosine cutoff (`f_cutoff`) to accurately represent atomistic systems for energy predictions.
+
+    Attributes
+    ----------
+    pair_indices : torch.Tensor
+        A 2D tensor of shape [2, num_pairs], indicating the indices of atom pairs within a molecule or system.
+    d_ij : torch.Tensor
+        A 1D tensor containing the distances between each pair of atoms identified in `pair_indices`. Shape: [num_pairs, 1].
+    r_ij : torch.Tensor
+        A 2D tensor of shape [num_pairs, 3], representing the displacement vectors between each pair of atoms.
+    number_of_atoms : int
+        A integer indicating the number of atoms in the batch.
+    positions : torch.Tensor
+        A 2D tensor of shape [num_atoms, 3], representing the XYZ coordinates of each atom within the system.
+    atomic_numbers : torch.Tensor
+        A 1D tensor containing atomic numbers for each atom, used to identify the type of each atom in the system(s).
+    atomic_subsystem_indices : torch.Tensor
+        A 1D tensor mapping each atom to its respective subsystem or molecule, useful for systems involving multiple
+        molecules or distinct subsystems.
+    total_charge : torch.Tensor
+        A tensor with the total charge of each system or molecule. Shape: [num_systems], where each entry corresponds
+        to a distinct system or molecule.
+    """
+
     pair_indices: torch.Tensor
     d_ij: torch.Tensor
     r_ij: torch.Tensor

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -346,7 +346,7 @@ class FeaturizeInput(nn.Module):
             A dictionary containing the featurization configuration. It should have the following keys:
             - "properties_to_featurize" : list
                 A list of properties to featurize.
-            - "highest_atomic_number" : int
+            - "maximum_atomic_number" : int
                 The maximum atomic number.
             - "number_of_per_atom_features" : int
                 The number of per-atom features.
@@ -375,7 +375,7 @@ class FeaturizeInput(nn.Module):
             ):
 
                 self.nuclear_charge_embedding = Embedding(
-                    int(featurization_config["highest_atomic_number"]),
+                    int(featurization_config["maximum_atomic_number"]),
                     int(featurization_config["number_of_per_atom_features"]),
                 )
                 self.registered_embedding_operations.append("nuclear_charge_embedding")
@@ -1295,6 +1295,7 @@ def scatter_softmax(
 
 
 from enum import Enum
+
 
 class ActivationFunction(Enum):
     ReLU = nn.ReLU

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -1294,15 +1294,15 @@ def scatter_softmax(
     return recentered_scores_exp.div(normalizing_constants)
 
 
-ACTIVATION_FUNCTIONS = {
-    "ReLU": nn.ReLU,
-    "CeLU": nn.CELU,
-    "Sigmoid": nn.Sigmoid,
-    "Softmax": nn.Softmax,
-    "ShiftedSoftplus": ShiftedSoftplus,
-    "SiLU": nn.SiLU,
-    "Tanh": nn.Tanh,
-    "LeakyReLU": nn.LeakyReLU,
-    "ELU": nn.ELU,
-    # Add more activation functions as needed
-}
+from enum import Enum
+
+class ActivationFunction(Enum):
+    ReLU = nn.ReLU
+    CeLU = nn.CELU
+    Sigmoid = nn.Sigmoid
+    Softmax = nn.Softmax
+    ShiftedSoftplus = ShiftedSoftplus
+    SiLU = nn.SiLU
+    Tanh = nn.Tanh
+    LeakyReLU = nn.LeakyReLU
+    ELU = nn.ELU

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -346,7 +346,7 @@ class FeaturizeInput(nn.Module):
             A dictionary containing the featurization configuration. It should have the following keys:
             - "properties_to_featurize" : list
                 A list of properties to featurize.
-            - "maximum_atomic_number" : int
+            - "highest_atomic_number" : int
                 The maximum atomic number.
             - "number_of_per_atom_features" : int
                 The number of per-atom features.
@@ -375,7 +375,7 @@ class FeaturizeInput(nn.Module):
             ):
 
                 self.nuclear_charge_embedding = Embedding(
-                    int(featurization_config["maximum_atomic_number"]),
+                    int(featurization_config["highest_atomic_number"]),
                     int(featurization_config["number_of_per_atom_features"]),
                 )
                 self.registered_embedding_operations.append("nuclear_charge_embedding")

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -1,13 +1,11 @@
 import math
-from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Tuple, NamedTuple, Type
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 import torch
 import torch.nn as nn
-from loguru import logger as log
 from openff.units import unit
-from pint import Quantity
 from typing import Union
 from modelforge.dataset.dataset import NNPInput
 
@@ -348,7 +346,7 @@ class FeaturizeInput(nn.Module):
             A dictionary containing the featurization configuration. It should have the following keys:
             - "properties_to_featurize" : list
                 A list of properties to featurize.
-            - "max_Z" : int
+            - "maximum_atomic_number" : int
                 The maximum atomic number.
             - "number_of_per_atom_features" : int
                 The number of per-atom features.
@@ -377,7 +375,7 @@ class FeaturizeInput(nn.Module):
             ):
 
                 self.nuclear_charge_embedding = Embedding(
-                    int(featurization_config["max_Z"]),
+                    int(featurization_config["maximum_atomic_number"]),
                     int(featurization_config["number_of_per_atom_features"]),
                 )
                 self.registered_embedding_operations.append("nuclear_charge_embedding")
@@ -477,15 +475,12 @@ class Dense(nn.Linear):
         in_features: int,
         out_features: int,
         bias: bool = True,
-        activation: Optional[
-            Union[nn.Module, Callable[[torch.Tensor], torch.Tensor]]
-        ] = None,
+        activation_function: Optional[nn.Module] = None,
         weight_init: Callable = xavier_uniform_,
         bias_init: Callable = zeros_,
     ):
         """
-        __init__ _summary_
-
+        A linear or non-linear transformation
 
         Parameters
         ----------
@@ -495,8 +490,8 @@ class Dense(nn.Linear):
             Number of output features.
         bias : bool, optional
             If set to False, the layer will not learn an additive bias. Default is True.
-        activation : nn.Module or Callable[[torch.Tensor], torch.Tensor], optional
-            Activation function to be applied. Default is None, which applies the identity function and makes this a linear transformation.
+        activation_function : nn.Module , optional
+            Activation function to be applied. Default is nn.Identity(), which applies the identity function and makes this a linear ransformation.
         weight_init : Callable, optional
             Callable to initialize the weights. Default is xavier_uniform_.
         bias_init : Callable, optional
@@ -510,7 +505,9 @@ class Dense(nn.Linear):
             in_features, out_features, bias
         )  # NOTE: the `reseet_paramters` method is called in the super class
 
-        self.activation = activation or nn.Identity()
+        self.activation_function = (
+            activation_function if activation_function is not None else nn.Identity()
+        )
 
     def reset_parameters(self):
         """
@@ -536,7 +533,7 @@ class Dense(nn.Linear):
 
         """
         y = F.linear(input, self.weight, self.bias)
-        return self.activation(y)
+        return self.activation_function(y)
 
 
 from openff.units import unit
@@ -1295,3 +1292,17 @@ def scatter_softmax(
     normalizing_constants = sum_per_index.gather(dim, index)
 
     return recentered_scores_exp.div(normalizing_constants)
+
+
+ACTIVATION_FUNCTIONS = {
+    "ReLU": nn.ReLU,
+    "CeLU": nn.CELU,
+    "Sigmoid": nn.Sigmoid,
+    "Softmax": nn.Softmax,
+    "ShiftedSoftplus": ShiftedSoftplus,
+    "SiLU": nn.SiLU,
+    "Tanh": nn.Tanh,
+    "LeakyReLU": nn.LeakyReLU,
+    "ELU": nn.ELU,
+    # Add more activation functions as needed
+}

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -1297,13 +1297,16 @@ def scatter_softmax(
 from enum import Enum
 
 
-class ActivationFunction(Enum):
-    ReLU = nn.ReLU
-    CeLU = nn.CELU
-    Sigmoid = nn.Sigmoid
-    Softmax = nn.Softmax
-    ShiftedSoftplus = ShiftedSoftplus
-    SiLU = nn.SiLU
-    Tanh = nn.Tanh
-    LeakyReLU = nn.LeakyReLU
-    ELU = nn.ELU
+
+ACTIVATION_FUNCTIONS = {
+    "ReLU": nn.ReLU,
+    "CeLU": nn.CELU,
+    "Sigmoid": nn.Sigmoid,
+    "Softmax": nn.Softmax,
+    "ShiftedSoftplus": ShiftedSoftplus,
+    "SiLU": nn.SiLU,
+    "Tanh": nn.Tanh,
+    "LeakyReLU": nn.LeakyReLU,
+    "ELU": nn.ELU,
+    # Add more activation functions as needed
+}

--- a/modelforge/tests/data/potential_defaults/ani2x.toml
+++ b/modelforge/tests/data/potential_defaults/ani2x.toml
@@ -3,12 +3,13 @@ potential_name = "ANI2x"
 
 [potential.core_parameter]
 angle_sections = 4
-radial_max_distance = "5.1 angstrom"
-radial_min_distance = "0.8 angstrom"
+maximum_interaction_radius = "5.1 angstrom"
+minimum_interaction_radius = "0.8 angstrom"
 number_of_radial_basis_functions = 16
-angular_max_distance = "3.5 angstrom"
-angular_min_distance = "0.8 angstrom"
+maximum_interaction_radius_for_angular_features = "3.5 angstrom"
+minimum_interaction_radius_for_angular_features = "0.8 angstrom"
 angular_dist_divisions = 8
+activation_function = "CeLU"   # for the original ANI behavior please stick with CeLu since the alpha parameter is currently hard coded and might lead to different behavior when another activation function is used.
 
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]

--- a/modelforge/tests/data/potential_defaults/painn.toml
+++ b/modelforge/tests/data/potential_defaults/painn.toml
@@ -11,7 +11,7 @@ activation_function = "SiLU"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-maximum_atomic_number = 101
+highest_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/data/potential_defaults/painn.toml
+++ b/modelforge/tests/data/potential_defaults/painn.toml
@@ -11,7 +11,7 @@ activation_function = "SiLU"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-highest_atomic_number = 101
+maximum_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/data/potential_defaults/painn.toml
+++ b/modelforge/tests/data/potential_defaults/painn.toml
@@ -2,15 +2,16 @@
 potential_name = "PaiNN"
 
 [potential.core_parameter]
-
 number_of_radial_basis_functions = 20
-cutoff = "5.0 angstrom"
+maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 3
 shared_interactions = false
 shared_filters = false
+activation_function = "SiLU"
+
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-max_Z = 101
+maximum_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/data/potential_defaults/physnet.toml
+++ b/modelforge/tests/data/potential_defaults/physnet.toml
@@ -11,7 +11,7 @@ activation_function = "ShiftedSoftplus"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-highest_atomic_number = 101
+maximum_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/data/potential_defaults/physnet.toml
+++ b/modelforge/tests/data/potential_defaults/physnet.toml
@@ -11,7 +11,7 @@ activation_function = "ShiftedSoftplus"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-maximum_atomic_number = 101
+highest_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/data/potential_defaults/physnet.toml
+++ b/modelforge/tests/data/potential_defaults/physnet.toml
@@ -4,12 +4,14 @@ potential_name = "PhysNet"
 [potential.core_parameter]
 
 number_of_radial_basis_functions = 16
-cutoff = "5.0 angstrom"
+maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_residual = 3
 number_of_modules = 5
+activation_function = "ShiftedSoftplus"
+
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-max_Z = 101
+maximum_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/data/potential_defaults/sake.toml
+++ b/modelforge/tests/data/potential_defaults/sake.toml
@@ -4,13 +4,15 @@ potential_name = "SAKE"
 [potential.core_parameter]
 
 number_of_radial_basis_functions = 50
-cutoff = "5.0 angstrom"
+maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 6
 number_of_spatial_attention_heads = 4
+activation_function = "SiLU"
+
 [potential.core_parameter.featurization]
 number_of_per_atom_features = 64
 properties_to_featurize = ['atomic_number']
-max_Z = 101
+maximum_atomic_number = 101
 
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]

--- a/modelforge/tests/data/potential_defaults/sake.toml
+++ b/modelforge/tests/data/potential_defaults/sake.toml
@@ -12,7 +12,7 @@ activation_function = "SiLU"
 [potential.core_parameter.featurization]
 number_of_per_atom_features = 64
 properties_to_featurize = ['atomic_number']
-highest_atomic_number = 101
+maximum_atomic_number = 101
 
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]

--- a/modelforge/tests/data/potential_defaults/sake.toml
+++ b/modelforge/tests/data/potential_defaults/sake.toml
@@ -12,7 +12,7 @@ activation_function = "SiLU"
 [potential.core_parameter.featurization]
 number_of_per_atom_features = 64
 properties_to_featurize = ['atomic_number']
-maximum_atomic_number = 101
+highest_atomic_number = 101
 
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]

--- a/modelforge/tests/data/potential_defaults/schnet.toml
+++ b/modelforge/tests/data/potential_defaults/schnet.toml
@@ -11,7 +11,7 @@ activation_function = "ShiftedSoftplus"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-highest_atomic_number = 101
+maximum_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/data/potential_defaults/schnet.toml
+++ b/modelforge/tests/data/potential_defaults/schnet.toml
@@ -11,7 +11,7 @@ activation_function = "ShiftedSoftplus"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-maximum_atomic_number = 101
+highest_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/data/potential_defaults/schnet.toml
+++ b/modelforge/tests/data/potential_defaults/schnet.toml
@@ -3,13 +3,15 @@ potential_name = "SchNet"
 
 [potential.core_parameter]
 number_of_radial_basis_functions = 20
-cutoff = "5.0 angstrom"
+maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 3
 number_of_filters = 32
 shared_interactions = false
+activation_function = "ShiftedSoftplus"
+
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']
-max_Z = 101
+maximum_atomic_number = 101
 number_of_per_atom_features = 32
 
 [potential.postprocessing_parameter]

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -80,6 +80,22 @@ def setup_two_methanes():
     return ani_species, coordinates, device, nnp_input
 
 
+def test_init():
+    from modelforge.potential.ani import ANI2x
+    from modelforge.tests.test_models import load_configs_into_pydantic_models
+
+    # read default parameters
+    config = load_configs_into_pydantic_models("ani2x", "qm9")
+
+    # initialize model
+    model = ANI2x(
+        **config["potential"].model_dump()["core_parameter"],
+        postprocessing_parameter=config["potential"].model_dump()[
+            "postprocessing_parameter"
+        ],
+    )
+
+
 @pytest.mark.xfail
 def test_forward_and_backward_using_torchani():
     # Test torchani ANI implementation

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -174,7 +174,7 @@ def test_compare_implementation_agains_reference_implementation():
     torch.manual_seed(1234)
 
     # override defaults to match reference implementation in spk
-    config["potential"].core_parameter.featurization.highest_atomic_number = 100
+    config["potential"].core_parameter.featurization.maximum_atomic_number = 100
     config["potential"].core_parameter.featurization.number_of_per_atom_features = 8
     config["potential"].core_parameter.number_of_radial_basis_functions = 5
 

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -174,7 +174,7 @@ def test_compare_implementation_agains_reference_implementation():
     torch.manual_seed(1234)
 
     # override defaults to match reference implementation in spk
-    config["potential"].core_parameter.featurization.maximum_atomic_number = 100
+    config["potential"].core_parameter.featurization.highest_atomic_number = 100
     config["potential"].core_parameter.featurization.number_of_per_atom_features = 8
     config["potential"].core_parameter.number_of_radial_basis_functions = 5
 

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -160,7 +160,7 @@ import torch
 from modelforge.tests.test_schnet import setup_single_methane_input
 
 
-def test_compare_representation():
+def test_compare_implementation_agains_reference_implementation():
     # ---------------------------------------- #
     # setup the PaiNN model
     # ---------------------------------------- #
@@ -174,7 +174,7 @@ def test_compare_representation():
     torch.manual_seed(1234)
 
     # override defaults to match reference implementation in spk
-    config["potential"].core_parameter.featurization.max_Z = 100
+    config["potential"].core_parameter.featurization.maximum_atomic_number = 100
     config["potential"].core_parameter.featurization.number_of_per_atom_features = 8
     config["potential"].core_parameter.number_of_radial_basis_functions = 5
 

--- a/modelforge/tests/test_sake.py
+++ b/modelforge/tests/test_sake.py
@@ -431,12 +431,12 @@ def test_model_against_reference(single_batch_with_batchsize_1):
     nr_interaction_blocks = 3
     cutoff = 5.0 * unit.angstrom
     nr_atom_basis = 11
-    maximum_atomic_number = 13
+    highest_atomic_number = 13
 
     mf_sake = SAKE(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "maximum_atomic_number": maximum_atomic_number,
+            "highest_atomic_number": highest_atomic_number,
             "number_of_per_atom_features": nr_atom_basis,
         },
         number_of_interaction_modules=nr_interaction_blocks,
@@ -478,7 +478,7 @@ def test_model_against_reference(single_batch_with_batchsize_1):
         ].set(1)
 
     h = jax.nn.one_hot(
-        prepared_methane.atomic_numbers.detach().numpy(), maximum_atomic_number
+        prepared_methane.atomic_numbers.detach().numpy(), highest_atomic_number
     )
     x = prepared_methane.positions.detach().numpy()
     variables = ref_sake.init(key, h, x, mask=mask)

--- a/modelforge/tests/test_sake.py
+++ b/modelforge/tests/test_sake.py
@@ -431,12 +431,12 @@ def test_model_against_reference(single_batch_with_batchsize_1):
     nr_interaction_blocks = 3
     cutoff = 5.0 * unit.angstrom
     nr_atom_basis = 11
-    highest_atomic_number = 13
+    maximum_atomic_number = 13
 
     mf_sake = SAKE(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "highest_atomic_number": highest_atomic_number,
+            "maximum_atomic_number": maximum_atomic_number,
             "number_of_per_atom_features": nr_atom_basis,
         },
         number_of_interaction_modules=nr_interaction_blocks,
@@ -478,7 +478,7 @@ def test_model_against_reference(single_batch_with_batchsize_1):
         ].set(1)
 
     h = jax.nn.one_hot(
-        prepared_methane.atomic_numbers.detach().numpy(), highest_atomic_number
+        prepared_methane.atomic_numbers.detach().numpy(), maximum_atomic_number
     )
     x = prepared_methane.positions.detach().numpy()
     variables = ref_sake.init(key, h, x, mask=mask)

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -21,12 +21,12 @@ def initialize_model(
     return SchNet(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "max_Z": 101,
+            "maximum_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,
         number_of_radial_basis_functions=number_of_radial_basis_functions,
-        cutoff=cutoff,
+        radial_max_distance=cutoff,
         number_of_filters=number_of_atom_features,
         shared_interactions=False,
         processing_operation=[],

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -21,7 +21,7 @@ def initialize_model(
     return SchNet(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "maximum_atomic_number": 101,
+            "highest_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,

--- a/modelforge/tests/test_schnet.py
+++ b/modelforge/tests/test_schnet.py
@@ -21,7 +21,7 @@ def initialize_model(
     return SchNet(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "highest_atomic_number": 101,
+            "maximum_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -73,7 +73,7 @@ def setup_modelforge_painn_representation(
     return mf_PaiNN(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "max_Z": 101,
+            "maximum_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,
@@ -458,7 +458,7 @@ def setup_mf_schnet_representation(
     return mf_SchNET(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "max_Z": 101,
+            "maximum_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -73,7 +73,7 @@ def setup_modelforge_painn_representation(
     return mf_PaiNN(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "highest_atomic_number": 101,
+            "maximum_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,
@@ -458,7 +458,7 @@ def setup_mf_schnet_representation(
     return mf_SchNET(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "highest_atomic_number": 101,
+            "maximum_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,

--- a/modelforge/tests/test_spk.py
+++ b/modelforge/tests/test_spk.py
@@ -73,7 +73,7 @@ def setup_modelforge_painn_representation(
     return mf_PaiNN(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "maximum_atomic_number": 101,
+            "highest_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,
@@ -458,7 +458,7 @@ def setup_mf_schnet_representation(
     return mf_SchNET(
         featurization={
             "properties_to_featurize": ["atomic_number"],
-            "maximum_atomic_number": 101,
+            "highest_atomic_number": 101,
             "number_of_per_atom_features": 32,
         },
         number_of_interaction_modules=nr_of_interactions,

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -454,11 +454,11 @@ def test_embedding():
     """
     from modelforge.potential.utils import Embedding
 
-    maximum_atomic_number = 100
+    highest_atomic_number = 100
     embedding_dim = 7
 
     # Create Embedding instance
-    embedding = Embedding(maximum_atomic_number, embedding_dim)
+    embedding = Embedding(highest_atomic_number, embedding_dim)
 
     # Test embedding_dim property
     assert embedding.embedding_dim == embedding_dim

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -454,11 +454,11 @@ def test_embedding():
     """
     from modelforge.potential.utils import Embedding
 
-    highest_atomic_number = 100
+    maximum_atomic_number = 100
     embedding_dim = 7
 
     # Create Embedding instance
-    embedding = Embedding(highest_atomic_number, embedding_dim)
+    embedding = Embedding(maximum_atomic_number, embedding_dim)
 
     # Test embedding_dim property
     assert embedding.embedding_dim == embedding_dim

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -454,11 +454,11 @@ def test_embedding():
     """
     from modelforge.potential.utils import Embedding
 
-    max_Z = 100
+    maximum_atomic_number = 100
     embedding_dim = 7
 
     # Create Embedding instance
-    embedding = Embedding(max_Z, embedding_dim)
+    embedding = Embedding(maximum_atomic_number, embedding_dim)
 
     # Test embedding_dim property
     assert embedding.embedding_dim == embedding_dim

--- a/scripts/config.toml
+++ b/scripts/config.toml
@@ -2,7 +2,7 @@
 potential_name = "SchNet"
 
 [potential.core_parameter]
-max_Z = 101
+maximum_atomic_number = 101
 number_of_atom_features = 32
 number_of_radial_basis_functions = 20
 cutoff = "5.0 angstrom"


### PR DESCRIPTION
## Description
This PR makes the following small naming changes:
- instead of `max_Z` for the highest element that defines the vocabulary for the embedding we use `highest_atomic_number`.
- instead of `cutoff` indicating the maximum interaction distance we use `maximum_interaction_radius`. This change is because some networks also define a minimum length, and the naming of that value was awkward, but `minimum_interaction_radius` is verbose and clear.

Additionally, to be more flexible, this PR includes changes allowing the user to define the activation function in the toml file. This clarifies what activation function is used and allows for rapid change. This won't work for all models out of the box; e.g., ANI uses the `CeLU` activation function with a defined alpha value. 

Some smaller changes include removing default values in some of the networks and adding missing docstrings.

## Question

@ArnNag , I noticed that SAKE uses 4 different activation functions. Are there empirical reasons for that, or can we use ShiftedSoftplus or SiLU for each case? 

## Status
- [ ] Ready to go