### PR TITLE
Pydantic models for potentials can now accept an activation function and any associated parameters

### DIFF
--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Tuple
+from typing import TYPE_CHECKING, Dict, Tuple, Type
 from .models import BaseNetwork, CoreNetwork
 
 import torch
@@ -428,7 +428,7 @@ class ANIInteraction(nn.Module):
             input_dim = aev_dim
             for units in layers:
                 network_layers.append(nn.Linear(input_dim, units))
-                network_layers.append(activation_function_class(0.1))
+                network_layers.append(activation_function_class)
                 input_dim = units
             network_layers.append(nn.Linear(input_dim, 1))
             return nn.Sequential(*network_layers)
@@ -489,8 +489,8 @@ class ANI2xCore(CoreNetwork):
         The maximum angular distance for the angular basis functions.
     minimum_interaction_radius_for_angular_features : unit.Quantity
         The minimum angular distance for the angular basis functions.
-    activation_function : str
-        The name of the activation function to use.
+    activation_function_class : Type[torch.nn.Module]
+        The  activation function class to use.
     angular_dist_divisions : int
         The number of divisions for the angular distance.
     angle_sections : int
@@ -505,7 +505,7 @@ class ANI2xCore(CoreNetwork):
         number_of_radial_basis_functions: int,
         maximum_interaction_radius_for_angular_features: unit.Quantity,
         minimum_interaction_radius_for_angular_features: unit.Quantity,
-        activation_function: str,
+        activation_function_class: Type[torch.nn.Module],
         angular_dist_divisions: int,
         angle_sections: int,
     ) -> None:
@@ -514,7 +514,7 @@ class ANI2xCore(CoreNetwork):
         self.num_species = 7
 
         log.debug("Initializing the ANI2x architecture.")
-        super().__init__(activation_function)
+        super().__init__(activation_function_class)
 
         # Initialize representation block
         self.ani_representation_module = ANIRepresentation(
@@ -538,7 +538,7 @@ class ANI2xCore(CoreNetwork):
         # The length of full aev
         self.aev_length = self.radial_length + self.angular_length
 
-        # Initialize interaction blocks
+        # Intialize interaction blocks
         self.interaction_modules = ANIInteraction(
             aev_dim=self.aev_length,
             activation_function_class=self.activation_function_class,
@@ -640,8 +640,9 @@ class ANI2x(BaseNetwork):
         The number of divisions for the angular distance.
     angle_sections : int
         The number of angle sections to use.
-    activation_function : str
-        The name of the activation function to use.
+    activation_function : Dict
+        Dict that contains keys: activation_function_name [str], activation_function_arguments [Dict],
+        and activation_function_class [Type[torch.nn.Module]].
     postprocessing_parameter : Dict[str, Dict[str, bool]]
         Configuration for postprocessing parameters.
     dataset_statistic : Optional[Dict[str, float]], optional
@@ -657,7 +658,7 @@ class ANI2x(BaseNetwork):
         minimum_interaction_radius_for_angular_features: Union[unit.Quantity, str],
         angular_dist_divisions: int,
         angle_sections: int,
-        activation_function: str,
+        activation_function: Dict,
         postprocessing_parameter: Dict[str, Dict[str, bool]],
         dataset_statistic: Optional[Dict[str, float]] = None,
     ) -> None:
@@ -672,6 +673,8 @@ class ANI2x(BaseNetwork):
             maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
         )
 
+        activation_function_class = activation_function["activation_function_class"]
+
         self.core_module = ANI2xCore(
             maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
             minimum_interaction_radius=_convert_str_to_unit(minimum_interaction_radius),
@@ -682,7 +685,7 @@ class ANI2x(BaseNetwork):
             minimum_interaction_radius_for_angular_features=_convert_str_to_unit(
                 minimum_interaction_radius_for_angular_features
             ),
-            activation_function=activation_function,
+            activation_function_class=activation_function_class,
             angular_dist_divisions=angular_dist_divisions,
             angle_sections=angle_sections,
         )

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1080,21 +1080,18 @@ class CoreNetwork(Module, ABC):
     Operations performed outside the network (e.g., pairlist calculation and operations that reduce atomic properties to molecule properties) are not part of the network and are implemented in the BaseNetwork, which is a wrapper around the CoreNetwork.
     """
 
-    def __init__(self, activation_function: str):
+    def __init__(self, activation_function_class: Type[torch.nn.Module]):
         """
         Initialize the CoreNetwork.
 
         Parameters
         ----------
-        activation_function : str
-            The name of the activation function to use.
+        activation_function_class : torch.nn.Module
+            The activation function to use.
         """
 
         super().__init__()
-        # initialize the activation funtion
-        activation_function_class = ACTIVATION_FUNCTIONS.get(activation_function, None)
-        if activation_function_class is None:
-            raise ValueError(f"Unknown activation function: {activation_function}")
+
         self.activation_function_class = activation_function_class
 
     @abstractmethod

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -1,8 +1,21 @@
-from pydantic import BaseModel, field_validator, ConfigDict
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    field_validator,
+    ConfigDict,
+    model_validator,
+    computed_field,
+)
 from openff.units import unit
-from typing import Union, List
+from typing import Union, List, Optional, Type
 from modelforge.utils.units import _convert_str_to_unit
 from enum import Enum
+
+import torch
+
+
+# needed to typecast to torch.nn.Module
 
 """
 This module contains pydantic models for storing the parameters of 
@@ -18,7 +31,24 @@ class CaseInsensitiveEnum(str, Enum):
         return super()._missing_(value)
 
 
-class ActivationFunction(CaseInsensitiveEnum):
+# To avoid having to set config parameters for each class,
+# we will just create a parent class for all the parameters classes.
+class ParametersBase(BaseModel):
+    model_config = ConfigDict(
+        use_enum_values=True, arbitrary_types_allowed=True, validate_assignment=True
+    )
+
+
+# for the activation functions we have defined alpha and negative slope are the two parameters that are possible
+class ActivationFunctionParamsAlpha(BaseModel):
+    alpha: Optional[float] = None
+
+
+class ActivationFunctionParamsNegativeSlope(BaseModel):
+    negative_slope: Optional[float] = None
+
+
+class ActivationFunctionName(CaseInsensitiveEnum):
     ReLU = "ReLU"
     CeLU = "CeLU"
     Sigmoid = "Sigmoid"
@@ -30,12 +60,53 @@ class ActivationFunction(CaseInsensitiveEnum):
     ELU = "ELU"
 
 
-# To avoid having to set config parameters for each class,
-# we will just create a parent class for all the parameters classes.
-class ParametersBase(BaseModel):
-    model_config = ConfigDict(
-        use_enum_values=True, arbitrary_types_allowed=True, validate_assignment=True
-    )
+# this enum will tell us if we need to pass additional parameters to the activation function
+class ActivationFunctionParamsEnum(CaseInsensitiveEnum):
+    ReLU = "None"
+    CeLU = ActivationFunctionParamsAlpha
+    Sigmoid = "None"
+    Softmax = "None"
+    ShiftedSoftplus = "None"
+    SiLU = "None"
+    Tanh = "None"
+    LeakyReLU = ActivationFunctionParamsNegativeSlope
+    ELU = ActivationFunctionParamsAlpha
+
+
+class ActivationFunctionConfig(ParametersBase):
+
+    activation_function_name: ActivationFunctionName
+    activation_function_arguments: Optional[
+        Union[ActivationFunctionParamsAlpha, ActivationFunctionParamsNegativeSlope]
+    ] = None
+
+    @model_validator(mode="after")
+    def validate_activation_function_arguments(self) -> "ActivationFunctionLoader":
+        if ActivationFunctionParamsEnum[self.activation_function_name].value != "None":
+            if self.activation_function_arguments is None:
+                raise ValueError(
+                    f"Activation function {self.activation_function_name} requires additional arguments."
+                )
+        else:
+            if self.activation_function_arguments is not None:
+                raise ValueError(
+                    f"Activation function {self.activation_function_name} does not require additional arguments."
+                )
+        return self
+
+    def return_activation_function_class(self):
+        from modelforge.potential.utils import ACTIVATION_FUNCTIONS
+
+        if self.activation_function_arguments is not None:
+            return ACTIVATION_FUNCTIONS[self.activation_function_name](
+                **self.activation_function_arguments.model_dump(exclude_unset=True)
+            )
+        return ACTIVATION_FUNCTIONS[self.activation_function_name]()
+
+    @computed_field
+    @property
+    def activation_function_class(self) -> Type[torch.nn.Module]:
+        return self.return_activation_function_class()
 
 
 # these will all be set by default to false
@@ -60,7 +131,7 @@ class ANI2xParameters(ParametersBase):
         maximum_interaction_radius_for_angular_features: Union[str, unit.Quantity]
         minimum_interaction_radius_for_angular_features: Union[str, unit.Quantity]
         angular_dist_divisions: int
-        activation_function: ActivationFunction
+        activation_function: ActivationFunctionConfig
 
         converted_units = field_validator(
             "maximum_interaction_radius",
@@ -92,7 +163,7 @@ class SchNetParameters(ParametersBase):
         number_of_interaction_modules: int
         number_of_filters: int
         shared_interactions: bool
-        activation_function: ActivationFunction
+        activation_function: ActivationFunctionConfig
         featurization: Featurization
 
         converted_units = field_validator("maximum_interaction_radius")(
@@ -123,7 +194,7 @@ class PaiNNParameters(ParametersBase):
         shared_interactions: bool
         shared_filters: bool
         featurization: Featurization
-        activation_function: ActivationFunction
+        activation_function: ActivationFunctionConfig
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit
@@ -152,7 +223,7 @@ class PhysNetParameters(ParametersBase):
         number_of_interaction_residual: int
         number_of_modules: int
         featurization: Featurization
-        activation_function: ActivationFunction
+        activation_function: ActivationFunctionConfig
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit
@@ -181,7 +252,7 @@ class SAKEParameters(ParametersBase):
         number_of_interaction_modules: int
         number_of_spatial_attention_heads: int
         featurization: Featurization
-        activation_function: ActivationFunction
+        activation_function: ActivationFunctionConfig
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 import torch.nn as nn
 from loguru import logger as log
-from typing import Dict, Tuple, Union, List
+from typing import Dict, Tuple, Union, List, Type
 from openff.units import unit
 from .models import NNPInput, BaseNetwork, CoreNetwork, PairListOutputs
 from .utils import (
@@ -79,7 +79,7 @@ class SAKECore(CoreNetwork):
         number_of_spatial_attention_heads: int,
         number_of_radial_basis_functions: int,
         maximum_interaction_radius: unit.Quantity,
-        activation_name: str,
+        activation_function_class: Type[torch.nn.Module],
         epsilon: float = 1e-8,
     ):
         """
@@ -97,11 +97,13 @@ class SAKECore(CoreNetwork):
             Number of radial basis functions.
         maximum_interaction_radius : unit.Quantity
             Cutoff distance.
+        activation_function_class : Type[torch.nn.Module]
+            Activation function class to use.
         epsilon : float, optional
             Small value to avoid division by zero, by default 1e-8.
         """
         log.debug("Initializing the SAKE architecture.")
-        super().__init__(activation_name)
+        super().__init__(activation_function_class)
         self.nr_interaction_blocks = number_of_interaction_modules
         number_of_per_atom_features = int(
             featurization_config["number_of_per_atom_features"]
@@ -114,7 +116,7 @@ class SAKECore(CoreNetwork):
         self.featurize_input = FeaturizeInput(featurization_config)
         self.energy_layer = nn.Sequential(
             Dense(number_of_per_atom_features, number_of_per_atom_features),
-            self.activation_function_class(),
+            self.activation_function_class,
             Dense(number_of_per_atom_features, 1),
         )
         # initialize the interaction networks
@@ -129,7 +131,7 @@ class SAKECore(CoreNetwork):
                 nr_atom_basis_velocity=number_of_per_atom_features,
                 nr_coefficients=(self.nr_heads * number_of_per_atom_features),
                 nr_heads=self.nr_heads,
-                activation=self.activation_function_class(),
+                activation=self.activation_function_class,
                 maximum_interaction_radius=maximum_interaction_radius,
                 number_of_radial_basis_functions=number_of_radial_basis_functions,
                 epsilon=epsilon,
@@ -280,12 +282,12 @@ class SAKEInteraction(nn.Module):
                 + self.nr_heads * self.nr_edge_basis
                 + self.nr_atom_basis_spatial,
                 self.nr_atom_basis_hidden,
-                activation_function=activation,
+                activation_function_class=activation,
             ),
             Dense(
                 self.nr_atom_basis_hidden,
                 self.nr_atom_basis,
-                activation_function=activation,
+                activation_function_class=activation,
             ),
         )
 
@@ -293,12 +295,12 @@ class SAKEInteraction(nn.Module):
             Dense(
                 self.nr_coefficients,
                 self.nr_atom_basis_spatial_hidden,
-                activation_function=activation,
+                activation_function_class=activation,
             ),
             Dense(
                 self.nr_atom_basis_spatial_hidden,
                 self.nr_atom_basis_spatial,
-                activation_function=activation,
+                activation_function_class=activation,
             ),
         )
 
@@ -310,25 +312,27 @@ class SAKEInteraction(nn.Module):
             Dense(
                 self.nr_atom_basis * 2 + number_of_radial_basis_functions + 1,
                 self.nr_edge_basis_hidden,
-                activation_function=activation,
+                activation_function_class=activation,
             ),
             nn.Linear(nr_edge_basis_hidden, nr_edge_basis),
         )
 
         self.semantic_attention_mlp = Dense(
-            self.nr_edge_basis, self.nr_heads, activation_function=nn.CELU(alpha=2.0)
+            self.nr_edge_basis,
+            self.nr_heads,
+            activation_function_class=nn.CELU(alpha=2.0),
         )
 
         self.velocity_mlp = nn.Sequential(
             Dense(
                 self.nr_atom_basis,
                 self.nr_atom_basis_velocity,
-                activation_function=activation,
+                activation_function_class=activation,
             ),
             Dense(
                 self.nr_atom_basis_velocity,
                 1,
-                activation_function=lambda x: 2.0 * F.sigmoid(x),
+                activation_function_class=lambda x: 2.0 * F.sigmoid(x),
                 bias=False,
             ),
         )
@@ -337,7 +341,7 @@ class SAKEInteraction(nn.Module):
             self.nr_heads * self.nr_edge_basis,
             self.nr_coefficients,
             bias=False,
-            activation_function=nn.Tanh(),
+            activation_function_class=nn.Tanh(),
         )
 
         self.v_mixing_mlp = Dense(self.nr_coefficients, 1, bias=False)
@@ -599,7 +603,7 @@ class SAKE(BaseNetwork):
         number_of_spatial_attention_heads: int,
         number_of_radial_basis_functions: int,
         maximum_interaction_radius: unit.Quantity,
-        activation_function: str,
+        activation_function: Dict,
         postprocessing_parameter: Dict[str, Dict[str, bool]],
         dataset_statistic: Optional[Dict[str, float]] = None,
         epsilon: float = 1e-8,
@@ -612,6 +616,7 @@ class SAKE(BaseNetwork):
             postprocessing_parameter=postprocessing_parameter,
             maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
         )
+        activation_function_class = activation_function["activation_function_class"]
 
         self.core_module = SAKECore(
             featurization_config=featurization,
@@ -619,7 +624,7 @@ class SAKE(BaseNetwork):
             number_of_spatial_attention_heads=number_of_spatial_attention_heads,
             number_of_radial_basis_functions=number_of_radial_basis_functions,
             maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
-            activation_name=activation_function,
+            activation_function_class=activation_function_class,
             epsilon=epsilon,
         )
 

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -500,7 +500,7 @@ class Dense(nn.Linear):
         in_features: int,
         out_features: int,
         bias: bool = True,
-        activation_function: Optional[nn.Module] = None,
+        activation_function_class: Optional[nn.Module] = None,
         weight_init: Callable = xavier_uniform_,
         bias_init: Callable = zeros_,
     ):
@@ -515,8 +515,8 @@ class Dense(nn.Linear):
             Number of output features.
         bias : bool, optional
             If set to False, the layer will not learn an additive bias. Default is True.
-        activation_function : nn.Module , optional
-            Activation function to be applied. Default is nn.Identity(), which applies the identity function and makes this a linear ransformation.
+        activation_function_class : nn.Module , optional
+            Activation function class to be applied. Default is nn.Identity(), which applies the identity function and makes this a linear ransformation.
         weight_init : Callable, optional
             Callable to initialize the weights. Default is xavier_uniform_.
         bias_init : Callable, optional
@@ -530,8 +530,10 @@ class Dense(nn.Linear):
             in_features, out_features, bias
         )  # NOTE: the `reseet_paramters` method is called in the super class
 
-        self.activation_function = (
-            activation_function if activation_function is not None else nn.Identity()
+        self.activation_function_class = (
+            activation_function_class
+            if activation_function_class is not None
+            else nn.Identity()
         )
 
     def reset_parameters(self):
@@ -558,7 +560,7 @@ class Dense(nn.Linear):
 
         """
         y = F.linear(input, self.weight, self.bias)
-        return self.activation_function(y)
+        return self.activation_function_class(y)
 
 
 from openff.units import unit
@@ -1320,7 +1322,6 @@ def scatter_softmax(
 
 
 from enum import Enum
-
 
 
 ACTIVATION_FUNCTIONS = {

--- a/modelforge/tests/data/config.toml
+++ b/modelforge/tests/data/config.toml
@@ -7,7 +7,9 @@ maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 3
 number_of_filters = 32
 shared_interactions = false
-activation_function = "ShiftedSoftplus"
+
+[potential.core_parameter.activation_function]
+activation_function_name = "ShiftedSoftplus"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']

--- a/modelforge/tests/data/potential_defaults/ani2x.toml
+++ b/modelforge/tests/data/potential_defaults/ani2x.toml
@@ -9,7 +9,12 @@ number_of_radial_basis_functions = 16
 maximum_interaction_radius_for_angular_features = "3.5 angstrom"
 minimum_interaction_radius_for_angular_features = "0.8 angstrom"
 angular_dist_divisions = 8
-activation_function = "CeLU"   # for the original ANI behavior please stick with CeLu since the alpha parameter is currently hard coded and might lead to different behavior when another activation function is used.
+
+[potential.core_parameter.activation_function]
+activation_function_name = "CeLU"   # for the original ANI behavior please stick with CeLu since the alpha parameter is currently hard coded and might lead to different behavior when another activation function is used.
+
+[potential.core_parameter.activation_function.activation_function_arguments]
+alpha = 0.1
 
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]

--- a/modelforge/tests/data/potential_defaults/painn.toml
+++ b/modelforge/tests/data/potential_defaults/painn.toml
@@ -7,7 +7,9 @@ maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 3
 shared_interactions = false
 shared_filters = false
-activation_function = "SiLU"
+
+[potential.core_parameter.activation_function]
+activation_function_name = "SiLU"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']

--- a/modelforge/tests/data/potential_defaults/physnet.toml
+++ b/modelforge/tests/data/potential_defaults/physnet.toml
@@ -7,7 +7,9 @@ number_of_radial_basis_functions = 16
 maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_residual = 3
 number_of_modules = 5
-activation_function = "ShiftedSoftplus"
+
+[potential.core_parameter.activation_function]
+activation_function_name = "ShiftedSoftplus"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']

--- a/modelforge/tests/data/potential_defaults/sake.toml
+++ b/modelforge/tests/data/potential_defaults/sake.toml
@@ -7,7 +7,9 @@ number_of_radial_basis_functions = 50
 maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 6
 number_of_spatial_attention_heads = 4
-activation_function = "SiLU"
+
+[potential.core_parameter.activation_function]
+activation_function_name = "SiLU"
 
 [potential.core_parameter.featurization]
 number_of_per_atom_features = 64

--- a/modelforge/tests/data/potential_defaults/schnet.toml
+++ b/modelforge/tests/data/potential_defaults/schnet.toml
@@ -7,7 +7,9 @@ maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 3
 number_of_filters = 32
 shared_interactions = false
-activation_function = "ShiftedSoftplus"
+
+[potential.core_parameter.activation_function]
+activation_function_name = "ShiftedSoftplus"
 
 [potential.core_parameter.featurization]
 properties_to_featurize = ['atomic_number']


### PR DESCRIPTION
Pedantic models for the potentials will now accept the activation function and any associated parameters. These will automatically be checked and used to return a callable class with said parameters passed (if applicable). The potential init  function will get the function stored in a dictionary (because that is the form after dumping the pydantic model); all other internal function in the code expect a callable class instance.  I changed the name in the potentials from 
`activation_function` to  `activation_function_class` to make it a bit clearer that these are not names (there was some inconsistency in the codes). 

The fact this had to get passed as a dict I think highlights the importance of switching to  accepting pydantic models directly, rather than dumping the output.  It will certainly simplify the entry points to a lot of these functions, but that is not an insignificant undertaking and can be done after we get a stable release out. 

## Status
- [ ] Ready to go