### PR TITLE
quick updated to tensornet pydantic model

### DIFF
--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -197,12 +197,9 @@ class TensorNetParameters(ParametersBase):
         equivariance_invariance_group: str
         activation_function_parameter: ActivationFunctionConfig
 
-        converted_units = field_validator("maximum_interaction_radius")(
-            _convert_str_to_unit
-        )
-        converted_units = field_validator("minimum_interaction_radius")(
-            _convert_str_to_unit
-        )
+        converted_units = field_validator(
+            "maximum_interaction_radius", "minimum_interaction_radius"
+        )(_convert_str_to_unit)
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()


### PR DESCRIPTION
The field validator for validating and converting str to units was defined twice in the tensornet model.  This was modified such that the two fields to validated are passed to the same validator definition (rather than defining it a second time with two different names). 

## Status
- [x] Ready to go