### PR TITLE
Ref wandb tags

### DIFF
--- a/modelforge/tests/data/config.toml
+++ b/modelforge/tests/data/config.toml
@@ -76,11 +76,11 @@ seed = 42
 
 [runtime]
 save_dir = "lightning_logs"
-experiment_name = "test_exp"
+experiment_name = "{model_name}_{dataset_name}"
 local_cache_dir = "./cache"
 accelerator = "cpu"
 number_of_nodes = 1
 devices = 1                        #[0,1,2,3]
 checkpoint_path = "None"
 simulation_environment = "PyTorch"
-log_every_n_steps = 50
+log_every_n_steps = 1

--- a/modelforge/tests/data/runtime_defaults/runtime.toml
+++ b/modelforge/tests/data/runtime_defaults/runtime.toml
@@ -1,6 +1,6 @@
 [runtime]
 save_dir = "lightning_logs"
-experiment_name = "test_exp2"
+experiment_name = "{model_name}_{dataset_name}"
 local_cache_dir = "./cache"
 accelerator = "cpu"
 number_of_nodes = 1

--- a/modelforge/tests/data/training_defaults/default.toml
+++ b/modelforge/tests/data/training_defaults/default.toml
@@ -15,11 +15,11 @@ save_dir = "logs"
 
 [training.experiment_logger.wandb_configuration]
 save_dir = "logs"
-project = "training_test"
-group = "modelforge_nnps"
+project = "training_potentials"
+group = "exp00"
 log_model = true
-job_type = "training"
-tags = ["modelforge", "v_0.1.0"]
+job_type = "testing"
+tags = ["v_0.1.0"]
 notes = "testing training"
 
 [training.lr_scheduler]

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1086,7 +1086,8 @@ class ModelTrainer:
         # add potential name
         tags.append(self.potential_config.potential_name)
         # add information about what is included in the loss
-        tags.append(f"loss-{self.training_config.loss_parameter.loss_property}")
+        str_loss_property = "-".join(self.training_config.loss_parameter.loss_property)
+        tags.append(f"loss-{str_loss_property}")
 
         return tags
 

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1085,6 +1085,9 @@ class ModelTrainer:
         tags.append(self.dataset_config.dataset_name)
         # add potential name
         tags.append(self.potential_config.potential_name)
+        # add information about what is included in the loss
+        tags.append(f"loss-{self.training_config.loss.loss_property}")
+        
         return tags
 
     def _replace_placeholder_in_experimental_name(self, experiment_name: str) -> str:

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1062,6 +1062,34 @@ class ModelTrainer:
         self.callbacks = self.setup_callbacks()
         self.trainer = self.setup_trainer()
 
+    def _add_tags(self, tags: List[str]) -> List[str]:
+        """
+        Add tags to the wandb tags.
+
+        Parameters
+        ----------
+        tags : List[str]
+            List of tags to add to the experiment.
+
+        Returns
+        -------
+        List[str]
+            List of tags for the experiment.
+        """
+        
+        # add version
+        import modelforge
+        version = modelforge.__version__
+        tags += version
+        
+        # add dataset
+        tags += self.dataset_config.dataset_name
+        
+        # add potential name
+        tags += self.potential_config.potential_name
+        
+        return tags
+
     def setup_logger(self) -> L.pytorch.loggers.Logger:
         """
         Set up the experiment logger based on the configuration.
@@ -1096,7 +1124,9 @@ class ModelTrainer:
                 project=self.training_config.experiment_logger.wandb_configuration.project,
                 group=self.training_config.experiment_logger.wandb_configuration.group,
                 job_type=self.training_config.experiment_logger.wandb_configuration.job_type,
-                tags=self.training_config.experiment_logger.wandb_configuration.tags,
+                tags=self._add_tags(
+                    self.training_config.experiment_logger.wandb_configuration.tags
+                ),
                 notes=self.training_config.experiment_logger.wandb_configuration.notes,
                 name=self.runtime_config.experiment_name,
             )

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1086,8 +1086,8 @@ class ModelTrainer:
         # add potential name
         tags.append(self.potential_config.potential_name)
         # add information about what is included in the loss
-        tags.append(f"loss-{self.training_config.loss.loss_property}")
-        
+        tags.append(f"loss-{self.training_config.loss_parameter.loss_property}")
+
         return tags
 
     def _replace_placeholder_in_experimental_name(self, experiment_name: str) -> str:

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1080,16 +1080,11 @@ class ModelTrainer:
         # add version
         import modelforge
 
-        print(tags)
-        version = modelforge.__version__
-        tags += version
-        print(tags)
+        tags.append(str(modelforge.__version__))
         # add dataset
-        tags += self.dataset_config.dataset_name
-        print(tags)
+        tags.append(self.dataset_config.dataset_name)
         # add potential name
-        tags += self.potential_config.potential_name
-        print(tags)
+        tags.append(self.potential_config.potential_name)
         return tags
 
     def _replace_placeholder_in_experimental_name(self, experiment_name: str) -> str:

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1080,15 +1080,16 @@ class ModelTrainer:
         # add version
         import modelforge
 
+        print(tags)
         version = modelforge.__version__
         tags += version
-
+        print(tags)
         # add dataset
         tags += self.dataset_config.dataset_name
-
+        print(tags)
         # add potential name
         tags += self.potential_config.potential_name
-
+        print(tags)
         return tags
 
     def _replace_placeholder_in_experimental_name(self, experiment_name: str) -> str:
@@ -1129,7 +1130,7 @@ class ModelTrainer:
             logger = TensorBoardLogger(
                 save_dir=str(
                     self.training_config.experiment_logger.tensorboard_configuration.save_dir
-                ), # FIXME: same variable for all logger, maybe we can use a varable not bound to a logger for this?
+                ),  # FIXME: same variable for all logger, maybe we can use a varable not bound to a logger for this?
                 name=self._replace_placeholder_in_experimental_name(
                     self.runtime_config.experiment_name
                 ),


### PR DESCRIPTION
## Description
This adds additional tags to the wandb logger, including modelforge version and dataset/potential name as well as the properties present in the loss function.

## Status
- [ ] Ready to go