### PR TITLE
Long range electrostatics

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -208,12 +208,11 @@ class NNPInput:
         """Export the dataclass fields and values as a named tuple.
         Convert pytorch tensors to jax arrays."""
 
-        from dataclasses import dataclass, fields
+        from dataclasses import fields
         import collections
         from modelforge.utils.io import import_
 
         convert_to_jax = import_("pytorch2jax").pytorch2jax.convert_to_jax
-        # from pytorch2jax.pytorch2jax import convert_to_jax
 
         NNPInputTuple = collections.namedtuple(
             "NNPInputTuple", [field.name for field in fields(self)]

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -660,7 +660,7 @@ class ANI2xCore(CoreNetwork):
         }
         # extract predictions per property
         for dim, property in enumerate(self.predicted_properties):
-            results[property["name"]] = predictions[:, dim]
+            results[property["name"]] = predictions[:, dim].contiguous()
 
         return results
 

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -782,7 +782,7 @@ class PostProcessing(torch.nn.Module):
     _SUPPORTED_OPERATIONS = [
         "normalize",
         "from_atom_to_molecule_reduction",
-        "conserve_integer_charge",
+        "long_range_electrostatics" "conserve_integer_charge",
     ]
 
     def __init__(
@@ -868,6 +868,7 @@ class PostProcessing(torch.nn.Module):
             ScaleValues,
             CalculateAtomicSelfEnergy,
             ChargeConservation,
+            LongRangeElectrostaticEnergy,
         )
 
         for property, operations in postprocessing_parameter.items():
@@ -887,9 +888,32 @@ class PostProcessing(torch.nn.Module):
             if property == "per_atom_charge":
                 if operations.get("conserve", False):
                     postprocessing_sequence.append(
-                        ChargeConservation(operations["strategy"])
+                        ChargeConservation(operations["conserve_strategy"])
                     )
                     prostprocessing_sequence_names.append("conserve_charge")
+
+                if operations.get("coulomb_potential", False):
+                    coulomb_potential = operations["coulomb_potential"]
+                    postprocessing_sequence.append(
+                        LongRangeElectrostaticEnergy(
+                            coulomb_potential["electrostatic_strategy"],
+                            coulomb_potential["maximum_interaction_radius"],
+                        )
+                    )
+                    prostprocessing_sequence_names.append("coulomb_potential")
+
+                    if coulomb_potential.get("from_atom_to_molecule_reduction, False"):
+                        postprocessing_sequence.append(
+                            FromAtomToMoleculeReduction(
+                                per_atom_property_name="per_atom_energy",
+                                index_name="atomic_subsystem_indices",
+                                output_name="per_molecule_energy",
+                                keep_per_atom_property=operations.get(
+                                    "keep_per_atom_property", False
+                                ),
+                            )
+                        )
+
             elif property == "per_atom_energy":
                 if operations.get("normalize", False):
                     (
@@ -990,6 +1014,10 @@ class PostProcessing(torch.nn.Module):
             if property in self._registered_properties:
                 self.registered_chained_operations[property](data)
 
+        # delte pairwise property object before returning
+        if 'pairwise_properties' in data:
+            del data['pairwise_properties']
+            
         return data
 
 
@@ -1126,7 +1154,10 @@ class BaseNetwork(Module):
         return self.compute_interacting_pairs.prepare_inputs(data)
 
     def _add_addiontal_properties(
-        self, data, output: Dict[str, torch.Tensor]
+        self,
+        data,
+        output: Dict[str, torch.Tensor],
+        pairwise_properties: PairListOutputs,
     ) -> Dict[str, torch.Tensor]:
         """
         Add additional properties to the output dictionary.
@@ -1144,6 +1175,7 @@ class BaseNetwork(Module):
         """
 
         output["per_molecule_charge"] = data.total_charge
+        output["pairwise_properties"] = pairwise_properties
         return output
 
     def compute(self, data, core_input):
@@ -1190,7 +1222,11 @@ class BaseNetwork(Module):
             input_data, pairwise_properties
         )  # FIXME: putput and processed_output are currently a dictionary, we really want to change this to a dataclass
         # perform postprocessing operations
-        output = self._add_addiontal_properties(input_data, output)
+        output = self._add_addiontal_properties(
+            input_data,
+            output,
+            pairwise_properties,
+        )
         processed_output = self.postprocessing(output)
         return processed_output
 

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -885,7 +885,7 @@ class PostProcessing(torch.nn.Module):
 
             # for each property parse the requested operations
             if property == "per_atom_charge":
-                if operations.get("conserve_integer_charge", False):
+                if operations.get("conserve", False):
                     postprocessing_sequence.append(
                         ChargeConservation(operations["strategy"])
                     )
@@ -1125,6 +1125,27 @@ class BaseNetwork(Module):
         self.compute_interacting_pairs._input_checks(data)
         return self.compute_interacting_pairs.prepare_inputs(data)
 
+    def _add_addiontal_properties(
+        self, data, output: Dict[str, torch.Tensor]
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Add additional properties to the output dictionary.
+
+        Parameters
+        ----------
+        data : Union[NNPInput, NamedTuple]
+            The input data.
+        output: Dict[str, torch.Tensor]
+            The output dictionary to add properties to.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+        """
+
+        output["per_molecule_charge"] = data.total_charge
+        return output
+
     def compute(self, data, core_input):
         """
         Compute the core model's output.
@@ -1143,7 +1164,7 @@ class BaseNetwork(Module):
         """
         return self.core_module(data, core_input)
 
-    def forward(self, input_data: NNPInput):
+    def forward(self, input_data: NNPInput) -> Dict[str, torch.Tensor]:
         """
         Executes the forward pass of the model.
 
@@ -1165,8 +1186,11 @@ class BaseNetwork(Module):
         # compute all interacting pairs with distances
         pairwise_properties = self.prepare_pairwise_properties(input_data)
         # prepare the input for the forward pass
-        output = self.compute(input_data, pairwise_properties)
+        output = self.compute(
+            input_data, pairwise_properties
+        )  # FIXME: putput and processed_output are currently a dictionary, we really want to change this to a dataclass
         # perform postprocessing operations
+        output = self._add_addiontal_properties(input_data, output)
         processed_output = self.postprocessing(output)
         return processed_output
 

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1144,7 +1144,6 @@ class BaseNetwork(Module):
         """
 
         output["per_molecule_charge"] = data.total_charge
-        output["pair_list"] = data.pair_list
         return output
 
     def compute(self, data, core_input):

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -1144,6 +1144,7 @@ class BaseNetwork(Module):
         """
 
         output["per_molecule_charge"] = data.total_charge
+        output["pair_list"] = data.pair_list
         return output
 
     def compute(self, data, core_input):

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -146,6 +146,7 @@ class ANI2xParameters(ParametersBase):
         minimum_interaction_radius_for_angular_features: Union[str, unit.Quantity]
         angular_dist_divisions: int
         activation_function_parameter: ActivationFunctionConfig
+        predicted_properties: List[PredictedPropertiesParameter]
 
         converted_units = field_validator(
             "maximum_interaction_radius",
@@ -275,7 +276,7 @@ class PhysNetParameters(ParametersBase):
         featurization: Featurization
         activation_function_parameter: ActivationFunctionConfig
         predicted_properties: List[PredictedPropertiesParameter]
-        
+
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit
         )

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -136,10 +136,20 @@ class PerAtomEnergy(ParametersBase):
     keep_per_atom_property: bool = False
 
 
+class CoulomPotential(ParametersBase):
+    electrostatic_strategy: str = "coulomb"
+    maximum_interaction_radius: Union[str, unit.Quantity]
+    
+    converted_units = field_validator(
+        "maximum_interaction_radius",
+    )(_convert_str_to_unit)
+
+
 class PerAtomCharge(ParametersBase):
     conserve: bool = False
-    strategy: str = "default"
+    conserve_strategy: str = "default"
     keep_per_atom_property: bool = False
+    coulomb_potential: Optional[CoulomPotential] = None
 
 
 class ANI2xParameters(ParametersBase):

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -136,6 +136,12 @@ class PerAtomEnergy(ParametersBase):
     keep_per_atom_property: bool = False
 
 
+class PerAtomCharge(ParametersBase):
+    conserve: bool = False
+    strategy: str = "default"
+    keep_per_atom_property: bool = False
+
+
 class ANI2xParameters(ParametersBase):
     class CoreParameter(ParametersBase):
         angle_sections: int
@@ -157,6 +163,7 @@ class ANI2xParameters(ParametersBase):
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
+        per_atom_charge: PerAtomCharge = PerAtomCharge()
         general_postprocessing_operation: GeneralPostProcessingOperation = (
             GeneralPostProcessingOperation()
         )
@@ -189,6 +196,7 @@ class SchNetParameters(ParametersBase):
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
+        per_atom_charge: PerAtomCharge = PerAtomCharge()
         general_postprocessing_operation: GeneralPostProcessingOperation = (
             GeneralPostProcessingOperation()
         )
@@ -201,11 +209,6 @@ class SchNetParameters(ParametersBase):
 
 class TensorNetParameters(ParametersBase):
     class CoreParameter(ParametersBase):
-        # class Featurization(ParametersBase):
-        #     properties_to_featurize: List[str]
-        #     max_Z: int
-        #     number_of_per_atom_features: int
-
         number_of_per_atom_features: int
         number_of_interaction_layers: int
         number_of_radial_basis_functions: int
@@ -222,6 +225,7 @@ class TensorNetParameters(ParametersBase):
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
+        per_atom_charge: PerAtomCharge = PerAtomCharge()
         general_postprocessing_operation: GeneralPostProcessingOperation = (
             GeneralPostProcessingOperation()
         )
@@ -254,6 +258,7 @@ class PaiNNParameters(ParametersBase):
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
+        per_atom_charge: PerAtomCharge = PerAtomCharge()
         general_postprocessing_operation: GeneralPostProcessingOperation = (
             GeneralPostProcessingOperation()
         )
@@ -285,6 +290,7 @@ class PhysNetParameters(ParametersBase):
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
+        per_atom_charge: PerAtomCharge = PerAtomCharge()
         general_postprocessing_operation: GeneralPostProcessingOperation = (
             GeneralPostProcessingOperation()
         )
@@ -316,6 +322,7 @@ class SAKEParameters(ParametersBase):
 
     class PostProcessingParameter(ParametersBase):
         per_atom_energy: PerAtomEnergy = PerAtomEnergy()
+        per_atom_charge: PerAtomCharge = PerAtomCharge()
         general_postprocessing_operation: GeneralPostProcessingOperation = (
             GeneralPostProcessingOperation()
         )

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -180,7 +180,7 @@ class SchNetParameters(ParametersBase):
         shared_interactions: bool
         activation_function_parameter: ActivationFunctionConfig
         featurization: Featurization
-        predicted_properties: List[PredictedPropertiesParameter]  # Add the outputs here
+        predicted_properties: List[PredictedPropertiesParameter]
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit
@@ -274,7 +274,8 @@ class PhysNetParameters(ParametersBase):
         number_of_modules: int
         featurization: Featurization
         activation_function_parameter: ActivationFunctionConfig
-
+        predicted_properties: List[PredictedPropertiesParameter]
+        
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit
         )

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -214,6 +214,7 @@ class TensorNetParameters(ParametersBase):
         highest_atomic_number: int
         equivariance_invariance_group: str
         activation_function_parameter: ActivationFunctionConfig
+        predicted_properties: List[PredictedPropertiesParameter]
 
         converted_units = field_validator(
             "maximum_interaction_radius", "minimum_interaction_radius"
@@ -245,6 +246,7 @@ class PaiNNParameters(ParametersBase):
         shared_filters: bool
         featurization: Featurization
         activation_function_parameter: ActivationFunctionConfig
+        predicted_properties: List[PredictedPropertiesParameter]
 
         converted_units = field_validator(
             "maximum_interaction_radius",
@@ -306,6 +308,7 @@ class SAKEParameters(ParametersBase):
         number_of_spatial_attention_heads: int
         featurization: Featurization
         activation_function_parameter: ActivationFunctionConfig
+        predicted_properties: List[PredictedPropertiesParameter]
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -64,6 +64,16 @@ class ActivationFunctionName(CaseInsensitiveEnum):
     ELU = "ELU"
 
 
+class OutputTypeEnum(CaseInsensitiveEnum):
+    scalar = "scalar"
+    vector = "vector"
+
+
+class PredictedPropertiesParameter(ParametersBase):
+    name: str
+    type: OutputTypeEnum
+
+
 # this enum will tell us if we need to pass additional parameters to the activation function
 class ActivationFunctionParamsEnum(CaseInsensitiveEnum):
     ReLU = "None"
@@ -170,6 +180,7 @@ class SchNetParameters(ParametersBase):
         shared_interactions: bool
         activation_function_parameter: ActivationFunctionConfig
         featurization: Featurization
+        predicted_properties: List[PredictedPropertiesParameter]  # Add the outputs here
 
         converted_units = field_validator("maximum_interaction_radius")(
             _convert_str_to_unit

--- a/modelforge/potential/processing.py
+++ b/modelforge/potential/processing.py
@@ -349,7 +349,9 @@ class ChargeConservation(torch.nn.Module):
 
         # for each atom i, calculate the sum of partial charges for all other
         predicted_per_molecule_charge = torch.zeros(
-            total_charges.shape, dtype=torch.float32, device=total_charges.device
+            total_charges.shape,
+            dtype=per_atom_charge.dtype,
+            device=total_charges.device,
         ).scatter_add_(0, mol_indices.long(), per_atom_charge)
 
         # Calculate the correction factor for each molecule

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -73,6 +73,7 @@ class SchNetCore(CoreNetwork):
         shared_interactions: bool,
         activation_function: Type[torch.nn.Module],
         maximum_interaction_radius: unit.Quantity,
+        predicted_properties: List[Dict[str, str]],
     ) -> None:
 
         log.debug("Initializing the SchNet architecture.")
@@ -132,6 +133,26 @@ class SchNetCore(CoreNetwork):
                 1,
             ),
         )
+        # Initialize output layers based on configuration
+        self.output_layers = nn.ModuleDict()
+        for property in predicted_properties:
+            output_name = property["name"]
+            output_type = property["type"]
+            output_dimension = (
+                1 if output_type == "scalar" else 3
+            )  # vector means 3D output
+
+            self.output_layers[output_name] = nn.Sequential(
+                DenseWithCustomDist(
+                    number_of_per_atom_features,
+                    number_of_per_atom_features,
+                    activation_function=self.activation_function,
+                ),
+                DenseWithCustomDist(
+                    number_of_per_atom_features,
+                    output_dimension,
+                ),
+            )
 
     def _model_specific_input_preparation(
         self, data: "NNPInput", pairlist_output: PairListOutputs
@@ -197,13 +218,16 @@ class SchNetCore(CoreNetwork):
                 atomic_embedding + v
             )  # Update per atom features given the environment
 
-        E_i = self.energy_layer(atomic_embedding).squeeze(1)
-
-        return {
-            "per_atom_energy": E_i,
+        results = {
             "per_atom_scalar_representation": atomic_embedding,
             "atomic_subsystem_indices": data.atomic_subsystem_indices,
         }
+
+        # Compute all specified outputs
+        for output_name, output_layer in self.output_layers.items():
+            results[output_name] = output_layer(atomic_embedding).squeeze(-1)
+
+        return results
 
 
 class SchNETInteractionModule(nn.Module):
@@ -442,6 +466,7 @@ class SchNet(BaseNetwork):
         activation_function_parameter: Dict,
         shared_interactions: bool,
         postprocessing_parameter: Dict[str, Dict[str, bool]],
+        predicted_properties: List[Dict[str, str]],
         dataset_statistic: Optional[Dict[str, float]] = None,
         potential_seed: Optional[int] = None,
     ) -> None:
@@ -465,6 +490,7 @@ class SchNet(BaseNetwork):
             shared_interactions=shared_interactions,
             activation_function=activation_function,
             maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
+            predicted_properties=predicted_properties,
         )
 
     def _config_prior(self):

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -121,18 +121,6 @@ class SchNetCore(CoreNetwork):
                 ]
             )
 
-        # output layer to obtain per-atom energies
-        self.energy_layer = nn.Sequential(
-            DenseWithCustomDist(
-                number_of_per_atom_features,
-                number_of_per_atom_features,
-                activation_function=self.activation_function,
-            ),
-            DenseWithCustomDist(
-                number_of_per_atom_features,
-                1,
-            ),
-        )
         # Initialize output layers based on configuration
         self.output_layers = nn.ModuleDict()
         for property in predicted_properties:

--- a/modelforge/tests/data/potential_defaults/ani2x.toml
+++ b/modelforge/tests/data/potential_defaults/ani2x.toml
@@ -16,7 +16,7 @@ predicted_properties = [
 ]
 
 [potential.core_parameter.activation_function_parameter]
-activation_function_name = "CeLU"   # for the original ANI behavior please stick with CeLu since the alpha parameter is currently hard coded and might lead to different behavior when another activation function is used.
+activation_function_name = "CeLU" # for the original ANI behavior please stick with CeLu since the alpha parameter is currently hard coded and might lead to different behavior when another activation function is used.
 
 [potential.core_parameter.activation_function_parameter.activation_function_arguments]
 alpha = 0.1
@@ -25,4 +25,10 @@ alpha = 0.1
 [potential.postprocessing_parameter.per_atom_energy]
 normalize = true
 from_atom_to_molecule_reduction = true
+keep_per_atom_property = true
+
+[potential.postprocessing_parameter.per_atom_charge]
+conserve = true
+strategy = "physnet"
+from_atom_to_molecule_reduction = false
 keep_per_atom_property = true

--- a/modelforge/tests/data/potential_defaults/ani2x.toml
+++ b/modelforge/tests/data/potential_defaults/ani2x.toml
@@ -9,6 +9,11 @@ number_of_radial_basis_functions = 16
 maximum_interaction_radius_for_angular_features = "3.5 angstrom"
 minimum_interaction_radius_for_angular_features = "0.8 angstrom"
 angular_dist_divisions = 8
+predicted_properties = [
+    { name = "per_atom_energy", type = "scalar" },
+    { name = "per_atom_charge", type = "scalar" },
+    # we could also define per_atom_force to be consistent?
+]
 
 [potential.core_parameter.activation_function_parameter]
 activation_function_name = "CeLU"   # for the original ANI behavior please stick with CeLu since the alpha parameter is currently hard coded and might lead to different behavior when another activation function is used.

--- a/modelforge/tests/data/potential_defaults/painn.toml
+++ b/modelforge/tests/data/potential_defaults/painn.toml
@@ -7,6 +7,11 @@ maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 3
 shared_interactions = false
 shared_filters = false
+predicted_properties = [
+    { name = "per_atom_energy", type = "scalar" },
+    { name = "per_atom_charge", type = "scalar" },
+    # we could also define per_atom_force to be consistent?
+]
 
 [potential.core_parameter.activation_function_parameter]
 activation_function_name = "SiLU"

--- a/modelforge/tests/data/potential_defaults/painn.toml
+++ b/modelforge/tests/data/potential_defaults/painn.toml
@@ -26,3 +26,9 @@ number_of_per_atom_features = 32
 normalize = true
 from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
+
+[potential.postprocessing_parameter.per_atom_charge]
+conserve = true
+strategy = "physnet"
+from_atom_to_molecule_reduction = false
+keep_per_atom_property = true

--- a/modelforge/tests/data/potential_defaults/physnet.toml
+++ b/modelforge/tests/data/potential_defaults/physnet.toml
@@ -26,3 +26,9 @@ number_of_per_atom_features = 32
 normalize = true
 from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
+
+[potential.postprocessing_parameter.per_atom_charge]
+conserve_integer_charge = true
+strategy = "physnet"
+from_atom_to_molecule_reduction = false
+keep_per_atom_property = true

--- a/modelforge/tests/data/potential_defaults/physnet.toml
+++ b/modelforge/tests/data/potential_defaults/physnet.toml
@@ -7,6 +7,11 @@ number_of_radial_basis_functions = 16
 maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_residual = 3
 number_of_modules = 5
+predicted_properties = [
+    { name = "per_atom_energy", type = "scalar" },
+    { name = "per_atom_charge", type = "scalar" },
+    # we could also define per_atom_force to be consistent?
+]
 
 [potential.core_parameter.activation_function_parameter]
 activation_function_name = "ShiftedSoftplus"

--- a/modelforge/tests/data/potential_defaults/physnet.toml
+++ b/modelforge/tests/data/potential_defaults/physnet.toml
@@ -28,7 +28,6 @@ from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
 
 [potential.postprocessing_parameter.per_atom_charge]
-conserve_integer_charge = true
+conserve = true
 strategy = "physnet"
-from_atom_to_molecule_reduction = false
 keep_per_atom_property = true

--- a/modelforge/tests/data/potential_defaults/sake.toml
+++ b/modelforge/tests/data/potential_defaults/sake.toml
@@ -26,3 +26,9 @@ maximum_atomic_number = 101
 normalize = true
 from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
+
+[potential.postprocessing_parameter.per_atom_charge]
+conserve = true
+strategy = "physnet"
+from_atom_to_molecule_reduction = false
+keep_per_atom_property = true

--- a/modelforge/tests/data/potential_defaults/sake.toml
+++ b/modelforge/tests/data/potential_defaults/sake.toml
@@ -7,6 +7,11 @@ number_of_radial_basis_functions = 16
 maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 6
 number_of_spatial_attention_heads = 4
+predicted_properties = [
+    { name = "per_atom_energy", type = "scalar" },
+    { name = "per_atom_charge", type = "scalar" },
+    # we could also define per_atom_force to be consistent?
+]
 
 [potential.core_parameter.activation_function_parameter]
 activation_function_name = "SiLU"

--- a/modelforge/tests/data/potential_defaults/schnet.toml
+++ b/modelforge/tests/data/potential_defaults/schnet.toml
@@ -21,7 +21,6 @@ properties_to_featurize = ['atomic_number']
 maximum_atomic_number = 101
 number_of_per_atom_features = 32
 
-
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]
 normalize = true
@@ -30,8 +29,11 @@ keep_per_atom_property = true
 
 [potential.postprocessing_parameter.per_atom_charge]
 conserve = true
-strategy = "physnet"
+conserve_strategy = "default"
 keep_per_atom_property = true
+[potential.postprocessing_parameter.per_atom_charge.coulomb_potential]
+electrostatic_strategy = "coulomb"
+maximum_interaction_radius = "10.0 angstrom"
 
 [potential.postprocessing_parameter.general_postprocessing_operation]
 calculate_molecular_self_energy = true

--- a/modelforge/tests/data/potential_defaults/schnet.toml
+++ b/modelforge/tests/data/potential_defaults/schnet.toml
@@ -7,6 +7,11 @@ maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 3
 number_of_filters = 32
 shared_interactions = false
+predicted_properties = [
+    { name = "per_atom_energy", type = "scalar" },
+    { name = "per_atom_charge", type = "scalar" },
+    # we could also define per_atom_force to be consistent?
+]
 
 [potential.core_parameter.activation_function_parameter]
 activation_function_name = "ShiftedSoftplus"
@@ -16,10 +21,18 @@ properties_to_featurize = ['atomic_number']
 maximum_atomic_number = 101
 number_of_per_atom_features = 32
 
+
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]
 normalize = true
 from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
+
+[potential.postprocessing_parameter.per_atom_charge]
+normalize = true
+from_atom_to_molecule_reduction = false
+keep_per_atom_property = true
+
+
 [potential.postprocessing_parameter.general_postprocessing_operation]
 calculate_molecular_self_energy = true

--- a/modelforge/tests/data/potential_defaults/schnet.toml
+++ b/modelforge/tests/data/potential_defaults/schnet.toml
@@ -36,3 +36,8 @@ keep_per_atom_property = true
 
 [potential.postprocessing_parameter.general_postprocessing_operation]
 calculate_molecular_self_energy = true
+
+[potential.postprocessing_parameter.per_atom_charge]
+conserve = true
+strategy = "physnet"
+keep_per_atom_property = true

--- a/modelforge/tests/data/potential_defaults/schnet.toml
+++ b/modelforge/tests/data/potential_defaults/schnet.toml
@@ -29,15 +29,9 @@ from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
 
 [potential.postprocessing_parameter.per_atom_charge]
-normalize = true
-from_atom_to_molecule_reduction = false
-keep_per_atom_property = true
-
-
-[potential.postprocessing_parameter.general_postprocessing_operation]
-calculate_molecular_self_energy = true
-
-[potential.postprocessing_parameter.per_atom_charge]
 conserve = true
 strategy = "physnet"
 keep_per_atom_property = true
+
+[potential.postprocessing_parameter.general_postprocessing_operation]
+calculate_molecular_self_energy = true

--- a/modelforge/tests/data/potential_defaults/tensornet.toml
+++ b/modelforge/tests/data/potential_defaults/tensornet.toml
@@ -19,9 +19,16 @@ predicted_properties = [
 activation_function_name = "SiLU"
 
 [potential.postprocessing_parameter]
+
 [potential.postprocessing_parameter.per_atom_energy]
 normalize = true
 from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
+
+[potential.postprocessing_parameter.per_atom_charge]
+conserve = true
+strategy = "physnet"
+keep_per_atom_property = true
+
 [potential.postprocessing_parameter.general_postprocessing_operation]
 calculate_molecular_self_energy = true

--- a/modelforge/tests/data/potential_defaults/tensornet.toml
+++ b/modelforge/tests/data/potential_defaults/tensornet.toml
@@ -9,6 +9,11 @@ maximum_interaction_radius = "5.1 angstrom"
 minimum_interaction_radius = "0.0 angstrom"
 highest_atomic_number = 128
 equivariance_invariance_group = "O(3)"
+predicted_properties = [
+    { name = "per_atom_energy", type = "scalar" },
+    { name = "per_atom_charge", type = "scalar" },
+    # we could also define per_atom_force to be consistent?
+]
 
 [potential.core_parameter.activation_function_parameter]
 activation_function_name = "SiLU"

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -26,7 +26,7 @@ def load_configs_into_pydantic_models(potential_name: str, dataset_name: str):
     dataset_config_dict = toml.load(dataset_path)
     potential_config_dict = toml.load(potential_path)
     runtime_config_dict = toml.load(runtime_path)
-
+    print(potential_config_dict)
     potential_name = potential_config_dict["potential"]["potential_name"]
 
     from modelforge.potential import _Implemented_NNP_Parameters
@@ -445,6 +445,10 @@ def test_forward_pass(
 
     # test that we get an energie per molecule
     assert len(output["per_molecule_energy"]) == nr_of_mols
+
+    # check that per-atom charge/energies are present
+    assert "per_atom_energy" in output
+    assert "per_atom_charge" in output
 
     # the batch consists of methane (CH4) and amamonium (NH3)
     # which have chemically equivalent hydrogens at the minimum geometry.

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -3,6 +3,106 @@ import pytest
 from modelforge.potential import _Implemented_NNPs
 from modelforge.dataset import _ImplementedDatasets
 from modelforge.potential import NeuralNetworkPotentialFactory
+import torch
+from modelforge.utils.io import import_
+
+
+def initialize_model(simulation_environment: str, config):
+    """Initialize the model based on the simulation environment and configuration."""
+    return NeuralNetworkPotentialFactory.generate_potential(
+        use="inference",
+        simulation_environment=simulation_environment,
+        potential_parameter=config["potential"],
+    )
+
+
+def prepare_input_for_model(nnp_input, model):
+    """Prepare the input for the model based on the simulation environment."""
+    if "JAX" in str(type(model)):
+        return nnp_input.as_jax_namedtuple()
+    return nnp_input
+
+
+def validate_output_shapes(output, nr_of_mols):
+    """Validate the output shapes to ensure they are correct."""
+    assert len(output["per_molecule_energy"]) == nr_of_mols
+    assert "per_atom_energy" in output
+    assert "per_atom_charge" in output
+    assert "per_atom_charge_corrected" in output
+
+
+def validate_charge_conservation(
+    per_molecule_charge: torch.Tensor,
+    per_molecule_charge_corrected: torch.Tensor,
+    per_molecule_charge_from_dataset: torch.Tensor,
+    model_name: str,
+):
+    """Ensure charge conservation by validating the corrected charges."""
+
+    if "PhysNet".lower() in model_name.lower():
+        print(
+            "Physnet starts with all zero partial charges"
+        )  # NOTE: I am not sure if this is correct
+    else:
+        assert not torch.allclose(per_molecule_charge, per_molecule_charge_corrected)
+    assert torch.allclose(
+        per_molecule_charge_from_dataset.to(torch.float32),
+        per_molecule_charge_corrected,
+        atol=1e-5,
+    )
+
+
+def validate_energy_conservation(output: torch.Tensor):
+    """Ensure that the total energy is the sum of atomic energies."""
+    assert torch.allclose(
+        output["per_molecule_energy"][0],
+        output["per_atom_energy"][0:5].sum(dim=0),
+        atol=1e-5,
+    )
+    assert torch.allclose(
+        output["per_molecule_energy"][1],
+        output["per_atom_energy"][5:9].sum(dim=0),
+        atol=1e-5,
+    )
+
+
+def validate_chemical_equivalence(output):
+    """Ensure that chemically equivalent hydrogens have equal energies."""
+    assert torch.allclose(
+        output["per_atom_energy"][1:4], output["per_atom_energy"][1], atol=1e-4
+    )
+    assert torch.allclose(
+        output["per_atom_energy"][6:8], output["per_atom_energy"][6], atol=1e-4
+    )
+
+
+def retrieve_molecular_charges(output, atomic_subsystem_indices):
+    """Retrieve per-molecule charge from per-atom charges."""
+    per_molecule_charge = torch.zeros_like(output["per_molecule_energy"]).index_add_(
+        0, atomic_subsystem_indices, output["per_atom_charge"]
+    )
+    per_molecule_charge_corrected = torch.zeros_like(
+        output["per_molecule_energy"]
+    ).index_add_(0, atomic_subsystem_indices, output["per_atom_charge_corrected"])
+    return per_molecule_charge, per_molecule_charge_corrected
+
+
+def convert_to_pytorch_if_needed(output, nnp_input, model):
+    """Convert output to PyTorch tensors if the model is in JAX."""
+    if "JAX" in str(type(model)):
+        convert_to_pyt = import_("pytorch2jax").pytorch2jax.convert_to_pyt
+        output["per_molecule_energy"] = convert_to_pyt(output["per_molecule_energy"])
+        output["per_atom_charge"] = convert_to_pyt(output["per_atom_charge"])
+        output["per_atom_charge_corrected"] = convert_to_pyt(
+            output["per_atom_charge_corrected"]
+        )
+        output["per_molecule_charge"] = convert_to_pyt(
+            output["per_molecule_charge"]
+        ).to(torch.float32)
+        atomic_subsystem_indices = convert_to_pyt(nnp_input.atomic_subsystem_indices)
+    else:
+        atomic_subsystem_indices = nnp_input.atomic_subsystem_indices
+    return output, atomic_subsystem_indices
 
 
 def load_configs_into_pydantic_models(potential_name: str, dataset_name: str):
@@ -424,78 +524,37 @@ def test_forward_pass(
     potential_name, simulation_environment, single_batch_with_batchsize_64
 ):
     # this test sends a single batch from different datasets through the model
-    import torch
 
+    # get input and set up model
     nnp_input = single_batch_with_batchsize_64.nnp_input
-
-    # read default parameters
     config = load_configs_into_pydantic_models(f"{potential_name.lower()}", "qm9")
     nr_of_mols = nnp_input.atomic_subsystem_indices.unique().shape[0]
+    model = initialize_model(simulation_environment, config)
+    nnp_input = prepare_input_for_model(nnp_input, model)
 
-    # test the forward pass through each of the models
-    model = NeuralNetworkPotentialFactory.generate_potential(
-        use="inference",
-        simulation_environment=simulation_environment,
-        potential_parameter=config["potential"],
-    )
-    if "JAX" in str(type(model)):
-        nnp_input = nnp_input.as_jax_namedtuple()
-
+    # perform the forward pass through each of the models
     output = model(nnp_input)
 
-    # test that we get an energie per molecule
-    assert len(output["per_molecule_energy"]) == nr_of_mols
-
-    # check that per-atom charge/energies are present
-    assert "per_atom_energy" in output
-    assert "per_atom_charge" in output
-
-    # retrieve per-molecule charge from per-atom (corrected) charges
-    per_molecule_charge = torch.zeros_like(output["per_molecule_energy"]).index_add_(
-        0, nnp_input.atomic_subsystem_indices, output["per_atom_charge"]
-    )
-    per_molecule_corrected_charge = torch.zeros_like(
-        output["per_molecule_energy"]
-    ).index_add_(
-        0, nnp_input.atomic_subsystem_indices, output["per_atom_charge_corrected"]
-    )
-    per_molecule_charge_from_dataset = output["per_molecule_charge"].to(torch.float32)
-
-    # make sure that corrected and uncorrected partial charges differ
-    assert not torch.allclose(per_molecule_charge, per_molecule_corrected_charge)
-
-    # make sure that the experimental charges are the same as the sum over the corrected partial charges
-    assert torch.allclose(
-        per_molecule_charge_from_dataset, per_molecule_corrected_charge
+    # validate the output
+    validate_output_shapes(output, nr_of_mols)
+    output, atomic_subsystem_indices = convert_to_pytorch_if_needed(
+        output, nnp_input, model
     )
 
-    # the batch consists of methane (CH4) and amamonium (NH3)
-    # which have chemically equivalent hydrogens at the minimum geometry.
-    # This has to be reflected in the atomic energies E_i, which
-    # have to be equal for all hydrogens
-    if "JAX" not in str(type(model)):
-        from loguru import logger as log
-
-        # assert that the following tensor has equal values for dim=0 index 1 to 4 and 6 to 8
-
-        assert torch.allclose(
-            output["per_atom_energy"][1:4], output["per_atom_energy"][1], atol=1e-4
-        )
-        assert torch.allclose(
-            output["per_atom_energy"][6:8], output["per_atom_energy"][6], atol=1e-4
-        )
-
-        # make sure that the total energy is \sum E_i
-        assert torch.allclose(
-            output["per_molecule_energy"][0],
-            output["per_atom_energy"][0:5].sum(dim=0),
-            atol=1e-5,
-        )
-        assert torch.allclose(
-            output["per_molecule_energy"][1],
-            output["per_atom_energy"][5:9].sum(dim=0),
-            atol=1e-5,
-        )
+    # test that charge correction is working
+    per_molecule_charge, per_molecule_charge_corrected = retrieve_molecular_charges(
+        output, atomic_subsystem_indices
+    )
+    validate_charge_conservation(
+        per_molecule_charge,
+        per_molecule_charge_corrected,
+        output["per_molecule_charge"],
+        potential_name,
+    )
+    # check that per-atom energies are correct
+    if "JAX" not in simulation_environment:
+        validate_chemical_equivalence(output)
+        validate_energy_conservation(output)
 
 
 @pytest.mark.parametrize(
@@ -999,8 +1058,8 @@ def test_casting(potential_name, single_batch_with_batchsize_64):
 )
 @pytest.mark.parametrize("simulation_environment", ["PyTorch"])
 def test_equivariant_energies_and_forces(
-    potential_name,
-    simulation_environment,
+    potential_name: str,
+    simulation_environment: str,
     single_batch_with_batchsize_64,
     equivariance_utils,
 ):

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -450,6 +450,16 @@ def test_forward_pass(
     assert "per_atom_energy" in output
     assert "per_atom_charge" in output
 
+    # check that the per-atom charges sum to integer charges
+    per_molecule_charge = torch.zeros_like(output["per_molecule_energy"]).index_add_(
+        0, nnp_input.atomic_subsystem_indices, output["per_atom_charge"]
+    )
+    per_molecule_corrected_charge = torch.zeros_like(
+        output["per_molecule_energy"]
+    ).index_add_(
+        0, nnp_input.atomic_subsystem_indices, output["per_atom_corrected_charge"]
+    )
+
     # the batch consists of methane (CH4) and amamonium (NH3)
     # which have chemically equivalent hydrogens at the minimum geometry.
     # This has to be reflected in the atomic energies E_i, which


### PR DESCRIPTION
## Description
This PR implements the infrastructure to calculate long-range electrostatics. In the first version, we will calculate the long-range term using a damped coulomb potential (see [ref](https://pubs.acs.org/doi/10.1021/acs.jctc.9b00181) for details). 

## Todos
  - [x] Add infrastructure to support the calculation of long-range electrostatic in a postprocessing step
  - [x] implement damped coulomb potential
  - [ ] add tests 

## Status
- [ ] Ready to go