### PR TITLE
fix conflicting save_dir parameter definition

### DIFF
--- a/modelforge/tests/data/runtime_defaults/runtime.toml
+++ b/modelforge/tests/data/runtime_defaults/runtime.toml
@@ -1,5 +1,4 @@
 [runtime]
-save_dir = "lightning_logs"
 experiment_name = "{potential_name}_{dataset_name}"
 local_cache_dir = "./cache"
 accelerator = "cpu"

--- a/modelforge/train/parameters.py
+++ b/modelforge/train/parameters.py
@@ -309,7 +309,6 @@ class RuntimeParameters(ParametersBase):
     A class to hold the runtime parameters that inherits from the pydantic BaseModel
 
     args:
-        save_dir (str): The save directory
         experiment_name (str): The experiment name
         accelerator (Accelerator): The accelerator, options are: "cpu", "gpu", "tpu"
         number_of_nodes (int): The number of nodes
@@ -322,7 +321,6 @@ class RuntimeParameters(ParametersBase):
 
     """
 
-    save_dir: str
     experiment_name: str
     accelerator: Accelerator
     number_of_nodes: int


### PR DESCRIPTION
## Description

save_idr parameter was both defined in the runtime and training.toml, and only the runtime.toml parameter was used, but the Pydantic model also expected it to present the runtime.toml (without any additional effect).

## Status
- [x] Ready to go