### PR TITLE
Make it easier to test on single batch of dataset

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -1552,3 +1552,71 @@ def collate_conformers(conf_list: List[BatchData]) -> BatchData:
         number_of_atoms=atomic_numbers.numel(),
     )
     return BatchData(nnp_input, metadata)
+
+
+from modelforge.dataset.dataset import DatasetFactory
+from modelforge.dataset.utils import (
+    FirstComeFirstServeSplittingStrategy,
+    SplittingStrategy,
+)
+
+
+def initialize_datamodule(
+    dataset_name: str,
+    version_select: str = "nc_1000_v0",
+    batch_size: int = 64,
+    splitting_strategy: SplittingStrategy = FirstComeFirstServeSplittingStrategy(),
+    remove_self_energies: bool = True,
+    regression_ase: bool = False,
+    regenerate_dataset_statistic: bool = False,
+) -> DataModule:
+    """
+    Initialize a dataset for a given mode.
+    """
+
+    data_module = DataModule(
+        dataset_name,
+        splitting_strategy=splitting_strategy,
+        batch_size=batch_size,
+        version_select=version_select,
+        remove_self_energies=remove_self_energies,
+        regression_ase=regression_ase,
+        regenerate_dataset_statistic=regenerate_dataset_statistic,
+    )
+    data_module.prepare_data()
+    data_module.setup()
+    return data_module
+
+
+def single_batch(batch_size: int = 64, dataset_name="QM9"):
+    """
+    Utility function to create a single batch of data for testing.
+    """
+    data_module = initialize_datamodule(
+        dataset_name=dataset_name,
+        batch_size=batch_size,
+        version_select="nc_1000_v0",
+    )
+    return next(iter(data_module.train_dataloader(shuffle=False)))
+
+
+def initialize_dataset(
+    dataset_name: str,
+    local_cache_dir: str,
+    versions_select: str = "nc_1000_v0",
+    force_download: bool = False,
+) -> DataModule:
+    """
+    Initialize a dataset for a given mode.
+    """
+    from modelforge.dataset import _ImplementedDatasets
+
+    factory = DatasetFactory()
+    data = _ImplementedDatasets.get_dataset_class(dataset_name)(
+        local_cache_dir=local_cache_dir,
+        version_select=versions_select,
+        force_download=force_download,
+    )
+    dataset = factory.create_dataset(data)
+
+    return dataset

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -5,51 +5,7 @@ from modelforge.dataset import _ImplementedDatasets
 from modelforge.potential import NeuralNetworkPotentialFactory
 
 
-def load_configs_into_pydantic_models(potential_name: str, dataset_name: str):
-    from modelforge.tests.data import (
-        potential_defaults,
-        training_defaults,
-        dataset_defaults,
-        runtime_defaults,
-    )
-    from importlib import resources
-    import toml
-
-    potential_path = (
-        resources.files(potential_defaults) / f"{potential_name.lower()}.toml"
-    )
-    dataset_path = resources.files(dataset_defaults) / f"{dataset_name.lower()}.toml"
-    training_path = resources.files(training_defaults) / "default.toml"
-    runtime_path = resources.files(runtime_defaults) / "runtime.toml"
-
-    training_config_dict = toml.load(training_path)
-    dataset_config_dict = toml.load(dataset_path)
-    potential_config_dict = toml.load(potential_path)
-    runtime_config_dict = toml.load(runtime_path)
-
-    potential_name = potential_config_dict["potential"]["potential_name"]
-
-    from modelforge.potential import _Implemented_NNP_Parameters
-
-    PotentialParameters = (
-        _Implemented_NNP_Parameters.get_neural_network_parameter_class(potential_name)
-    )
-    potential_parameters = PotentialParameters(**potential_config_dict["potential"])
-
-    from modelforge.dataset.dataset import DatasetParameters
-    from modelforge.train.parameters import TrainingParameters, RuntimeParameters
-
-    dataset_parameters = DatasetParameters(**dataset_config_dict["dataset"])
-    training_parameters = TrainingParameters(**training_config_dict["training"])
-    runtime_parameters = RuntimeParameters(**runtime_config_dict["runtime"])
-
-    return {
-        "potential": potential_parameters,
-        "dataset": dataset_parameters,
-        "training": training_parameters,
-        "runtime": runtime_parameters,
-    }
-
+from modelforge.utils.misc import load_configs_into_pydantic_models
 
 @pytest.mark.parametrize(
     "potential_name", _Implemented_NNPs.get_all_neural_network_names()

--- a/modelforge/tests/test_models.py
+++ b/modelforge/tests/test_models.py
@@ -7,6 +7,7 @@ from modelforge.potential import NeuralNetworkPotentialFactory
 
 from modelforge.utils.misc import load_configs_into_pydantic_models
 
+
 @pytest.mark.parametrize(
     "potential_name", _Implemented_NNPs.get_all_neural_network_names()
 )


### PR DESCRIPTION
## Description
Move the functions to test on a single batch of dataset from the test folder to the modelforge folder, makes it easier to use in notebooks/scripts and avoids duplication.

## Status
- [x] Ready to go