### PR TITLE
TensorNet parameter rename

### DIFF
--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -199,7 +199,7 @@ class TensorNetParameters(ParametersBase):
         number_of_radial_basis_functions: int
         maximum_interaction_radius: Union[str, unit.Quantity]
         minimum_interaction_radius: Union[str, unit.Quantity]
-        highest_atomic_number: int
+        maximum_atomic_number: int
         equivariance_invariance_group: str
         activation_function_parameter: ActivationFunctionConfig
 

--- a/modelforge/potential/tensornet.py
+++ b/modelforge/potential/tensornet.py
@@ -192,8 +192,8 @@ class TensorNet(BaseNetwork):
         Maximum interaction radius.
     minimum_interaction_radius : unit.Quantity
         Minimum interaction radius.
-    highest_atomic_number : int
-        Highest atomic number in the dataset.
+    maximum_atomic_number : int
+        Maximum atomic number in the dataset.
     equivariance_invariance_group : str
         Equivariance invariance group, either "O(3)" or "SO(3)".
     activation_function_parameter : Dict
@@ -214,7 +214,7 @@ class TensorNet(BaseNetwork):
         number_of_radial_basis_functions: int,
         maximum_interaction_radius: unit.Quantity,
         minimum_interaction_radius: unit.Quantity,
-        highest_atomic_number: int,
+        maximum_atomic_number: int,
         equivariance_invariance_group: str,
         activation_function_parameter: Dict,
         postprocessing_parameter: Dict[str, Dict[str, bool]],
@@ -239,7 +239,7 @@ class TensorNet(BaseNetwork):
             maximum_interaction_radius=_convert_str_to_unit(maximum_interaction_radius),
             minimum_interaction_radius=_convert_str_to_unit(minimum_interaction_radius),
             trainable_centers_and_scale_factors=False,
-            highest_atomic_number=highest_atomic_number,
+            maximum_atomic_number=maximum_atomic_number,
             equivariance_invariance_group=equivariance_invariance_group,
             activation_function=activation_function,
         )
@@ -263,8 +263,8 @@ class TensorNetCore(CoreNetwork):
         Minimum interaction radius.
     trainable_centers_and_scale_factors : bool
         If True, centers and scale factors are trainable.
-    highest_atomic_number : int
-        Highest atomic number in the dataset.
+    maximum_atomic_number : int
+        Maximum atomic number in the dataset.
     equivariance_invariance_group : str
         Equivariance invariance group, either "O(3)" or "SO(3)".
     activation_function : Type[torch.nn.Module]
@@ -279,7 +279,7 @@ class TensorNetCore(CoreNetwork):
         maximum_interaction_radius: unit.Quantity,
         minimum_interaction_radius: unit.Quantity,
         trainable_centers_and_scale_factors: bool,
-        highest_atomic_number: int,
+        maximum_atomic_number: int,
         equivariance_invariance_group: str,
         activation_function: Type[torch.nn.Module],
         seed: int = 0,
@@ -294,7 +294,7 @@ class TensorNetCore(CoreNetwork):
             maximum_interaction_radius=maximum_interaction_radius,
             minimum_interaction_radius=minimum_interaction_radius,
             trainable_centers_and_scale_factors=trainable_centers_and_scale_factors,
-            highest_atomic_number=highest_atomic_number,
+            maximum_atomic_number=maximum_atomic_number,
         )
         self.interaction_modules = nn.ModuleList(
             [
@@ -423,8 +423,8 @@ class TensorNetRepresentation(torch.nn.Module):
         Minimum interaction radius.
     trainable_centers_and_scale_factors : bool
         If True, centers and scale factors are trainable.
-    highest_atomic_number : int
-        Highest atomic number in the dataset.
+    maximum_atomic_number : int
+        Maximum atomic number in the dataset.
     """
 
     def __init__(
@@ -435,7 +435,7 @@ class TensorNetRepresentation(torch.nn.Module):
         maximum_interaction_radius: unit.Quantity,
         minimum_interaction_radius: unit.Quantity,
         trainable_centers_and_scale_factors: bool,
-        highest_atomic_number: int,
+        maximum_atomic_number: int,
     ):
         super().__init__()
         from modelforge.potential.utils import Dense
@@ -467,7 +467,7 @@ class TensorNetRepresentation(torch.nn.Module):
             }
         )
         self.atomic_number_i_embedding_layer = nn.Embedding(
-            highest_atomic_number,
+            maximum_atomic_number,
             number_of_per_atom_features,
         )
         self.atomic_number_ij_embedding_layer = nn.Linear(

--- a/modelforge/tests/data/potential_defaults/tensornet.toml
+++ b/modelforge/tests/data/potential_defaults/tensornet.toml
@@ -7,7 +7,7 @@ number_of_interaction_layers = 2
 number_of_radial_basis_functions = 16
 maximum_interaction_radius = "5.1 angstrom"
 minimum_interaction_radius = "0.0 angstrom"
-highest_atomic_number = 128
+maximum_atomic_number = 128
 equivariance_invariance_group = "O(3)"
 
 [potential.core_parameter.activation_function_parameter]

--- a/modelforge/tests/test_tensornet.py
+++ b/modelforge/tests/test_tensornet.py
@@ -224,7 +224,7 @@ def test_representation():
     cutoff_lower = 0.0
     cutoff_upper = 5.1
     trainable_rbf = False
-    highest_atomic_number = 128
+    maximum_atomic_number = 128
 
     # Set up a dataset
     # prepare reference value
@@ -266,7 +266,7 @@ def test_representation():
         cutoff_upper * unit.angstrom,
         cutoff_lower * unit.angstrom,
         trainable_rbf,
-        highest_atomic_number,
+        maximum_atomic_number,
     )
     nnp_input = tensornet.core_module._model_specific_input_preparation(
         mf_input, pairlist_output
@@ -286,7 +286,7 @@ def test_representation():
             cutoff_lower,
             cutoff_upper,
             trainable_rbf,
-            highest_atomic_number,
+            maximum_atomic_number,
             seed,
         )
     ################ torchmd-net TensorNet ################

--- a/scripts/config.toml
+++ b/scripts/config.toml
@@ -1,29 +1,29 @@
 [potential]
-potential_name = "ANI2x"
+potential_name = "TensorNet"
 
 [potential.core_parameter]
-angle_sections = 4
-maximum_interaction_radius = "5.1 angstrom"
-minimum_interaction_radius = "0.8 angstrom"
-number_of_radial_basis_functions = 16
-maximum_interaction_radius_for_angular_features = "3.5 angstrom"
-minimum_interaction_radius_for_angular_features = "0.8 angstrom"
-angular_dist_divisions = 8
+number_of_per_atom_features = 128
+number_of_interaction_layers = 2
+number_of_radial_basis_functions = 32
+maximum_interaction_radius = "10.0 angstrom"
+minimum_interaction_radius = "0.0 angstrom"
+maximum_atomic_number = 128
+equivariance_invariance_group = "O(3)"
 
 [potential.core_parameter.activation_function_parameter]
-activation_function_name = "CeLU"   # for the original ANI behavior please stick with CeLu since the alpha parameter is currently hard coded and might lead to different behavior when another activation function is used.
-
-[potential.core_parameter.activation_function_parameter.activation_function_arguments]
-alpha = 0.1
+activation_function_name = "SiLU"
 
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]
 normalize = true
 from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
+[potential.postprocessing_parameter.general_postprocessing_operation]
+calculate_molecular_self_energy = true
+
 
 [dataset]
-dataset_name = "PHALKETHOH"
+dataset_name = "SPICE2"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
@@ -31,7 +31,7 @@ pin_memory = true
 [training]
 number_of_epochs = 1000
 remove_self_energies = true
-batch_size = 16
+batch_size = 32
 lr = 0.5e-3
 monitor_for_checkpoint = "val/per_molecule_energy/rmse"
 
@@ -75,7 +75,7 @@ seed = 42
 save_dir = "test_setup"
 experiment_name = "{potential_name}_{dataset_name}"
 local_cache_dir = "./cache"
-accelerator = "cpu"
+accelerator = "gpu"
 number_of_nodes = 1
 devices = 1                                         #[0,1,2,3]
 checkpoint_path = "None"

--- a/scripts/config.toml
+++ b/scripts/config.toml
@@ -1,29 +1,29 @@
 [potential]
-potential_name = "TensorNet"
+potential_name = "ANI2x"
 
 [potential.core_parameter]
-number_of_per_atom_features = 128
-number_of_interaction_layers = 2
-number_of_radial_basis_functions = 32
-maximum_interaction_radius = "10.0 angstrom"
-minimum_interaction_radius = "0.0 angstrom"
-maximum_atomic_number = 128
-equivariance_invariance_group = "O(3)"
+angle_sections = 4
+maximum_interaction_radius = "5.1 angstrom"
+minimum_interaction_radius = "0.8 angstrom"
+number_of_radial_basis_functions = 16
+maximum_interaction_radius_for_angular_features = "3.5 angstrom"
+minimum_interaction_radius_for_angular_features = "0.8 angstrom"
+angular_dist_divisions = 8
 
 [potential.core_parameter.activation_function_parameter]
-activation_function_name = "SiLU"
+activation_function_name = "CeLU"   # for the original ANI behavior please stick with CeLu since the alpha parameter is currently hard coded and might lead to different behavior when another activation function is used.
+
+[potential.core_parameter.activation_function_parameter.activation_function_arguments]
+alpha = 0.1
 
 [potential.postprocessing_parameter]
 [potential.postprocessing_parameter.per_atom_energy]
 normalize = true
 from_atom_to_molecule_reduction = true
 keep_per_atom_property = true
-[potential.postprocessing_parameter.general_postprocessing_operation]
-calculate_molecular_self_energy = true
-
 
 [dataset]
-dataset_name = "SPICE2"
+dataset_name = "PHALKETHOH"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
@@ -31,7 +31,7 @@ pin_memory = true
 [training]
 number_of_epochs = 1000
 remove_self_energies = true
-batch_size = 32
+batch_size = 16
 lr = 0.5e-3
 monitor_for_checkpoint = "val/per_molecule_energy/rmse"
 
@@ -75,7 +75,7 @@ seed = 42
 save_dir = "test_setup"
 experiment_name = "{potential_name}_{dataset_name}"
 local_cache_dir = "./cache"
-accelerator = "gpu"
+accelerator = "cpu"
 number_of_nodes = 1
 devices = 1                                         #[0,1,2,3]
 checkpoint_path = "None"


### PR DESCRIPTION
## Description
Change `highest_atomic_number` to `maximum_atomic_number` for code consistency with other NNPs (issue #251).

## Status
- [ ] Ready to go