### PR TITLE
Ref training nlist

### DIFF
--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -1135,7 +1135,7 @@ class DataModule(pl.LightningDataModule):
             regenerate_cache : bool, defaults to False
                 Whether to regenerate the cache.
         """
-        from modelforge.potential.models import Pairlist
+        from modelforge.potential.neighbors import Pairlist
         import os
 
         super().__init__()

--- a/modelforge/potential/aimnet2.py
+++ b/modelforge/potential/aimnet2.py
@@ -6,7 +6,8 @@ from loguru import logger as log
 
 from modelforge.potential.utils import Dense
 
-from .models import NNPInputTuple, PairlistData
+from modelforge.dataset.dataset import NNPInput, NNPInputTuple
+from modelforge.potential.neighbors import PairlistData
 
 
 class AimNet2Core(torch.nn.Module):

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -17,7 +17,8 @@ from torch import nn
 
 from modelforge.utils.prop import SpeciesAEV
 
-from .models import NNPInputTuple, PairlistData
+from modelforge.dataset.dataset import NNPInputTuple
+from modelforge.potential.neighbors import PairlistData
 
 
 def triu_index(num_species: int) -> torch.Tensor:

--- a/modelforge/potential/models.py
+++ b/modelforge/potential/models.py
@@ -716,17 +716,17 @@ class Potential(torch.nn.Module):
 
         # remove key neighborlist.calculate_distances_and_pairlist.cutoff
         # if present in the state_dict and replace it with 'neighborlist.cutoff'
-        if (
-            "neighborlist.calculate_distances_and_pairlist.cutoff"
-            in filtered_state_dict
-        ):
-            filtered_state_dict["neighborlist.cutoff"] = filtered_state_dict.pop(
-                "neighborlist.calculate_distances_and_pairlist.cutoff"
-            )
-        else:
-            raise KeyError(
-                "load_stat_dict() is only available for training and inference."
-            )
+        # if (
+        #     "neighborlist.calculate_distances_and_pairlist.cutoff"
+        #     in filtered_state_dict
+        # ):
+        #     filtered_state_dict["neighborlist.cutoff"] = filtered_state_dict.pop(
+        #         "neighborlist.calculate_distances_and_pairlist.cutoff"
+        #     )
+        # else:
+        #     raise KeyError(
+        #         "load_stat_dict() is only available for training and inference."
+        #     )
 
         super().load_state_dict(
             filtered_state_dict,

--- a/modelforge/potential/neighbors.py
+++ b/modelforge/potential/neighbors.py
@@ -1,8 +1,285 @@
+"""
+This file contains classes for computing pairs and neighbors.
+"""
+
 import torch
 from loguru import logger as log
-from modelforge.potential.models import PairlistData
-from modelforge.dataset.dataset import NNPInputTuple
-from modelforge.potential.models import Pairlist
+from modelforge.dataset.dataset import NNPInputTuple, NNPInput
+
+from typing import Union, NamedTuple
+
+
+class PairlistData(NamedTuple):
+    """
+    A namedtuple to store the outputs of the Pairlist and Neighborlist forward methods.
+
+    Attributes
+    ----------
+    pair_indices : torch.Tensor
+        A tensor of shape (2, n_pairs) containing the indices of the interacting atom pairs.
+    d_ij : torch.Tensor
+        A tensor of shape (n_pairs, 1) containing the Euclidean distances between the atoms in each pair.
+    r_ij : torch.Tensor
+        A tensor of shape (n_pairs, 3) containing the displacement vectors between the atoms in each pair.
+    """
+
+    pair_indices: torch.Tensor
+    d_ij: torch.Tensor
+    r_ij: torch.Tensor
+
+
+class Pairlist(torch.nn.Module):
+
+    def __init__(self, only_unique_pairs: bool = False):
+        """
+         Handle pair list calculations for systems, returning indices, distances
+         and distance vectors for atom pairs within a certain cutoff.
+
+        Parameters
+        ----------
+        only_unique_pairs : bool, optional
+            If True, only unique pairs are returned (default is False).
+        """
+        super().__init__()
+        self.only_unique_pairs = only_unique_pairs
+
+    def enumerate_all_pairs(self, atomic_subsystem_indices: torch.Tensor):
+        """
+        Compute all pairs of atoms and their distances.
+
+        Parameters
+        ----------
+        atomic_subsystem_indices : torch.Tensor
+            Atom indices to indicate which atoms belong to which molecule.
+            Note in all cases, the values in this tensor must be numbered from 0 to n_molecules - 1 sequentially, with no gaps in the numbering. E.g., [0,0,0,1,1,2,2,2 ...].
+            This is the case for all internal data structures, and thus no validation is performed in this routine. If the data is not structured in this way, the results will be incorrect.
+
+        Returns
+        -------
+        torch.Tensor
+            Pair indices for all atom pairs.
+        """
+
+        # get device that passed tensors lives on, initialize on the same device
+        device = atomic_subsystem_indices.device
+
+        # if there is only one molecule, we do not need to use additional looping and offsets
+        if torch.sum(atomic_subsystem_indices) == 0:
+            n = len(atomic_subsystem_indices)
+            if self.only_unique_pairs:
+                i_final_pairs, j_final_pairs = torch.triu_indices(
+                    n, n, 1, device=device
+                )
+            else:
+                # Repeat each number n-1 times for i_indices
+                i_final_pairs = torch.repeat_interleave(
+                    torch.arange(n, device=device),
+                    repeats=n - 1,
+                )
+
+                # Correctly construct j_indices
+                j_final_pairs = torch.cat(
+                    [
+                        torch.cat(
+                            (
+                                torch.arange(i, device=device),
+                                torch.arange(i + 1, n, device=device),
+                            )
+                        )
+                        for i in range(n)
+                    ]
+                )
+
+        else:
+            # if we have more than one molecule, we will take into account molecule size and offsets when
+            # calculating pairs, as using the approach above is not memory efficient for datasets with large molecules
+            # and/or larger batch sizes; while not likely a problem on higher end GPUs with large amounts of memory
+            # cheaper commodity and mobile GPUs may have issues
+
+            # atomic_subsystem_indices are always numbered from 0 to n_molecules
+            # - 1 e.g., a single molecule will be [0, 0, 0, 0 ... ] and a batch
+            # of molecules will always start at 0 and increment [ 0, 0, 0, 1, 1,
+            # 1, ...] As such, we can use bincount, as there are no gaps in the
+            # numbering
+
+            # Note if the indices are not numbered from 0 to n_molecules - 1, this will not work
+            # E.g., bincount on [3,3,3, 4,4,4, 5,5,5] will return [0,0,0,3,3,3,3,3,3]
+            # as we have no values for 0, 1, 2
+            # using a combination of unique and argsort would make this work for any numbering ordering
+            # but that is not how the data ends up being structured internally, and thus is not needed
+            repeats = torch.bincount(atomic_subsystem_indices)
+            offsets = torch.cat(
+                (torch.tensor([0], device=device), torch.cumsum(repeats, dim=0)[:-1])
+            )
+
+            i_indices = torch.cat(
+                [
+                    torch.repeat_interleave(
+                        torch.arange(o, o + r, device=device), repeats=r
+                    )
+                    for r, o in zip(repeats, offsets)
+                ]
+            )
+            j_indices = torch.cat(
+                [
+                    torch.cat([torch.arange(o, o + r, device=device) for _ in range(r)])
+                    for r, o in zip(repeats, offsets)
+                ]
+            )
+
+            if self.only_unique_pairs:
+                # filter out pairs that are not unique
+                unique_pairs_mask = i_indices < j_indices
+                i_final_pairs = i_indices[unique_pairs_mask]
+                j_final_pairs = j_indices[unique_pairs_mask]
+            else:
+                # filter out identical values
+                unique_pairs_mask = i_indices != j_indices
+                i_final_pairs = i_indices[unique_pairs_mask]
+                j_final_pairs = j_indices[unique_pairs_mask]
+
+        # concatenate to form final (2, n_pairs) tensor
+        pair_indices = torch.stack((i_final_pairs, j_final_pairs))
+
+        return pair_indices.to(device)
+
+    def construct_initial_pairlist_using_numpy(
+        self, atomic_subsystem_indices: torch.Tensor
+    ):
+        """Compute all pairs of atoms and also return counts of the number of pairs for each molecule in batch.
+
+        Parameters
+        ----------
+        atomic_subsystem_indices : torch.Tensor
+            Atom indices to indicate which atoms belong to which molecule.
+
+        Returns
+        -------
+        pair_indices : np.ndarray, shape (2, n_pairs)
+            Pairs of atom indices, 0-indexed for each molecule
+        number_of_pairs : np.ndarray, shape (n_molecules)
+            The number to index into pair_indices for each molecule
+
+        """
+
+        # atomic_subsystem_indices are always numbered from 0 to n_molecules - 1
+        # e.g., a single molecule will be [0, 0, 0, 0 ... ]
+        # and a batch of molecules will always start at 0 and increment [ 0, 0, 0, 1, 1, 1, ...]
+        # As such, we can use bincount, as there are no gaps in the numbering
+        # Note if the indices are not numbered from 0 to n_molecules - 1, this will not work
+        # E.g., bincount on [3,3,3, 4,4,4, 5,5,5] will return [0,0,0,3,3,3,3,3,3]
+        # as we have no values for 0, 1, 2
+        # using a combination of unique and argsort would make this work for any numbering ordering
+        # but that is not how the data ends up being structured internally, and thus is not needed
+
+        import numpy as np
+
+        # get the number of atoms in each molecule
+        repeats = np.bincount(atomic_subsystem_indices)
+
+        # calculate the number of pairs for each molecule, using simple permutation
+        npairs_by_molecule = np.array([r * (r - 1) for r in repeats], dtype=np.int16)
+
+        i_indices = np.concatenate(
+            [
+                np.repeat(
+                    np.arange(
+                        0,
+                        r,
+                        dtype=np.int16,
+                    ),
+                    repeats=r,
+                )
+                for r in repeats
+            ]
+        )
+        j_indices = np.concatenate(
+            [
+                np.concatenate([np.arange(0, 0 + r, dtype=np.int16) for _ in range(r)])
+                for r in repeats
+            ]
+        )
+
+        # filter out identical pairs where i==j
+        unique_pairs_mask = i_indices != j_indices
+        i_final_pairs = i_indices[unique_pairs_mask]
+        j_final_pairs = j_indices[unique_pairs_mask]
+
+        # concatenate to form final (2, n_pairs) vector
+        pair_indices = np.stack((i_final_pairs, j_final_pairs))
+
+        return pair_indices, npairs_by_molecule
+
+    def calculate_r_ij(
+        self, pair_indices: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        """Compute displacement vectors between atom pairs.
+
+        Parameters
+        ----------
+        pair_indices : torch.Tensor
+            Atom indices for pairs of atoms. Shape: [2, n_pairs].
+        positions : torch.Tensor
+            Atom positions. Shape: [atoms, 3].
+
+        Returns
+        -------
+        torch.Tensor
+            Displacement vectors between atom pairs. Shape: [n_pairs, 3].
+        """
+        # Select the pairs of atom coordinates from the positions
+        selected_positions = positions.index_select(0, pair_indices.view(-1)).view(
+            2, -1, 3
+        )
+        return selected_positions[1] - selected_positions[0]
+
+    def calculate_d_ij(self, r_ij: torch.Tensor) -> torch.Tensor:
+        """
+        ompute Euclidean distances between atoms in each pair.
+
+        Parameters
+        ----------
+        r_ij : torch.Tensor
+            Displacement vectors between atoms in a pair. Shape: [n_pairs, 3].
+
+        Returns
+        -------
+        torch.Tensor
+            Euclidean distances. Shape: [n_pairs, 1].
+        """
+        return r_ij.norm(dim=1).unsqueeze(1)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        atomic_subsystem_indices: torch.Tensor,
+    ) -> PairlistData:
+        """
+        Performs the forward pass of the Pairlist module.
+
+        Parameters
+        ----------
+        positions : torch.Tensor
+            Atom positions. Shape: [nr_atoms, 3].
+        atomic_subsystem_indices (torch.Tensor, shape (nr_atoms_per_systems)):
+            Atom indices to indicate which atoms belong to which molecule.
+
+        Returns
+        -------
+        PairListOutputs: A dataclass containing the following attributes:
+            pair_indices (torch.Tensor): A tensor of shape (2, n_pairs) containing the indices of the interacting atom pairs.
+            d_ij (torch.Tensor): A tensor of shape (n_pairs, 1) containing the Euclidean distances between the atoms in each pair.
+            r_ij (torch.Tensor): A tensor of shape (n_pairs, 3) containing the displacement vectors between the atoms in each pair.
+        """
+        pair_indices = self.enumerate_all_pairs(
+            atomic_subsystem_indices,
+        )
+        r_ij = self.calculate_r_ij(pair_indices, positions)
+        return PairlistData(
+            pair_indices=pair_indices,
+            d_ij=self.calculate_d_ij(r_ij),
+            r_ij=r_ij,
+        )
 
 
 class OrthogonalDisplacementFunction(torch.nn.Module):
@@ -443,7 +720,7 @@ class NeighborlistVerletNsq(torch.nn.Module):
             )
 
 
-class NeighborForlistTraining(torch.nn.Module):
+class NeighborListForTraining(torch.nn.Module):
 
     def __init__(self, cutoff: float, only_unique_pairs: bool = False):
         """
@@ -458,17 +735,55 @@ class NeighborForlistTraining(torch.nn.Module):
         """
 
         super().__init__()
-        from .models import Neighborlist
 
         self.only_unique_pairs = only_unique_pairs
-        self.pairlist = Pairlist(cutoff, only_unique_pairs)
+        self.pairlist = Pairlist(only_unique_pairs)
         self.register_buffer("cutoff", torch.tensor(cutoff))
+
+    def calculate_r_ij(
+        self, pair_indices: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        """Compute displacement vectors between atom pairs.
+
+        Parameters
+        ----------
+        pair_indices : torch.Tensor
+            Atom indices for pairs of atoms. Shape: [2, n_pairs].
+        positions : torch.Tensor
+            Atom positions. Shape: [atoms, 3].
+
+        Returns
+        -------
+        torch.Tensor
+            Displacement vectors between atom pairs. Shape: [n_pairs, 3].
+        """
+        # Select the pairs of atom coordinates from the positions
+        selected_positions = positions.index_select(0, pair_indices.view(-1)).view(
+            2, -1, 3
+        )
+        return selected_positions[1] - selected_positions[0]
+
+    def calculate_d_ij(self, r_ij: torch.Tensor) -> torch.Tensor:
+        """
+        ompute Euclidean distances between atoms in each pair.
+
+        Parameters
+        ----------
+        r_ij : torch.Tensor
+            Displacement vectors between atoms in a pair. Shape: [n_pairs, 3].
+
+        Returns
+        -------
+        torch.Tensor
+            Euclidean distances. Shape: [n_pairs, 1].
+        """
+        return r_ij.norm(dim=1).unsqueeze(1)
 
     def _calculate_interacting_pairs(
         self,
         positions: torch.Tensor,
         atomic_subsystem_indices: torch.Tensor,
-        pair_indices: Optional[torch.Tensor] = None,
+        pair_indices: torch.Tensor,
     ) -> PairlistData:
         """
         Compute the neighbor list considering a cutoff distance.
@@ -529,25 +844,30 @@ class NeighborForlistTraining(torch.nn.Module):
         atomic_subsystem_indices = data.atomic_subsystem_indices
         # calculate pairlist if none is provided
         if data.pair_list is None:
+            # note, we set the flag for unique pairs when instantiated in the constructor
+            # and thus this call will return unique pairs if requested.
             pair_list = self.pairlist.enumerate_all_pairs(atomic_subsystem_indices)
 
         else:
-            # pairlist is provided, remove redundant pairs if requested
+            pair_list = data.pair_list
+
+            # when we precompute the pairlist, we included all pairs, including non-unique
+            # since we do this before we know about which potential we are using
+            # and whether we require unique pairs or not
+            # thus, if the pairlist is provided we need to remove redundant pairs if requested
             if self.only_unique_pairs:
-                i_indices = data.pair_list[0]
-                j_indices = data.pair_list[1]
+                i_indices = pair_list[0]
+                j_indices = pair_list[1]
                 unique_pairs_mask = i_indices < j_indices
                 i_final_pairs = i_indices[unique_pairs_mask]
                 j_final_pairs = j_indices[unique_pairs_mask]
                 pair_list = torch.stack((i_final_pairs, j_final_pairs))
-            else:
-                pair_list = data.pair_list
-            # only calculate d_ij and r_ij
-            pairlist_output = self.calculate_distances_and_pairlist(
-                positions=positions,
-                atomic_subsystem_indices=atomic_subsystem_indices,
-                pair_indices=pair_list.to(torch.int64),
-            )
+
+        pairlist_output = self._calculate_interacting_pairs(
+            positions=positions,
+            atomic_subsystem_indices=atomic_subsystem_indices,
+            pair_indices=pair_list.to(torch.int64),
+        )
 
         return pairlist_output
 

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -9,7 +9,8 @@ import torch.nn as nn
 from loguru import logger as log
 from openff.units import unit
 
-from .models import NNPInputTuple, PairlistData
+from modelforge.dataset.dataset import NNPInputTuple
+from modelforge.potential.neighbors import PairlistData
 from .utils import DenseWithCustomDist
 
 

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -8,7 +8,8 @@ import torch
 from loguru import logger as log
 from torch import nn
 
-from .models import NNPInputTuple, PairlistData
+from modelforge.dataset.dataset import NNPInputTuple
+from modelforge.potential.neighbors import PairlistData
 from .utils import Dense
 
 

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -8,7 +8,9 @@ import torch
 import torch.nn as nn
 from loguru import logger as log
 
-from .models import NNPInputTuple, PairlistData
+from modelforge.dataset.dataset import NNPInputTuple
+from modelforge.potential.neighbors import PairlistData
+
 from .utils import DenseWithCustomDist, scatter_softmax
 from .representation import PhysNetRadialBasisFunction
 

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -8,7 +8,8 @@ import torch
 import torch.nn as nn
 from loguru import logger as log
 
-from .models import NNPInputTuple, PairlistData
+from modelforge.dataset.dataset import NNPInputTuple
+from modelforge.potential.neighbors import PairlistData
 
 
 class SchNetCore(torch.nn.Module):

--- a/modelforge/potential/tensornet.py
+++ b/modelforge/potential/tensornet.py
@@ -7,10 +7,10 @@ from typing import Dict, List, Tuple
 import torch
 from torch import nn
 
-from modelforge.dataset import NNPInputTuple
 from modelforge.potential import CosineAttenuationFunction, TensorNetRadialBasisFunction
 
-from .models import PairlistData
+from modelforge.dataset.dataset import NNPInputTuple
+from modelforge.potential.neighbors import PairlistData
 
 
 class DenseAndSum(nn.Module):


### PR DESCRIPTION
## Pull Request Summary
This relates to some of the changes suggested in Issue #269.  Specifically, this streamlines the Neighborlist for training.  The code has changed quite a bit since these initial classes had been sketched out, and this should hopefully make things clearer and make the code easier to read.  This also will reduce the need to massage the config dict inputs related to the neighbor list cutoff that currently needs to be done.  

### Key changes
Notable points that this PR has either accomplished or will accomplish.
 - [ ] The key logic used in what had been the `NeighborList` class is merged in the `CalculateInteractingPairs` class.  
 - [ ]  The `Neighborlist` class has been removed.
 - [ ] `CalculateInteractingPairs` is renamed `NeighborListForTraining` and moved to the neighbors.py file
 - [ ] The `PairList` class has been moved to the neighbors.py file



### Associated Issue(s)
 - [ ] #269

## Pull Request Checklist
 - [ ] Issue(s) raised/addressed and linked
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) added/updated
 - [ ] Appropriate .rst doc file(s) added/updated
 - [ ] PR is ready for review