### PR TITLE
Speeding up CI using pytest-xdist

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Run tests
         # conda setup requires this special shell
         run: |
-          pytest -n {matrix.nprocs} --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
+          pytest -n {matrix.n_procs} --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
 
       - name: CodeCov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Run tests
         # conda setup requires this special shell
         run: |
-          pytest -n {matrix.n_procs} --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
+          pytest -n ${{matrix.n_procs}} --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
 
       - name: CodeCov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,6 +35,11 @@ jobs:
       matrix:
         os: [macOS-latest, ubuntu-latest]
         python-version: ["3.10", "3.11"]
+        include:
+          - os: ubuntu-latest
+            n_procs: 4
+          - os: macOS-latest
+            n_procs: 0
 
     steps:
       - uses: actions/checkout@v3
@@ -73,7 +78,7 @@ jobs:
       - name: Run tests
         # conda setup requires this special shell
         run: |
-          pytest -n 8 --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
+          pytest -n {matrix.nprocs} --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
 
       - name: CodeCov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         # conda setup requires this special shell
         run: |
-          pytest -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
+          pytest -n auto --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
 
       - name: CodeCov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         # conda setup requires this special shell
         run: |
-          pytest -n auto --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
+          pytest -n 8 --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
 
       - name: CodeCov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,7 +37,7 @@ jobs:
         python-version: ["3.10", "3.11"]
         include:
           - os: ubuntu-latest
-            n_procs: 4
+            n_procs: auto
           - os: macOS-latest
             n_procs: 0
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -40,4 +40,5 @@ dependencies:
       - git+https://github.com/ArnNag/sake.git@nanometer
       - flax
       - torch
+      - pytest-xdist
 

--- a/devtools/conda-envs/test_env_mac.yaml
+++ b/devtools/conda-envs/test_env_mac.yaml
@@ -40,3 +40,4 @@ dependencies:
       - git+https://github.com/ArnNag/sake.git@nanometer
       - jax
       - flax
+      - pytest-xdist

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -1692,7 +1692,7 @@ def initialize_datamodule(
     return data_module
 
 
-def single_batch(batch_size: int = 64, dataset_name="QM9"):
+def single_batch(batch_size: int = 64, dataset_name="QM9", local_cache_dir="./"):
     """
     Utility function to create a single batch of data for testing.
     """
@@ -1700,6 +1700,7 @@ def single_batch(batch_size: int = 64, dataset_name="QM9"):
         dataset_name=dataset_name,
         batch_size=batch_size,
         version_select="nc_1000_v0",
+        local_cache_dir=local_cache_dir,
     )
     return next(iter(data_module.train_dataloader(shuffle=False)))
 

--- a/modelforge/dataset/phalkethoh.py
+++ b/modelforge/dataset/phalkethoh.py
@@ -92,6 +92,7 @@ class PhAlkEthOHDataset(HDF5Dataset):
             "dft_total_energy",
             "dft_total_force",
             "total_charge",
+            "scf_dipole",
         ]  # NOTE: Default values
 
         self._properties_of_interest = _default_properties_of_interest

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -70,14 +70,14 @@ def single_batch_with_batchsize():
     return _create_single_batch
 
 
-@pytest.fixture(scope="session")
-def prep_temp_dir(tmp_path_factory):
-    import uuid
-
-    filename = str(uuid.uuid4())
-
-    tmp_path_factory.mktemp(f"dataset_test/")
-    return f"dataset_test"
+# @pytest.fixture(scope="session")
+# def prep_temp_dir(tmp_path_factory):
+#     import uuid
+#
+#     filename = str(uuid.uuid4())
+#
+#     tmp_path_factory.mktemp(f"dataset_test/")
+#     return f"dataset_test"
 
 
 @dataclass

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -60,8 +60,12 @@ def single_batch_with_batchsize():
     Utility fixture to create a single batch of data for testing.
     """
 
-    def _create_single_batch(batch_size: int, dataset_name: str):
-        return single_batch(batch_size=batch_size, dataset_name=dataset_name)
+    def _create_single_batch(batch_size: int, dataset_name: str, local_cache_dir: str):
+        return single_batch(
+            batch_size=batch_size,
+            dataset_name=dataset_name,
+            local_cache_dir=local_cache_dir,
+        )
 
     return _create_single_batch
 

--- a/modelforge/tests/test_aimnet2.py
+++ b/modelforge/tests/test_aimnet2.py
@@ -5,6 +5,12 @@ from openff.units import unit
 from modelforge.tests.helper_functions import setup_potential_for_test
 
 
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("test_aimnet2_temp")
+    return fn
+
+
 def test_initialize_model():
     """Test initialization of the Schnet model."""
 
@@ -130,13 +136,13 @@ def test_radial_symmetry_function_regression():
     assert torch.allclose(modelforge_aimnet2_outputs, regression_outputs, atol=1e-4)
 
 
-def test_forward(single_batch_with_batchsize):
+def test_forward(single_batch_with_batchsize, prep_temp_dir):
     """Test initialization of the AIMNet2 model."""
     # read default parameters
     aimnet = setup_potential_for_test("aimnet2", "training")
 
     assert aimnet is not None, "Aimnet model should be initialized."
-    batch = single_batch_with_batchsize(64, "QM9")
+    batch = single_batch_with_batchsize(64, "QM9", str(prep_temp_dir))
 
     y_hat = aimnet(batch.nnp_input_tuple)
 

--- a/modelforge/tests/test_curation.py
+++ b/modelforge/tests/test_curation.py
@@ -127,6 +127,15 @@ def test_dict_to_hdf5(prep_temp_dir):
             id_key="name",
         )
 
+    # test.hdf5 was generated in test_dict_to_hdf5
+    files = list_files(str(prep_temp_dir), ".hdf5")
+
+    # check to see if test.hdf5 is in the files
+    assert "test.hdf5" in files
+
+    with pytest.raises(Exception):
+        list_files("/path/that/should/not/exist/", ".hdf5")
+
 
 def test_series_dict_to_hdf5(prep_temp_dir):
     # generate an hdf5 file from simple test data
@@ -213,17 +222,6 @@ def test_series_dict_to_hdf5(prep_temp_dir):
                     assert record_m == test_data_m
             else:
                 assert records[i][key] == test_data[i][key]
-
-
-def test_list_files(prep_temp_dir):
-    # test.hdf5 was generated in test_dict_to_hdf5
-    files = list_files(str(prep_temp_dir), ".hdf5")
-
-    # check to see if test.hdf5 is in the files
-    assert "test.hdf5" in files
-
-    with pytest.raises(Exception):
-        list_files("/path/that/should/not/exist/", ".hdf5")
 
 
 def test_str_to_float(prep_temp_dir):

--- a/modelforge/tests/test_nn.py
+++ b/modelforge/tests/test_nn.py
@@ -1,14 +1,23 @@
 from .test_models import load_configs_into_pydantic_models
+import pytest
 
 
-def test_embedding(single_batch_with_batchsize):
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("test_nn_temp")
+    return fn
+
+
+def test_embedding(single_batch_with_batchsize, prep_temp_dir):
     # test the input featurization, including:
     # - nuclear charge embedding
     # - total charge mixing
 
     import torch  # noqa: F401
 
-    batch = single_batch_with_batchsize(batch_size=64, dataset_name="QM9")
+    batch = single_batch_with_batchsize(
+        batch_size=64, dataset_name="QM9", local_cache_dir=str(prep_temp_dir)
+    )
 
     nnp_input = batch.nnp_input
     model_name = "SchNet"

--- a/modelforge/tests/test_painn.py
+++ b/modelforge/tests/test_painn.py
@@ -1,5 +1,12 @@
 import torch
 from modelforge.potential import NeuralNetworkPotentialFactory
+import pytest
+
+
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("test_painn_temp")
+    return fn
 
 
 def setup_painn_model(potential_seed: int):
@@ -27,11 +34,13 @@ def setup_painn_model(potential_seed: int):
     return trainer_painn
 
 
-def test_forward(single_batch_with_batchsize):
+def test_forward(single_batch_with_batchsize, prep_temp_dir):
     """Test initialization of the PaiNN neural network potential."""
     trainer_painn = setup_painn_model(42)
     assert trainer_painn is not None, "PaiNN model should be initialized."
-    batch = batch = single_batch_with_batchsize(batch_size=64, dataset_name="QM9")
+    batch = single_batch_with_batchsize(
+        batch_size=64, dataset_name="QM9", local_cache_dir=str(prep_temp_dir)
+    )
 
     nnp_input = batch.to(dtype=torch.float32).nnp_input_tuple
     energy = trainer_painn(nnp_input)["per_molecule_energy"]

--- a/modelforge/tests/test_physnet.py
+++ b/modelforge/tests/test_physnet.py
@@ -1,7 +1,13 @@
 from typing import Optional
-
+import pytest
 
 from modelforge.tests.helper_functions import setup_potential_for_test
+
+
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("test_physnet_temp")
+    return fn
 
 
 def test_init():
@@ -10,12 +16,14 @@ def test_init():
     assert model is not None, "PhysNet model should be initialized."
 
 
-def test_forward(single_batch_with_batchsize):
+def test_forward(single_batch_with_batchsize, prep_temp_dir):
     import torch
 
     model = setup_potential_for_test("physnet", "training")
     print(model)
-    batch = batch = single_batch_with_batchsize(batch_size=64, dataset_name="QM9")
+    batch = single_batch_with_batchsize(
+        batch_size=64, dataset_name="QM9", local_cache_dir=str(prep_temp_dir)
+    )
 
     yhat = model(batch.nnp_input.to(dtype=torch.float32))
 

--- a/modelforge/tests/test_pt_lightning.py
+++ b/modelforge/tests/test_pt_lightning.py
@@ -1,4 +1,13 @@
-def test_datamodule():
+import pytest
+
+
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("test_pt_temp")
+    return fn
+
+
+def test_datamodule(prep_temp_dir):
     # This is an example script that trains an implemented model on the QM9 dataset.
     from modelforge.dataset.dataset import DataModule
 
@@ -7,4 +16,5 @@ def test_datamodule():
     dm = DataModule(
         name="QM9",
         batch_size=512,
+        local_cache_dir=str(prep_temp_dir),
     )

--- a/modelforge/tests/test_remote.py
+++ b/modelforge/tests/test_remote.py
@@ -8,7 +8,7 @@ from modelforge.utils.remote import *
 
 @pytest.fixture(scope="session")
 def prep_temp_dir(tmp_path_factory):
-    fn = tmp_path_factory.mktemp("remote_test")
+    fn = tmp_path_factory.mktemp("test_remote_temp")
     return fn
 
 

--- a/modelforge/tests/test_sake.py
+++ b/modelforge/tests/test_sake.py
@@ -14,6 +14,12 @@ from modelforge.tests.helper_functions import setup_potential_for_test
 ON_MAC = platform == "darwin"
 
 
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("test_sake_temp")
+    return fn
+
+
 def test_init():
     """Test initialization of the SAKE neural network potential."""
 
@@ -25,12 +31,14 @@ def test_init():
 from openff.units import unit
 
 
-def test_forward(single_batch_with_batchsize):
+def test_forward(single_batch_with_batchsize, prep_temp_dir):
     """
     Test the forward pass of the SAKE model.
     """
     # get methane input
-    batch = single_batch_with_batchsize(batch_size=64, dataset_name="QM9")
+    batch = single_batch_with_batchsize(
+        batch_size=64, dataset_name="QM9", local_cache_dir=str(prep_temp_dir)
+    )
     methane = batch.nnp_input
 
     sake = setup_potential_for_test("sake", "training")
@@ -74,7 +82,9 @@ def test_interaction_forward():
 
 @pytest.mark.parametrize("eq_atol", [3e-1])
 @pytest.mark.parametrize("h_atol", [8e-2])
-def test_layer_equivariance(h_atol, eq_atol, single_batch_with_batchsize):
+def test_layer_equivariance(
+    h_atol, eq_atol, single_batch_with_batchsize, prep_temp_dir
+):
     from dataclasses import replace
 
     import torch
@@ -89,7 +99,9 @@ def test_layer_equivariance(h_atol, eq_atol, single_batch_with_batchsize):
     sake = setup_potential_for_test("sake", "training")
 
     # get methane input
-    batch = single_batch_with_batchsize(batch_size=64, dataset_name="QM9")
+    batch = single_batch_with_batchsize(
+        batch_size=64, dataset_name="QM9", local_cache_dir=str(prep_temp_dir)
+    )
 
     nnp_input = batch.nnp_input
     perturbed_nnp_input = replace(nnp_input)
@@ -388,12 +400,14 @@ def test_sake_layer_against_reference(include_self_pairs, v_is_none):
 import pytest
 
 
-def test_model_invariance(single_batch_with_batchsize):
+def test_model_invariance(single_batch_with_batchsize, prep_temp_dir):
     from dataclasses import replace
 
     sake = setup_potential_for_test("sake", "training")
     # get methane input
-    batch = single_batch_with_batchsize(batch_size=1, dataset_name="QM9")
+    batch = single_batch_with_batchsize(
+        batch_size=1, dataset_name="QM9", local_cache_dir=str(prep_temp_dir)
+    )
     methane = batch.nnp_input
 
     rotation_matrix = torch.tensor([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])

--- a/modelforge/tests/test_tensornet.py
+++ b/modelforge/tests/test_tensornet.py
@@ -3,6 +3,12 @@ import pytest
 from modelforge.tests.helper_functions import setup_potential_for_test
 
 
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("test_physnet_temp")
+    return fn
+
+
 def test_init():
     """Test initialization of the TensorNet model."""
 
@@ -19,10 +25,12 @@ def test_init():
 
 @pytest.mark.parametrize("simulation_environment", ["PyTorch", "JAX"])
 def test_forward_with_inference_model(
-    simulation_environment, single_batch_with_batchsize
+    simulation_environment, single_batch_with_batchsize, prep_temp_dir
 ):
 
-    batch = single_batch_with_batchsize(batch_size=32, dataset_name="QM9")
+    batch = single_batch_with_batchsize(
+        batch_size=32, dataset_name="QM9", local_cache_dir=str(prep_temp_dir)
+    )
 
     # load default parameters
     model = setup_potential_for_test(

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -10,7 +10,15 @@ IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 from modelforge.potential import NeuralNetworkPotentialFactory, _Implemented_NNPs
 
 
-def load_configs_into_pydantic_models(potential_name: str, dataset_name: str):
+@pytest.fixture(scope="session")
+def prep_temp_dir(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("test_training_temp")
+    return fn
+
+
+def load_configs_into_pydantic_models(
+    potential_name: str, dataset_name: str, local_cache_dir: str
+):
     from importlib import resources
 
     import toml
@@ -50,6 +58,7 @@ def load_configs_into_pydantic_models(potential_name: str, dataset_name: str):
     training_parameters = TrainingParameters(**training_config_dict["training"])
     runtime_parameters = RuntimeParameters(**runtime_config_dict["runtime"])
 
+    runtime_parameters.local_cache_dir = local_cache_dir
     return {
         "potential": potential_parameters,
         "dataset": dataset_parameters,
@@ -134,6 +143,7 @@ def replace_per_molecule_with_per_atom_loss(config):
     t_config.lr_scheduler.monitor = "val/per_molecule_energy/rmse"
 
 
+@pytest.mark.xdist_group(name="test_training_with_lightning")
 @pytest.mark.skipif(ON_MACOS, reason="Skipping this test on MacOS GitHub Actions")
 @pytest.mark.parametrize(
     "potential_name", _Implemented_NNPs.get_all_neural_network_names()
@@ -143,7 +153,7 @@ def replace_per_molecule_with_per_atom_loss(config):
     "loss",
     ["energy", "energy_force", "normalized_energy_force", "energy_force_dipole_moment"],
 )
-def test_train_with_lightning(loss, potential_name, dataset_name):
+def test_train_with_lightning(loss, potential_name, dataset_name, prep_temp_dir):
     """
     Test that we can train, save and load checkpoints.
     """
@@ -156,7 +166,9 @@ def test_train_with_lightning(loss, potential_name, dataset_name):
             "Skipping Sake training with forces on GitHub Actions because it allocates too much memory"
         )
 
-    config = load_configs_into_pydantic_models(potential_name, dataset_name)
+    config = load_configs_into_pydantic_models(
+        potential_name, dataset_name, str(prep_temp_dir)
+    )
 
     if "force" in loss:
         add_force_to_loss_parameter(config)
@@ -171,7 +183,7 @@ def test_train_with_lightning(loss, potential_name, dataset_name):
     get_trainer(config).train_potential()
 
 
-def test_train_from_single_toml_file():
+def test_train_from_single_toml_file(prep_temp_dir):
     from importlib import resources
 
     from modelforge.tests import data
@@ -179,10 +191,10 @@ def test_train_from_single_toml_file():
 
     config_path = resources.files(data) / f"config.toml"
 
-    read_config_and_train(config_path)
+    read_config_and_train(config_path, local_cache_dir=str(prep_temp_dir))
 
 
-def test_error_calculation(single_batch_with_batchsize):
+def test_error_calculation(single_batch_with_batchsize, prep_temp_dir):
     # test the different Loss classes
     from modelforge.train.losses import (
         ForceSquaredError,
@@ -190,7 +202,9 @@ def test_error_calculation(single_batch_with_batchsize):
     )
 
     # generate data
-    batch = single_batch_with_batchsize(batch_size=16, dataset_name="PHALKETHOH")
+    batch = single_batch_with_batchsize(
+        batch_size=16, dataset_name="PHALKETHOH", local_cache_dir=str(prep_temp_dir)
+    )
 
     data = batch
     true_E = data.metadata.E
@@ -237,14 +251,18 @@ def test_error_calculation(single_batch_with_batchsize):
     assert torch.allclose(torch.mean(F_error), reference_F_error)
 
 
-def test_loss_with_dipole_moment(single_batch_with_batchsize):
+def test_loss_with_dipole_moment(single_batch_with_batchsize, prep_temp_dir):
 
     # Generate a batch with the specified batch size and dataset
-    batch = single_batch_with_batchsize(batch_size=16, dataset_name="SPICE2")
+    batch = single_batch_with_batchsize(
+        batch_size=16, dataset_name="SPICE2", local_cache_dir=str(prep_temp_dir)
+    )
 
     # Get the trainer object with the specified model and dataset
     config = load_configs_into_pydantic_models(
-        potential_name="schnet", dataset_name="SPICE2"
+        potential_name="schnet",
+        dataset_name="SPICE2",
+        local_cache_dir=str(prep_temp_dir),
     )
     add_dipole_moment_to_loss_parameter(config)
     add_force_to_loss_parameter(config)
@@ -314,10 +332,12 @@ def test_loss_with_dipole_moment(single_batch_with_batchsize):
     ).all(), "Total loss contains non-finite values."
 
 
-def test_loss(single_batch_with_batchsize):
+def test_loss(single_batch_with_batchsize, prep_temp_dir):
     from modelforge.train.losses import Loss
 
-    batch = single_batch_with_batchsize(batch_size=16, dataset_name="PHALKETHOH")
+    batch = single_batch_with_batchsize(
+        batch_size=16, dataset_name="PHALKETHOH", local_cache_dir=str(prep_temp_dir)
+    )
 
     loss_porperty = ["per_molecule_energy", "per_atom_force", "per_atom_energy"]
     loss_weights = {
@@ -330,7 +350,7 @@ def test_loss(single_batch_with_batchsize):
 
     # Get the trainer object with the specified model and dataset
     config = load_configs_into_pydantic_models(
-        potential_name="schnet", dataset_name="QM9"
+        potential_name="schnet", dataset_name="QM9", local_cache_dir=str(prep_temp_dir)
     )
     add_force_to_loss_parameter(config)
 

--- a/modelforge/tests/test_utils.py
+++ b/modelforge/tests/test_utils.py
@@ -10,7 +10,7 @@ IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 @pytest.fixture(scope="session")
 def prep_temp_dir(tmp_path_factory):
-    fn = tmp_path_factory.mktemp("utils_test")
+    fn = tmp_path_factory.mktemp("test_utils_temp")
     return fn
 
 


### PR DESCRIPTION
## Pull Request Summary
The CI is taking quite a long time to run (about 45 minutes).  This aims to speed this up using pytest-xdist, which will allow concurrent execution of tests.  To do this though, we need to make sure our tests will not be in conflict (make sure any files being written out/read have unique names, making sure all unique test files are at minimum using their own unique temp directories). 

Edit: actual numbers from the last merge into main:

- ubuntu 3.11: 44m 16s
- ubtuntu 3.10: 44m 23s
- macOS 3.11: 53m 30s
- macOS 3.10: 48m 42s


### Associated Issue(s)
 - [x] #277

## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [x] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review