### PR TITLE
Normalize loss components

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -177,7 +177,7 @@ Here is an example of a training routine definition:
     interval = "epoch"  # Interval for learning rate updates (per epoch)
 
     [training.loss_parameter]
-    loss_property = ['per_molecule_energy', 'per_atom_force']  # Properties to include in the loss function
+    loss_components = ['per_molecule_energy', 'per_atom_force']  # Properties to include in the loss function
 
     [training.loss_parameter.weight]
     per_molecule_energy = 0.999  # Weight for per molecule energy in the loss calculation

--- a/docs/training.rst
+++ b/docs/training.rst
@@ -37,9 +37,9 @@ Loss function
 ^^^^^^^^^^^^^^^^^^^^^^^^
 The loss function quantifies the discrepancy between the model's predictions and the target properties, providing a scalar value that guides the optimizer in updating the model's parameters. This function is configured in the `[training.loss]` section of the training TOML file.
 
-Depending on the specified `loss_property`` section, the loss function can combine various individual loss functions. *Modelforge* always includes the mean squared error (MSE) for energy prediction, and may also incorporate MSE for force prediction, dipole moment prediction, and partial charge prediction.
+Depending on the specified `loss_components`` section, the loss function can combine various individual loss functions. *Modelforge* always includes the mean squared error (MSE) for energy prediction, and may also incorporate MSE for force prediction, dipole moment prediction, and partial charge prediction.
 
-The design of the loss function is intrinsically linked to the structure of the energy function. For instance, if the energy function aggregates atomic energies, then loss_property should include `per_molecule_energy` and optionally, `per_atom_force`.
+The design of the loss function is intrinsically linked to the structure of the energy function. For instance, if the energy function aggregates atomic energies, then loss_components should include `per_molecule_energy` and optionally, `per_atom_force`.
 
 
 Predicting Short-Range Atomic Energies

--- a/modelforge/tests/data/config.toml
+++ b/modelforge/tests/data/config.toml
@@ -60,8 +60,8 @@ threshold_mode = "abs"
 interval = "epoch"
 
 [training.loss_parameter]
-loss_property = ['per_molecule_energy', 'per_atom_force'] # use
-
+loss_components = ['per_molecule_energy', 'per_atom_force'] # use
+normalize = false
 [training.loss_parameter.weight]
 per_molecule_energy = 0.999 #NOTE: reciprocal units
 per_atom_force = 0.001

--- a/modelforge/tests/data/training_defaults/default.toml
+++ b/modelforge/tests/data/training_defaults/default.toml
@@ -4,7 +4,7 @@ remove_self_energies = true
 shift_center_of_mass_to_origin = false
 batch_size = 128
 lr = 5e-4
-monitor = "val/per_molecule_energy/rmse"  # Common monitor key
+monitor = "val/per_molecule_energy/rmse" # Common monitor key
 # ------------------------------------------------------------ #
 [training.experiment_logger]
 logger_name = "tensorboard" # this will set which logger to use
@@ -32,11 +32,10 @@ threshold_mode = "abs"
 interval = "epoch"
 # ------------------------------------------------------------ #
 [training.loss_parameter]
-loss_property = ['per_molecule_energy'] #, 'per_atom_force'] # use
-# ------------------------------------------------------------ #
+loss_components = ['per_molecule_energy']
+normalize = false
 [training.loss_parameter.weight]
-per_molecule_energy = 1.0 #NOTE: reciprocal units
-#per_atom_force = 0.001
+per_molecule_energy = 1.0
 # ------------------------------------------------------------ #
 [training.early_stopping]
 verbose = true

--- a/modelforge/tests/test_parameter_models.py
+++ b/modelforge/tests/test_parameter_models.py
@@ -142,9 +142,9 @@ def test_training_parameter_model():
     with pytest.raises(ValidationError):
         training_parameters.splitting_strategy.dataset_split = [0.7, 0.1, 0.1, 0.1]
 
-    # this will throw an error because the datafile has 1 entries for the loss_property dictionary
+    # this will throw an error because the datafile has 1 entries for the loss_components dictionary
     with pytest.raises(ValidationError):
-        training_parameters.loss_parameter.loss_property = [
+        training_parameters.loss_parameter.loss_components = [
             "per_molecule_energy",
             "per_atom_force",
         ]

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -321,6 +321,11 @@ def test_loss_with_dipole_moment(single_batch_with_batchsize, prep_temp_dir):
         loss_dict["per_molecule_dipole_moment"]
     ).all(), "Dipole moment loss contains non-finite values."
 
+    # check that only the total loss has gradient information
+    assert loss_dict["total_loss"].requires_grad
+    assert not loss_dict["per_molecule_total_charge"].requires_grad
+    assert not loss_dict["per_molecule_dipole_moment"].requires_grad
+
     # Optionally, print or log the losses for debugging
     print("Total Charge Loss:", loss_dict["per_molecule_total_charge"].mean().item())
     print("Dipole Moment Loss:", loss_dict["per_molecule_dipole_moment"].mean().item())

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -87,7 +87,7 @@ def get_trainer(config):
 def add_force_to_loss_parameter(config):
     """
     [training.loss_parameter]
-    loss_property = ['per_molecule_energy', 'per_atom_force']
+    loss_components = ['per_molecule_energy', 'per_atom_force']
     # ------------------------------------------------------------ #
     [training.loss_parameter.weight]
     per_molecule_energy = 0.999 #NOTE: reciprocal units
@@ -95,14 +95,14 @@ def add_force_to_loss_parameter(config):
 
     """
     t_config = config["training"]
-    t_config.loss_parameter.loss_property.append("per_atom_force")
+    t_config.loss_parameter.loss_components.append("per_atom_force")
     t_config.loss_parameter.weight["per_atom_force"] = 0.001
 
 
 def add_dipole_moment_to_loss_parameter(config):
     """
     [training.loss_parameter]
-    loss_property = [
+    loss_components = [
         "per_molecule_energy",
         "per_atom_force",
         "per_molecule_dipole_moment",
@@ -116,8 +116,8 @@ def add_dipole_moment_to_loss_parameter(config):
 
     """
     t_config = config["training"]
-    t_config.loss_parameter.loss_property.append("per_molecule_dipole_moment")
-    t_config.loss_parameter.loss_property.append("per_molecule_total_charge")
+    t_config.loss_parameter.loss_components.append("per_molecule_dipole_moment")
+    t_config.loss_parameter.loss_components.append("per_molecule_total_charge")
     t_config.loss_parameter.weight["per_molecule_dipole_moment"] = 0.01
     t_config.loss_parameter.weight["per_molecule_total_charge"] = 0.01
 
@@ -130,8 +130,8 @@ def add_dipole_moment_to_loss_parameter(config):
 
 def replace_per_molecule_with_per_atom_loss(config):
     t_config = config["training"]
-    t_config.loss_parameter.loss_property.remove("per_molecule_energy")
-    t_config.loss_parameter.loss_property.append("per_atom_energy")
+    t_config.loss_parameter.loss_components.remove("per_molecule_energy")
+    t_config.loss_parameter.loss_components.append("per_atom_energy")
 
     t_config.loss_parameter.weight.pop("per_molecule_energy")
     t_config.loss_parameter.weight["per_atom_energy"] = 0.999

--- a/modelforge/train/losses.py
+++ b/modelforge/train/losses.py
@@ -412,19 +412,26 @@ class Loss(nn.Module):
                 predict_target[f"{prop_}_true"],
                 batch,
             )
+
+
             # Accumulate weighted per-sample losses
             weighted_loss = self.weights[prop] * prop_loss
-
             total_loss += weighted_loss  # Note: total_loss is still per-sample
+
             if self.normalize:
+                # Normalize the loss by the mean of the loss
                 normalized_loss += self.weights[prop] * (
                     prop_loss.mean() / prop_loss.detach().mean()
                 )
-                loss_dict[prop] = prop_loss  # Store per-sample loss
+
+            # save the loss for the property
+            loss_dict[prop] = prop_loss.detach()  # Store per-sample loss
+
 
         # Add total loss to results dict and return
         loss_dict["total_loss"] = total_loss
         if self.normalize:
+            # add normalized total loss to results dict
             loss_dict["normalized_total_loss"] = normalized_loss
 
         return loss_dict

--- a/modelforge/train/losses.py
+++ b/modelforge/train/losses.py
@@ -413,7 +413,6 @@ class Loss(nn.Module):
                 batch,
             )
 
-
             # Accumulate weighted per-sample losses
             weighted_loss = self.weights[prop] * prop_loss
             total_loss += weighted_loss  # Note: total_loss is still per-sample
@@ -426,7 +425,6 @@ class Loss(nn.Module):
 
             # save the loss for the property
             loss_dict[prop] = prop_loss.detach()  # Store per-sample loss
-
 
         # Add total loss to results dict and return
         loss_dict["total_loss"] = total_loss

--- a/modelforge/train/parameters.py
+++ b/modelforge/train/parameters.py
@@ -164,23 +164,24 @@ class TrainingParameters(ParametersBase):
         class to hold the loss properties
 
         args:
-            loss_property (List[str]): The loss property.
+            loss_components (List[str]): The loss property.
                 The length of this list must match the length of loss_weight
             weight (Dict[str,float]): The loss weight.
-                The keys must correspond to entries in the loss_property list.
+                The keys must correspond to entries in the loss_components list.
 
         """
 
-        loss_property: List
+        loss_components: List
         weight: Dict[str, float]
+        normalize: bool
 
         @model_validator(mode="after")
         def ensure_length_match(self) -> "LossParameter":
-            loss_property = self.loss_property
+            loss_components = self.loss_components
             loss_weight = self.weight
-            if len(loss_property) != len(loss_weight):
+            if len(loss_components) != len(loss_weight):
                 raise ValueError(
-                    f"The length of loss_property ({len(loss_property)}) and weight ({len(loss_weight)}) must match."
+                    f"The length of loss_components ({len(loss_components)}) and weight ({len(loss_weight)}) must match."
                 )
             return self
 
@@ -279,7 +280,7 @@ class TrainingParameters(ParametersBase):
 
     @model_validator(mode="after")
     def validate_dipole_and_shift_com(self):
-        if "dipole_moment" in self.loss_parameter.loss_property:
+        if "dipole_moment" in self.loss_parameter.loss_components:
             if not self.shift_center_of_mass_to_origin:
                 raise ValueError(
                     "Use of dipole_moment in the loss requires shift_center_of_mass_to_origin to be True"

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -356,11 +356,11 @@ class TrainingAdapter(pL.LightningModule):
         )
 
         self.include_force = (
-            "per_atom_force" in training_parameter.loss_parameter.loss_property
+            "per_atom_force" in training_parameter.loss_parameter.loss_components
         )
 
         self.calculate_predictions = CalculateProperties(
-            training_parameter.loss_parameter.loss_property
+            training_parameter.loss_parameter.loss_components
         )
         self.optimizer_class = training_parameter.optimizer
         self.learning_rate = training_parameter.lr
@@ -381,17 +381,17 @@ class TrainingAdapter(pL.LightningModule):
 
         # Initialize performance metrics
         self.test_metrics = create_error_metrics(
-            training_parameter.loss_parameter.loss_property
+            training_parameter.loss_parameter.loss_components
         )
         self.val_metrics = create_error_metrics(
-            training_parameter.loss_parameter.loss_property
+            training_parameter.loss_parameter.loss_components
         )
         self.train_metrics = create_error_metrics(
-            training_parameter.loss_parameter.loss_property
+            training_parameter.loss_parameter.loss_components
         )
 
         self.loss_metrics = create_error_metrics(
-            training_parameter.loss_parameter.loss_property, is_loss=True
+            training_parameter.loss_parameter.loss_components, is_loss=True
         )
 
     def forward(self, batch: BatchData) -> Dict[str, torch.Tensor]:
@@ -976,7 +976,7 @@ class ModelTrainer:
                 str(modelforge.__version__),
                 self.dataset_parameter.dataset_name,
                 self.potential_parameter.potential_name,
-                f"loss-{'-'.join(self.training_parameter.loss_parameter.loss_property)}",
+                f"loss-{'-'.join(self.training_parameter.loss_parameter.loss_components)}",
             ]
         )
         return tags

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -476,10 +476,14 @@ class TrainingAdapter(pL.LightningModule):
         # Update loss metrics with per-sample losses
         batch_size = batch.batch_size()
         for key, metric in loss_dict.items():
+            if key == "normalized_total_loss":
+                continue
             self.loss_metrics[key].update(metric.detach(), batch_size=batch_size)
 
         # Compute the mean loss for optimization
         mean_total_loss = loss_dict["total_loss"].mean()
+        if "normalized_total_loss" in loss_dict:
+            return loss_dict["normalized_total_loss"]
         return mean_total_loss
 
     def on_after_backward(self):

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -889,7 +889,7 @@ class ModelTrainer:
             benchmark=True,
             inference_mode=False,
             num_sanity_val_steps=2,
-            gradient_clip_val=10.0,  # FIXME: hardcoded for now
+            gradient_clip_val=1.0,  # FIXME: hardcoded for now
             log_every_n_steps=self.runtime_parameter.log_every_n_steps,
             enable_model_summary=True,
             enable_progress_bar=self.runtime_parameter.verbose,  # if true will show progress bar

--- a/scripts/config.toml
+++ b/scripts/config.toml
@@ -58,8 +58,8 @@ monitor = "val/per_molecule_energy/rmse"
 interval = "epoch"
 
 [training.loss_parameter]
-loss_property = ['per_molecule_energy', 'per_atom_force'] # use
-
+loss_components = ['per_molecule_energy', 'per_atom_force'] # use
+normalize = false
 [training.loss_parameter.weight]
 per_molecule_energy = 0.999 #NOTE: reciprocal units
 per_atom_force = 0.001


### PR DESCRIPTION
## Pull Request Summary

An easy way to normalize loss components is

$$
L = \sum_i \frac{L_i}{L_i^{\text{detached}}}
$$

which uses the componentwise loss and divides it by the detached value, scaling the loss to 1.

```
# Normalizing losses and combining them
combined_loss = loss_1 / loss_1.detach() + loss_2 / loss_2.detach()

# Backpropagation
combined_loss.backward()
```


### Key changes
Notable points that this PR has either accomplished or will accomplish.
 - [x] add an option to normalize the loss

### Associated Issue(s)
 - [x] issue #271 
## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [x] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review