### PR TITLE
Fixing NNPInput to allow us to write torch script models

### DIFF
--- a/modelforge/dataset/__init__.py
+++ b/modelforge/dataset/__init__.py
@@ -7,7 +7,7 @@ from .spice1 import SPICE1Dataset
 from .spice2 import SPICE2Dataset
 from .spice1openff import SPICE1OpenFFDataset
 from .phalkethoh import PhAlkEthOHDataset
-from .dataset import DatasetFactory, DataModule, NNPInput
+from .dataset import DatasetFactory, DataModule
 from enum import Enum
 
 

--- a/modelforge/jax.py
+++ b/modelforge/jax.py
@@ -47,12 +47,4 @@ def convert_NNPInput_to_jax(nnp_input: NNPInput):
         nnp_input.per_atom_partial_charge
     )
 
-    # if nnp_input.pair_list is not None:
-    #     nnp_input.pair_list = convert_to_jax(nnp_input.pair_list)
-    #
-    # if nnp_input.per_atom_partial_charge is not None:
-    #     nnp_input.per_atom_partial_charge = convert_to_jax(
-    #         nnp_input.per_atom_partial_charge
-    #     )
-
     return nnp_input

--- a/modelforge/jax.py
+++ b/modelforge/jax.py
@@ -1,4 +1,4 @@
-from modelforge.dataset import NNPInput
+from modelforge.utils.prop import NNPInput
 
 
 def nnpinput_flatten(nnpinput: NNPInput):

--- a/modelforge/jax.py
+++ b/modelforge/jax.py
@@ -42,12 +42,17 @@ def convert_NNPInput_to_jax(nnp_input: NNPInput):
     nnp_input.box_vectors = convert_to_jax(nnp_input.box_vectors)
     nnp_input.is_periodic = convert_to_jax(nnp_input.is_periodic)
 
-    if nnp_input.pair_list is not None:
-        nnp_input.pair_list = convert_to_jax(nnp_input.pair_list)
+    nnp_input.pair_list = convert_to_jax(nnp_input.pair_list)
+    nnp_input.per_atom_partial_charge = convert_to_jax(
+        nnp_input.per_atom_partial_charge
+    )
 
-    if nnp_input.per_atom_partial_charge is not None:
-        nnp_input.per_atom_partial_charge = convert_to_jax(
-            nnp_input.per_atom_partial_charge
-        )
+    # if nnp_input.pair_list is not None:
+    #     nnp_input.pair_list = convert_to_jax(nnp_input.pair_list)
+    #
+    # if nnp_input.per_atom_partial_charge is not None:
+    #     nnp_input.per_atom_partial_charge = convert_to_jax(
+    #         nnp_input.per_atom_partial_charge
+    #     )
 
     return nnp_input

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -12,9 +12,8 @@ import torch
 from loguru import logger as log
 from torch import nn
 
-from modelforge.utils.prop import SpeciesAEV
+from modelforge.utils.prop import SpeciesAEV, NNPInput
 
-from modelforge.dataset.dataset import NNPInput
 from modelforge.potential.neighbors import PairlistData
 
 

--- a/modelforge/potential/featurization.py
+++ b/modelforge/potential/featurization.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 from typing import Dict, List, Union
 
 from modelforge.potential.utils import DenseWithCustomDist
-from modelforge.dataset import NNPInput
+from modelforge.utils.prop import NNPInput
 
 
 class AddPerMoleculeValue(nn.Module):

--- a/modelforge/potential/neighbors.py
+++ b/modelforge/potential/neighbors.py
@@ -790,19 +790,14 @@ class NeighborListForTraining(torch.nn.Module):
             Atom positions. Shape: [nr_systems, nr_atoms, 3].
         atomic_subsystem_indices : torch.Tensor
             Indices identifying atoms in subsystems. Shape: [nr_atoms].
-        pair_indices : Optional[torch.Tensor]
-            Precomputed pair indices. If None, will compute pair indices.
+        pair_indices : torch.Tensor
+            Precomputed pair indices.
 
         Returns
         -------
         PairListOutputs
             A dataclass containing 'pair_indices', 'd_ij' (distances), and 'r_ij' (displacement vectors).
         """
-
-        if pair_indices is None:
-            pair_indices = self.enumerate_all_pairs(
-                atomic_subsystem_indices,
-            )
 
         r_ij = self.calculate_r_ij(pair_indices, positions)
         d_ij = self.calculate_d_ij(r_ij)
@@ -838,8 +833,9 @@ class NeighborListForTraining(torch.nn.Module):
         # general input manipulation
         positions = data.positions
         atomic_subsystem_indices = data.atomic_subsystem_indices
-        # calculate pairlist if none is provided
-        if data.pair_list is None:
+        # calculate pairlist if it is not provided
+
+        if data.pair_list is None or data.pair_list.shape[0] == 0:
             # note, we set the flag for unique pairs when instantiated in the constructor
             # and thus this call will return unique pairs if requested.
             pair_list = self.pairlist.enumerate_all_pairs(atomic_subsystem_indices)

--- a/modelforge/potential/painn.py
+++ b/modelforge/potential/painn.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 from loguru import logger as log
 from openff.units import unit
 
-from modelforge.dataset.dataset import NNPInput
+from modelforge.utils.prop import NNPInput
 from modelforge.potential.neighbors import PairlistData
 from .utils import DenseWithCustomDist
 

--- a/modelforge/potential/physnet.py
+++ b/modelforge/potential/physnet.py
@@ -8,7 +8,7 @@ import torch
 from loguru import logger as log
 from torch import nn
 
-from modelforge.dataset.dataset import NNPInput
+from modelforge.utils.prop import NNPInput
 from modelforge.potential.neighbors import PairlistData
 from .utils import Dense
 

--- a/modelforge/potential/potential.py
+++ b/modelforge/potential/potential.py
@@ -620,7 +620,6 @@ class NeuralNetworkPotentialFactory:
 
                 jax = import_("jax")
                 from modelforge.jax import nnpinput_flatten, nnpinput_unflatten
-                from modelforge.dataset import NNPInput
 
                 # registering NNPInput multiple times will result in a
                 # ValueError

--- a/modelforge/potential/sake.py
+++ b/modelforge/potential/sake.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 from loguru import logger as log
 
-from modelforge.dataset.dataset import NNPInput
+from modelforge.utils.prop import NNPInput
 from modelforge.potential.neighbors import PairlistData
 
 from .utils import DenseWithCustomDist, scatter_softmax

--- a/modelforge/potential/schnet.py
+++ b/modelforge/potential/schnet.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 from loguru import logger as log
 
-from modelforge.dataset.dataset import NNPInput
+from modelforge.utils.prop import NNPInput
 from modelforge.potential.neighbors import PairlistData
 
 

--- a/modelforge/potential/tensornet.py
+++ b/modelforge/potential/tensornet.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from modelforge.potential import CosineAttenuationFunction, TensorNetRadialBasisFunction
 
-from modelforge.dataset.dataset import NNPInput
+from modelforge.utils.prop import NNPInput
 from modelforge.potential.neighbors import PairlistData
 
 

--- a/modelforge/potential/utils.py
+++ b/modelforge/potential/utils.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn as nn
 from openff.units import unit
 
-from modelforge.dataset.dataset import NNPInput
+from modelforge.utils.prop import NNPInput
 
 
 @dataclass(frozen=False)

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -252,7 +252,7 @@ def generate_uniform_quaternion(u=None):
     """
     Generates a uniform normalized quaternion.
 
-    Adapted from numpy implementation in openmm-tools
+    Adapted from numpy implementation in modelforgeopenmm-tools
     https://github.com/choderalab/openmmtools/blob/main/openmmtools/mcmc.py
 
     Parameters
@@ -288,7 +288,7 @@ def generate_uniform_quaternion(u=None):
 def rotation_matrix_from_quaternion(quaternion):
     """Compute a 3x3 rotation matrix from a given quaternion (4-vector).
 
-    Adapted from the numpy implementation in openmm-tools
+    Adapted from the numpy implementation in modelforgeopenmm-tools
 
     https://github.com/choderalab/openmmtools/blob/main/openmmtools/mcmc.py
 

--- a/modelforge/tests/conftest.py
+++ b/modelforge/tests/conftest.py
@@ -252,7 +252,7 @@ def generate_uniform_quaternion(u=None):
     """
     Generates a uniform normalized quaternion.
 
-    Adapted from numpy implementation in modelforgeopenmm-tools
+    Adapted from numpy implementation in openmm-tools
     https://github.com/choderalab/openmmtools/blob/main/openmmtools/mcmc.py
 
     Parameters

--- a/modelforge/tests/precalculated_values.py
+++ b/modelforge/tests/precalculated_values.py
@@ -106,7 +106,7 @@ def setup_single_methane_input():
     )
     E = torch.tensor([0.0], requires_grad=True)
     atomic_subsystem_indices = torch.tensor([0, 0, 0, 0, 0], dtype=torch.int32)
-    from modelforge.dataset.dataset import NNPInput
+    from modelforge.utils.prop import NNPInput
 
     modelforge_methane = NNPInput(
         atomic_numbers=atomic_numbers,

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -31,7 +31,7 @@ def setup_methane():
         [0, 0, 0, 0, 0], dtype=torch.int32, device=device
     )
 
-    from modelforge.dataset.dataset import NNPInput
+    from modelforge.utils.prop import NNPInput
 
     nnp_input = NNPInput(
         atomic_numbers=torch.tensor([6, 1, 1, 1, 1], device=device),
@@ -76,7 +76,7 @@ def setup_two_methanes():
     )
 
     atomic_numbers = mf_species
-    from modelforge.dataset.dataset import NNPInput
+    from modelforge.utils.prop import NNPInput
 
     nnp_input = NNPInput(
         atomic_numbers=atomic_numbers,

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -13,11 +13,7 @@ from modelforge.utils.prop import PropertyNames
 
 @pytest.fixture(scope="session")
 def prep_temp_dir(tmp_path_factory):
-    import uuid
-
-    filename = str(uuid.uuid4())
-
-    fn = tmp_path_factory.mktemp(f"test_dataset_temp")
+    fn = tmp_path_factory.mktemp("test_dataset_temp")
     return fn
 
 
@@ -258,7 +254,7 @@ def test_file_existence_after_initialization(
 def test_caching(prep_temp_dir):
     import contextlib
 
-    local_cache_dir = str(prep_temp_dir) + "/data_test"
+    local_cache_dir = str(prep_temp_dir)
     from modelforge.dataset.qm9 import QM9Dataset
 
     data = QM9Dataset(version_select="nc_1000_v0", local_cache_dir=local_cache_dir)
@@ -334,7 +330,7 @@ def test_metadata_validation(prep_temp_dir):
     which is used to validate if we can use .npz file, or we need to
     regenerate it."""
 
-    local_cache_dir = str(prep_temp_dir) + "/data_test"
+    local_cache_dir = str(prep_temp_dir)
 
     from modelforge.dataset.qm9 import QM9Dataset
 
@@ -471,7 +467,7 @@ def test_data_item_format_of_datamodule(
     """Test the format of individual data items in the dataset."""
     from typing import Dict
 
-    local_cache_dir = str(prep_temp_dir) + "/data_test"
+    local_cache_dir = str(prep_temp_dir)
 
     dm = datamodule_factory(
         dataset_name=dataset_name,
@@ -728,7 +724,7 @@ def test_dataset_downloader(dataset_name, dataset_factory, prep_temp_dir):
     """
     Test the DatasetDownloader functionality.
     """
-    local_cache_dir = str(prep_temp_dir) + "/data_test"
+    local_cache_dir = str(prep_temp_dir)
 
     dataset = dataset_factory(
         dataset_name=dataset_name, local_cache_dir=local_cache_dir
@@ -740,7 +736,7 @@ def test_dataset_downloader(dataset_name, dataset_factory, prep_temp_dir):
 
 
 @pytest.mark.parametrize("dataset_name", _ImplementedDatasets.get_all_dataset_names())
-def test_numpy_dataset_assignment(dataset_name):
+def test_numpy_dataset_assignment(dataset_name, prep_temp_dir):
     """
     Test if the numpy_dataset attribute is correctly assigned after processing or loading.
     """
@@ -748,7 +744,7 @@ def test_numpy_dataset_assignment(dataset_name):
 
     factory = DatasetFactory()
     data = _ImplementedDatasets.get_dataset_class(dataset_name)(
-        version_select="nc_1000_v0"
+        version_select="nc_1000_v0", local_cache_dir=str(prep_temp_dir)
     )
     factory._load_or_process_data(data)
 
@@ -992,7 +988,7 @@ def test_function_of_self_energy(dataset_name, datamodule_factory, prep_temp_dir
 
 
 def test_shifting_center_of_mass_to_origin(prep_temp_dir):
-    local_cache_dir = str(prep_temp_dir) + "/data_test"
+    local_cache_dir = str(prep_temp_dir)
 
     from modelforge.dataset.dataset import initialize_datamodule
     from openff.units.elements import MASSES

--- a/modelforge/tests/test_potentials.py
+++ b/modelforge/tests/test_potentials.py
@@ -1119,7 +1119,7 @@ def test_saving_torchscript(potential_name, single_batch_with_batchsize, prep_te
     from modelforge.potential.potential import NeuralNetworkPotentialFactory
     from modelforge.utils.misc import load_configs_into_pydantic_models
 
-    config = load_configs_into_pydantic_models("ani2x", "qm9")
+    config = load_configs_into_pydantic_models(potential_name.lower(), "qm9")
 
     # read default parameters
     potential = NeuralNetworkPotentialFactory.generate_potential(

--- a/modelforge/utils/prop.py
+++ b/modelforge/utils/prop.py
@@ -106,12 +106,6 @@ class NNPInput:
         self.pair_list = self.pair_list.to(device)
         self.per_atom_partial_charge = self.per_atom_partial_charge.to(device)
 
-        # if not self.pair_list is None:
-        #     self.pair_list = self.pair_list.to(device)
-        #
-        # if not self.per_atom_partial_charge is None:
-        #     self.per_atom_partial_charge = self.per_atom_partial_charge.to(device)
-
         return self
 
     def to_dtype(self, dtype: torch.dtype):

--- a/modelforge/utils/prop.py
+++ b/modelforge/utils/prop.py
@@ -48,8 +48,8 @@ class NNPInput:
         per_system_total_charge: torch.Tensor,
         box_vectors: torch.Tensor = torch.zeros(3, 3),
         is_periodic: torch.Tensor = torch.tensor([False]),
-        pair_list: torch.Tensor = None,
-        per_atom_partial_charge: torch.Tensor = None,
+        pair_list: torch.Tensor = torch.tensor([]),
+        per_atom_partial_charge: torch.Tensor = torch.tensor([]),
     ):
         self.atomic_numbers = atomic_numbers
         self.positions = positions
@@ -59,7 +59,6 @@ class NNPInput:
         self.per_atom_partial_charge = per_atom_partial_charge
         self.box_vectors = box_vectors
         self.is_periodic = is_periodic
-
 
         # Validate inputs
         self._validate_inputs()
@@ -95,7 +94,6 @@ class NNPInput:
                 "The size of atomic_subsystem_indices and the first dimension of positions must match"
             )
 
-
     def to_device(self, device: torch.device):
         """Move all tensors in this instance to the specified device."""
 
@@ -105,12 +103,14 @@ class NNPInput:
         self.per_system_total_charge = self.per_system_total_charge.to(device)
         self.box_vectors = self.box_vectors.to(device)
         self.is_periodic = self.is_periodic.to(device)
+        self.pair_list = self.pair_list.to(device)
+        self.per_atom_partial_charge = self.per_atom_partial_charge.to(device)
 
-        if self.pair_list is not None:
-            self.pair_list = self.pair_list.to(device)
-
-        if self.per_atom_partial_charge is not None:
-            self.per_atom_partial_charge = self.per_atom_partial_charge.to(device)
+        # if not self.pair_list is None:
+        #     self.pair_list = self.pair_list.to(device)
+        #
+        # if not self.per_atom_partial_charge is None:
+        #     self.per_atom_partial_charge = self.per_atom_partial_charge.to(device)
 
         return self
 
@@ -191,11 +191,11 @@ class Metadata:
 class BatchData:
     nnp_input: NNPInput
     metadata: Metadata
-    
+
     def to(
         self,
         device: torch.device,
-    ): # NOTE: this is required to move the data to device
+    ):  # NOTE: this is required to move the data to device
         """Move all data in this batch to the specified device and dtype."""
         self.nnp_input = self.nnp_input.to_device(device=device)
         self.metadata = self.metadata.to_device(device=device)


### PR DESCRIPTION
## Pull Request Summary
When changing NNPInput from a tuple to using slots, pair_list and per atom charge were set to None.  While we can call torch.jit.script on the potential with None in the NNPInput and evaluate it, we can't write it to file as it goes through all the validation.  

This defines these as empty tensors; we can check the shape of the pair_list in the Neighborlist to know if we need to generate these pairs. 


### Associated Issue(s)
 - [x] #293 
 
## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [x] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review