### PR TITLE
refactoring HDF5Dataset class to check and convert units.

### DIFF
--- a/modelforge/dataset/ani1x.py
+++ b/modelforge/dataset/ani1x.py
@@ -69,13 +69,24 @@ class ANI1xDataset(HDF5Dataset):
         F="wb97x_dz.forces",
     )
 
+    # for simplicifty, commenting out those properties that are cannot be used in our current implementation
     _available_properties = [
         "geometry",
         "atomic_numbers",
         "wb97x_dz.energy",
         "wb97x_dz.forces",
-        "wb97x_dz.cm5_charges",
+        # "wb97x_dz.cm5_charges",
     ]  # All properties within the datafile, aside from SMILES/inchi.
+
+    # Mapping of available properties to the associated PropertyNames
+    _available_properties_association = {
+        "geometry": "positions",
+        "atomic_numbers": "atomic_numbers",
+        "wb97x_dz.energy": "E",
+        "wb97x_dz.forces": "F",
+    }  # note cm5_charges are not actually total charge, as they as per-atom charges, but unit is the same
+    # we need to discuss if we want to allow per_atom_charges at all and if we want to preprocess
+    # per atom charges into dipole moment
 
     def __init__(
         self,

--- a/modelforge/dataset/ani2x.py
+++ b/modelforge/dataset/ani2x.py
@@ -61,6 +61,14 @@ class ANI2xDataset(HDF5Dataset):
         "forces",
     ]  # All properties within the datafile, aside from SMILES/inchi.
 
+    # Mapping of available properties to the associated PropertyNames
+    _available_properties_association = {
+        "geometry": "positions",
+        "atomic_numbers": "atomic_numbers",
+        "energies": "E",
+        "forces": "F",
+    }
+
     def __init__(
         self,
         dataset_name: str = "ANI2x",

--- a/modelforge/dataset/phalkethoh.py
+++ b/modelforge/dataset/phalkethoh.py
@@ -54,6 +54,16 @@ class PhAlkEthOHDataset(HDF5Dataset):
         "total_charge",
     ]  # All properties within the datafile, aside from SMILES/inchi.
 
+    # Mapping of available properties to the associated PropertyNames
+    _available_properties_association = {
+        "geometry": "positions",
+        "atomic_numbers": "atomic_numbers",
+        "dft_total_energy": "E",
+        "dft_total_force": "F",
+        "scf_dipole": "dipole_moment",
+        "total_charge": "total_charge",
+    }
+
     def __init__(
         self,
         dataset_name: str = "PhAlkEthOH",

--- a/modelforge/dataset/qm9.py
+++ b/modelforge/dataset/qm9.py
@@ -41,9 +41,10 @@ class QM9Dataset(HDF5Dataset):
     _property_names = PropertyNames(
         atomic_numbers="atomic_numbers",
         positions="geometry",
-        E="internal_energy_at_0K",  # Q="charges"
+        E="internal_energy_at_0K",
     )
 
+    # for simplicity, commenting out those properties that are cannot be used in our current implementation
     _available_properties = [
         "geometry",
         "atomic_numbers",
@@ -51,19 +52,33 @@ class QM9Dataset(HDF5Dataset):
         "internal_energy_at_298.15K",
         "enthalpy_at_298.15K",
         "free_energy_at_298.15K",
-        "heat_capacity_at_298.15K",
+        # "heat_capacity_at_298.15K",
         "zero_point_vibrational_energy",
-        "electronic_spatial_extent",
+        # "electronic_spatial_extent",
         "lumo-homo_gap",
         "energy_of_homo",
         "energy_of_lumo",
-        "rotational_constant_A",
-        "rotational_constant_B",
-        "rotational_constant_C",
+        # "rotational_constant_A",
+        # "rotational_constant_B",
+        # "rotational_constant_C",
         "dipole_moment",
-        "isotropic_polarizability",
-        "charges",
+        # "isotropic_polarizability",
+        # "charges",
     ]  # All properties within the datafile, aside from SMILES/inchi.
+
+    _available_properties_association = {
+        "geometry": "positions",
+        "atomic_numbers": "atomic_numbers",
+        "internal_energy_at_0K": "E",
+        "internal_energy_at_298.15K": "E",
+        "enthalpy_at_298.15K": "E",
+        "free_energy_at_298.15K": "E",
+        "zero_point_vibrational_energy": "E",
+        "lumo-homo_gap": "E",
+        "energy_of_homo": "E",
+        "energy_of_lumo": "E",
+        "dipole_moment": "dipole_moment",
+    }
 
     def __init__(
         self,
@@ -101,7 +116,6 @@ class QM9Dataset(HDF5Dataset):
             "geometry",
             "atomic_numbers",
             "internal_energy_at_0K",
-            "charges",
             "dipole_moment",
         ]  # NOTE: Default values
 

--- a/modelforge/dataset/spice1.py
+++ b/modelforge/dataset/spice1.py
@@ -58,20 +58,33 @@ class SPICE1Dataset(HDF5Dataset):
         dipole_moment="scf_dipole",
     )
 
+    # note for simplicifty, commenting out those properties that cannot be used in the current implementation
     _available_properties = [
         "geometry",
         "atomic_numbers",
         "dft_total_energy",
         "dft_total_force",
-        "mbis_charges",
-        "mbis_multipoles",
-        "mbis_octopoles",
+        # "mbis_charges",
+        # "mbis_multipoles",
+        # "mbis_octopoles",
         "formation_energy",
         "scf_dipole",
-        "scf_quadrupole",
+        # "scf_quadrupole",
         "total_charge",
         "reference_energy",
     ]  # All properties within the datafile, aside from SMILES/inchi.
+
+    # Mapping of available properties to the associated PropertyNames
+    _available_properties_association = {
+        "geometry": "positions",
+        "atomic_numbers": "atomic_numbers",
+        "dft_total_energy": "E",
+        "dft_total_force": "F",
+        "formation_energy": "E",
+        "scf_dipole": "dipole_moment",
+        "total_charge": "total_charge",
+        "reference_energy": "E",
+    }
 
     def __init__(
         self,

--- a/modelforge/dataset/spice1openff.py
+++ b/modelforge/dataset/spice1openff.py
@@ -68,20 +68,34 @@ class SPICE1OpenFFDataset(HDF5Dataset):
         positions="geometry",
         E="dft_total_energy",
         F="dft_total_force",
-        total_charge="mbis_charges",
+        total_charge="total_charge",
     )
 
+    # commenting out those properties that are cannot be used in our current implementation
     _available_properties = [
         "geometry",
         "atomic_numbers",
         "dft_total_energy",
         "dft_total_force",
-        "mbis_charges",
+        # "mbis_charges",
         "formation_energy",
         "scf_dipole",
         "total_charge",
         "reference_energy",
     ]  # All properties within the datafile, aside from SMILES/inchi.
+
+    # note these are simply mapping to a property with equivalent units in the dataset
+    # not implying we would want to use this for training
+    _available_properties_association = {
+        "geometry": "positions",
+        "atomic_numbers": "atomic_numbers",
+        "dft_total_energy": "E",
+        "dft_total_force": "F",
+        "formation_energy": "E",
+        "scf_dipole": "dipole_moment",
+        "total_charge": "total_charge",
+        "reference_energy": "E",
+    }
 
     def __init__(
         self,
@@ -120,7 +134,7 @@ class SPICE1OpenFFDataset(HDF5Dataset):
             "atomic_numbers",
             "dft_total_energy",
             "dft_total_force",
-            "mbis_charges",
+            "total_charge",
         ]  # NOTE: Default values
 
         self._properties_of_interest = _default_properties_of_interest

--- a/modelforge/dataset/spice2.py
+++ b/modelforge/dataset/spice2.py
@@ -82,21 +82,33 @@ class SPICE2Dataset(HDF5Dataset):
         positions="geometry",
         E="dft_total_energy",
         F="dft_total_force",
-        total_charge="mbis_charges",
+        total_charge="total_charge",
         dipole_moment="scf_dipole",
     )
 
+    # for simplicifty, commenting out those properties that are cannot be used in our current implementation
     _available_properties = [
         "geometry",
         "atomic_numbers",
         "dft_total_energy",
         "dft_total_force",
-        "mbis_charges",
+        # "mbis_charges",
         "formation_energy",
         "scf_dipole",
         "total_charge",
         "reference_energy",
     ]  # All properties within the datafile, aside from SMILES/inchi.
+
+    _available_properties_association = {
+        "geometry": "positions",
+        "atomic_numbers": "atomic_numbers",
+        "dft_total_energy": "E",
+        "dft_total_force": "F",
+        "formation_energy": "E",
+        "scf_dipole": "dipole_moment",
+        "total_charge": "total_charge",
+        "reference_energy": "E",
+    }
 
     def __init__(
         self,
@@ -135,7 +147,7 @@ class SPICE2Dataset(HDF5Dataset):
             "atomic_numbers",
             "dft_total_energy",
             "dft_total_force",
-            "mbis_charges",
+            "total_charge",
             "scf_dipole",
         ]  # NOTE: Default values
 

--- a/modelforge/potential/potential.py
+++ b/modelforge/potential/potential.py
@@ -8,7 +8,6 @@ import lightning as pl
 import torch
 from loguru import logger as log
 from openff.units import unit
-from torch.nn import Module
 from modelforge.potential.neighbors import PairlistData
 
 from modelforge.dataset.dataset import DatasetParameters
@@ -37,7 +36,10 @@ T_NNP_Parameters = TypeVar(
 )
 
 
-from typing import Callable, Literal, Optional, Union
+from typing import Callable, Literal, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from modelforge.train.training import PotentialTrainer
 
 import numpy as np
 
@@ -517,8 +519,6 @@ def setup_potential(
 
 from openff.units import unit
 
-from modelforge.train.training import PotentialTrainer
-
 
 class NeuralNetworkPotentialFactory:
 
@@ -630,7 +630,7 @@ class NeuralNetworkPotentialFactory:
         },
         potential_seed: Optional[int] = None,
         use_default_dataset_statistic: bool = False,
-    ) -> PotentialTrainer:
+    ) -> "PotentialTrainer":
         """
         Create a lightning trainer object to train the neural network potential.
 
@@ -657,6 +657,7 @@ class NeuralNetworkPotentialFactory:
             An instantiated neural network potential for training.
         """
         from modelforge.utils.misc import seed_random_number
+        from modelforge.train.training import PotentialTrainer
 
         if potential_seed is not None:
             log.info(f"Setting random seed to: {potential_seed}")

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -43,14 +43,12 @@ def test_dataset_basic_operations():
         ),
         "atomic_subsystem_counts": atomic_subsystem_counts,
         "n_confs": n_confs,
-        "charges": torch.randint(-1, 2, torch.Size([total_confs, 1])).numpy(),
     }
 
     property_names = PropertyNames(
         atomic_numbers="atomic_numbers",
         positions="geometry",
         E="internal_energy_at_0K",
-        total_charge="charges",
     )
     dataset = TorchDataset(input_data, property_names)
     assert len(dataset) == total_confs
@@ -122,7 +120,6 @@ def test_different_properties_of_interest(dataset_name, dataset_factory, prep_te
             "geometry",
             "atomic_numbers",
             "internal_energy_at_0K",
-            "charges",
             "dipole_moment",
         ]
         # spot check the processing of the yaml file
@@ -175,7 +172,7 @@ def test_different_properties_of_interest(dataset_name, dataset_factory, prep_te
             "atomic_numbers",
             "dft_total_energy",
             "dft_total_force",
-            "mbis_charges",
+            "total_charge",
             "scf_dipole",
         ]
 
@@ -183,13 +180,13 @@ def test_different_properties_of_interest(dataset_name, dataset_factory, prep_te
             "dft_total_energy",
             "geometry",
             "atomic_numbers",
-            "mbis_charges",
+            "total_charge",
         ]
         assert data.properties_of_interest == [
             "dft_total_energy",
             "geometry",
             "atomic_numbers",
-            "mbis_charges",
+            "total_charge",
         ]
     elif dataset_name == "PhAlkEthOH":
         assert data.properties_of_interest == [
@@ -356,7 +353,6 @@ def test_metadata_validation(prep_temp_dir):
             "atomic_numbers",
             "internal_energy_at_0K",
             "geometry",
-            "charges",
             "dipole_moment",
         ],
         "hdf5_checksum": "305a0602860f181fafa75f7c7e3e6de4",

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1206,6 +1206,7 @@ def read_config_and_train(
     Trainer
         The configured trainer instance after running the training process.
     """
+    from modelforge.potential.potential import NeuralNetworkPotentialFactory
     (
         training_parameter,
         dataset_parameter,
@@ -1227,7 +1228,6 @@ def read_config_and_train(
         log_every_n_steps=log_every_n_steps,
         simulation_environment=simulation_environment,
     )
-    from modelforge.potential.potential import NeuralNetworkPotentialFactory
 
     trainer = NeuralNetworkPotentialFactory.generate_trainer(
         potential_parameter=potential_parameter,

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1207,6 +1207,7 @@ def read_config_and_train(
         The configured trainer instance after running the training process.
     """
     from modelforge.potential.potential import NeuralNetworkPotentialFactory
+
     (
         training_parameter,
         dataset_parameter,

--- a/modelforge/utils/prop.py
+++ b/modelforge/utils/prop.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import torch
 from typing import NamedTuple, Optional
 from loguru import logger as log
+from openff.units import unit
 
 
 @dataclass
@@ -16,6 +17,16 @@ class PropertyNames:
     F: Optional[str] = None
     total_charge: Optional[str] = None
     dipole_moment: Optional[str] = None
+
+
+PropertyUnits = {
+    "atomic_numbers": "dimensionless",
+    "positions": unit.nanometer,
+    "E": unit.kilojoule_per_mole,
+    "F": unit.kilojoule_per_mole / unit.nanometer,
+    "total_charge": unit.elementary_charge,
+    "dipole_moment": unit.elementary_charge * unit.nanometer,
+}
 
 
 class SpeciesEnergies(NamedTuple):


### PR DESCRIPTION
## Pull Request Summary
This address the issue related to the force units being off (per angstrom, not per nanometer) in the datasets. 


### Key changes
 - [x] Units are attached to data read in and converted to our target system
 - [x] Each dataset now includes a mapping of a given property in the dataset to one of our available data fields (E, F, dipole_moment, total_charge). 
 - [x]  I commented out any available property that doesn't work in our current system (e.g., per_atom_charges, vibrational frequency, etc.), as they would be read in but couldn't be used in any context

### Questions
 - [x] While we dont' necessarily intend to embed using per-atom charges for our applications, do we want that to be an option? this might require more extensive discussion, just listing it because I've removed our ability to read any of those properties in at the moment. 

### Associated Issue(s)
 - #298 

## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [ ] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review