### PR TITLE
log time per epoch

### DIFF
--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -3,7 +3,7 @@ This module contains classes and functions for training neural network potential
 """
 
 from typing import Any, Dict, List, Optional, Type, TypeVar, Tuple, Literal
-
+import time
 import lightning.pytorch as pL
 import torch
 from lightning import Trainer
@@ -415,6 +415,8 @@ class TrainingAdapter(pL.LightningModule):
             Seed for initializing the model (default is None).
         """
         from modelforge.potential.potential import setup_potential
+
+        self.epoch_start_time = None
 
         super().__init__()
         self.save_hyperparameters()
@@ -1249,10 +1251,39 @@ class TrainingAdapter(pL.LightningModule):
             self.val_indices,
         )
 
+    def on_train_start(self):
+        """Log the GPU name to Weights & Biases at the start of training."""
+        if isinstance(self.logger, pL.loggers.WandbLogger):
+            if torch.cuda.is_available():
+                gpu_name = torch.cuda.get_device_name(0)
+            else:
+                gpu_name = "CPU"
+            # Log GPU name to W&B
+            self.logger.experiment.config.update({"GPU": gpu_name})
+            self.logger.experiment.log({"GPU Name": gpu_name})
+        else:
+            log.warning("Weights & Biases logger not found; GPU name not logged.")
+
+    def on_train_epoch_start(self):
+        """Start the epoch timer."""
+        self.epoch_start_time = time.time()
+
+    def _log_time(self):
+        """Log the time taken per epoch to W&B."""
+        epoch_time = time.time() - self.epoch_start_time
+        if isinstance(self.logger, pL.loggers.WandbLogger):
+            # Log epoch duration to W&B
+            self.logger.experiment.log(
+                {"epoch_time": epoch_time, "epoch": self.current_epoch}
+            )
+        else:
+            log.warning("Weights & Biases logger not found; epoch time not logged.")
+
     def on_train_epoch_end(self):
         """Logs metrics, learning rate, histograms, and figures at the end of the training epoch."""
         self._log_metrics(self.loss_metrics, "loss")
         self._log_learning_rate()
+        self._log_time()
         self._log_histograms()
         self._log_figures_for_each_phase(
             self.train_preds,


### PR DESCRIPTION
## Pull Request Summary
This PR adds logging for epoch time. The time is measured as wall time between  `on_train_epoch_start` and `on_train_epoch_end` method calls. 
