### PR TITLE
Dev global rank

### DIFF
--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -664,9 +664,8 @@ class TrainingAdapter(pL.LightningModule):
             if self.training_parameter.log_norm:
                 if key == "total_loss":
                     continue  # Skip total loss for gradient norm logging
-
                 grad_norm = compute_grad_norm(metric.mean(), self)
-                self.log(f"grad_norm/{key}", grad_norm)
+                self.log(f"grad_norm/{key}", grad_norm, sync_dist=True)
 
         # Save energy predictions and targets
         self._update_predictions(
@@ -1158,7 +1157,10 @@ class TrainingAdapter(pL.LightningModule):
             # Log outlier error counts for non-training phases
             if phase != "train":
                 self._identify__and_log_top_k_errors(errors, gathered_indices, phase)
-                self.log_dict(self.outlier_errors_over_epochs, on_epoch=True)
+                self.log_dict(
+                    self.outlier_errors_over_epochs,
+                    on_epoch=True,
+                )
 
     def _identify__and_log_top_k_errors(
         self,
@@ -1268,18 +1270,7 @@ class TrainingAdapter(pL.LightningModule):
 
     def on_train_epoch_end(self):
         """Logs metrics, learning rate, histograms, and figures at the end of the training epoch."""
-        print(self.global_rank)
-        print(self.trainer.is_global_zero)
-        if self.trainer.is_global_zero:
-
-            self._log_metrics(self.loss_metrics, "loss")
-            self._log_learning_rate()
-            self._log_time()
-            self._log_histograms()
-            # log the weights of the different loss components
-            for key, weight in self.loss.weights_scheduling.items():
-                self.log(f"loss/{key}/weight", weight[self.current_epoch])
-
+        self._log_metrics(self.loss_metrics, "loss")
         # this performs gather operations and logs only at rank == 0
         self._log_figures_for_each_phase(
             self.train_preds,
@@ -1301,12 +1292,27 @@ class TrainingAdapter(pL.LightningModule):
             self.train_indices,
         )
 
+        self._log_learning_rate()
+        self._log_time()
+        self._log_histograms()
+        # log the weights of the different loss components
+        for key, weight in self.loss.weights_scheduling.items():
+            self.log(
+                f"loss/{key}/weight",
+                weight[self.current_epoch],
+                rank_zero_only=True,
+            )
+
     def _log_learning_rate(self):
         """Logs the current learning rate."""
         sch = self.lr_schedulers()
         try:
             self.log(
-                "lr", sch.get_last_lr()[0], on_epoch=True, prog_bar=True, sync_dist=True
+                "lr",
+                sch.get_last_lr()[0],
+                on_epoch=True,
+                prog_bar=True,
+                rank_zero_only=True,
             )
         except AttributeError:
             pass

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1269,6 +1269,7 @@ class TrainingAdapter(pL.LightningModule):
     def on_train_epoch_end(self):
         """Logs metrics, learning rate, histograms, and figures at the end of the training epoch."""
         print(self.global_rank)
+        print(self.trainer.is_global_zero)
         if self.trainer.is_global_zero:
 
             self._log_metrics(self.loss_metrics, "loss")

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1157,9 +1157,7 @@ class TrainingAdapter(pL.LightningModule):
             # Log outlier error counts for non-training phases
             if phase != "train":
                 self._identify__and_log_top_k_errors(errors, gathered_indices, phase)
-                self.log_dict(
-                    self.outlier_errors_over_epochs, on_epoch=True, sync_dist=True
-                )
+                self.log_dict(self.outlier_errors_over_epochs, on_epoch=True)
 
     def _identify__and_log_top_k_errors(
         self,
@@ -1299,7 +1297,6 @@ class TrainingAdapter(pL.LightningModule):
             self.log(
                 f"loss/{key}/weight",
                 weight[self.current_epoch],
-                sync_dist=True,
             )
 
     def _log_learning_rate(self):
@@ -1311,7 +1308,6 @@ class TrainingAdapter(pL.LightningModule):
                 sch.get_last_lr()[0],
                 on_epoch=True,
                 prog_bar=True,
-                sync_dist=True,
             )
         except AttributeError:
             pass

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1251,19 +1251,6 @@ class TrainingAdapter(pL.LightningModule):
             self.val_indices,
         )
 
-    def on_train_start(self):
-        """Log the GPU name to Weights & Biases at the start of training."""
-        if isinstance(self.logger, pL.loggers.WandbLogger) and self.global_rank == 0:
-            if torch.cuda.is_available():
-                gpu_name = torch.cuda.get_device_name(0)
-            else:
-                gpu_name = "CPU"
-            # Log GPU name to W&B
-            self.logger.experiment.config.update({"GPU": gpu_name})
-            self.logger.experiment.log({"GPU Name": gpu_name})
-        else:
-            log.warning("Weights & Biases logger not found; GPU name not logged.")
-
     def on_train_epoch_start(self):
         """Start the epoch timer."""
         self.epoch_start_time = time.time()
@@ -1281,7 +1268,9 @@ class TrainingAdapter(pL.LightningModule):
 
     def on_train_epoch_end(self):
         """Logs metrics, learning rate, histograms, and figures at the end of the training epoch."""
-        if self.global_rank == 0:
+        print(self.global_rank)
+        if self.trainer.is_global_zero:
+
             self._log_metrics(self.loss_metrics, "loss")
             self._log_learning_rate()
             self._log_time()

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1158,8 +1158,7 @@ class TrainingAdapter(pL.LightningModule):
             if phase != "train":
                 self._identify__and_log_top_k_errors(errors, gathered_indices, phase)
                 self.log_dict(
-                    self.outlier_errors_over_epochs,
-                    on_epoch=True,
+                    self.outlier_errors_over_epochs, on_epoch=True, sync_dist=True
                 )
 
     def _identify__and_log_top_k_errors(
@@ -1300,7 +1299,7 @@ class TrainingAdapter(pL.LightningModule):
             self.log(
                 f"loss/{key}/weight",
                 weight[self.current_epoch],
-                rank_zero_only=True,
+                sync_dist=True,
             )
 
     def _log_learning_rate(self):
@@ -1312,7 +1311,7 @@ class TrainingAdapter(pL.LightningModule):
                 sch.get_last_lr()[0],
                 on_epoch=True,
                 prog_bar=True,
-                rank_zero_only=True,
+                sync_dist=True,
             )
         except AttributeError:
             pass


### PR DESCRIPTION
## Pull Request Summary
This PR addresses an issue introduced in PR #308 where logging of the epoch time was intended to occur only on the main process (rank == 0). However, this led to a synchronization error that caused training to freeze after the first epoch. To resolve this, we adjusted the logging to ensure it only occurs on the main process without disrupting the training flow.


### Key changes
- Adjusted Logging Conditions: Updated specific logging calls to include rank_zero_only=True where necessary. This change ensures that logging occurs only on the main process without causing synchronization issues across processes.
- Removed Redundant Logging Checks: Refactored the logging of certain metrics to avoid redundant if self.global_rank == 0 checks by using rank_zero_only directly in self.log() calls.
- Ensured Sync Consistency: For logging operations that require distribution synchronization (e.g., gradients, learning rate), we used sync_dist=True for safe distributed handling, while maintaining rank_zero_only=True for process-specific logging.


### Associated Issue(s)
 - [x] issue #308 

## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [x] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review