### PR TITLE
Improved dataset control

### DIFF
--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -103,4 +103,6 @@ Explanation of fields in `qm9.toml`:
 - `dataset_name`: Specifies the name of the dataset. For this example, it is QM9.
 - `number_of_worker`: Determines the number of worker threads for data loading. Increasing the number of workers can speed up data loading but requires more memory.
 - `version_select`: Indicates the version of the dataset to use. In this example, it points to a small subset of the dataset for quick testing. To use the full QM9 dataset, set this variable to `latest`.
+- `properties_of_interest`: Lists the properties of interest to load from the hdf5 file.
+- `properties_assignment`: Maps the properties of interest to the corresponding fields in the dataset. This mapping is crucial for the correct loading of properties during training; note, many datasets contain multiple properties can potentially be swapped (e.g., energy calculated with or without dispersion corrections, different charge population schemes, different levels of theory, etc.).  Any properties listed here must appear in the properties of interest list; the code will raise a validation error if this condition is not met.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -80,6 +80,7 @@ These architectures can be trained on the following datasets (distributed via ze
 - QM9
 - SPICE1 (/openff)
 - SPICE2
+- tmQM
 
 By default, potentials predict the total energy  and per-atom forces within a given cutoff radius and can be trained on energies and forces.
 

--- a/modelforge/curation/scripts/curate_spice114_openff.py
+++ b/modelforge/curation/scripts/curate_spice114_openff.py
@@ -99,7 +99,7 @@ def main():
 
     # We'll want to provide some simple means of versioning
     # if we make updates to either the underlying dataset, curation modules, or parameters given to the code
-    version = "1"
+    version = "2"
     # version of the dataset to curate
     version_select = f"v_0"
 

--- a/modelforge/curation/spice_1_openff_curation.py
+++ b/modelforge/curation/spice_1_openff_curation.py
@@ -163,7 +163,7 @@ class SPICE1OpenFFCuration(DatasetCuration):
             "dft_total_force": "series_atom",
             "formation_energy": "series_mol",
             "mbis_charges": "series_atom",
-            "scf_dipole": "series_atom",
+            "scf_dipole": "series_mol",
         }
 
     # we will use the retry package to allow us to resume download if we lose connection to the server

--- a/modelforge/dataset/dataset.py
+++ b/modelforge/dataset/dataset.py
@@ -1002,9 +1002,7 @@ class DataModule(pl.LightningDataModule):
         if self.properties_assignment is not None:
             from modelforge.utils import PropertyNames
 
-            dataset._properties_names = PropertyNames(
-                **self.properties_assignment.model_dump()
-            )
+            dataset._properties_names = PropertyNames(**self.properties_assignment)
 
         torch_dataset = self._create_torch_dataset(dataset)
         # if dataset statistics is present load it from disk
@@ -1442,6 +1440,8 @@ def initialize_datamodule(
     regression_ase: bool = False,
     regenerate_dataset_statistic: bool = False,
     local_cache_dir="./",
+    properties_of_interest: Optional[PropertyNames] = None,
+    properties_assignment: Optional[Dict[str, str]] = None,
 ) -> DataModule:
     """
     Initialize a dataset for a given mode.
@@ -1457,6 +1457,8 @@ def initialize_datamodule(
         regression_ase=regression_ase,
         regenerate_dataset_statistic=regenerate_dataset_statistic,
         local_cache_dir=local_cache_dir,
+        properties_of_interest=properties_of_interest,
+        properties_assignment=properties_assignment,
     )
     data_module.prepare_data()
     data_module.setup()

--- a/modelforge/dataset/parameters.py
+++ b/modelforge/dataset/parameters.py
@@ -1,0 +1,100 @@
+from enum import Enum
+from typing import Optional, List, Dict
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing_extensions import Self
+
+
+class CaseInsensitiveEnum(str, Enum):
+    """
+    Enum class that allows case-insensitive comparison of its members.
+    """
+
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value.lower() == value.lower():
+                return member
+        return super()._missing_(value)
+
+
+# To avoid having to set config parameters for each class,
+# we will just create a parent class for all the parameters classes.
+class ParametersBase(BaseModel):
+    model_config = ConfigDict(
+        use_enum_values=True,
+        arbitrary_types_allowed=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+
+class DataSetName(CaseInsensitiveEnum):
+    QM9 = "QM9"
+    ANI1X = "ANI1X"
+    ANI2X = "ANI2X"
+    SPICE1 = "SPICE1"
+    SPICE2 = "SPICE2"
+    SPICE1_OPENFF = "SPICE1_OPENFF"
+    PHALKETHOH = "PhAlkEthOH"
+    TMQM = "tmQM"
+
+
+class PropertiesDefinition(ParametersBase):
+    atomic_numbers: str
+    positions: str
+    E: str
+    F: Optional[str] = None
+    dipole_moment: Optional[str] = None
+    total_charge: Optional[str] = None
+
+
+class DatasetParameters(BaseModel):
+    """
+    Class to hold the dataset parameters.
+
+    Attributes
+    ----------
+    dataset_name : DataSetName
+        The name of the dataset.
+    version_select : str
+        The version of the dataset to use.
+    num_workers : int
+        The number of workers to use for the DataLoader.
+    pin_memory : bool
+        Whether to pin memory for the DataLoader.
+    regenerate_processed_cache : bool
+        Whether to regenerate the processed cache.
+    properties_of_interest : List[str]
+        The properties of interest to load from the hdf5 file.
+    properties_assignment : PropertiesDefinition
+        Association between the properties of interest and the internal naming convention
+    """
+
+    model_config = ConfigDict(
+        use_enum_values=True, arbitrary_types_allowed=True, validate_assignment=True
+    )
+
+    dataset_name: DataSetName
+    version_select: str
+    num_workers: int = Field(gt=0)
+    pin_memory: bool
+    regenerate_processed_cache: bool = False
+    properties_of_interest: List[str]
+    properties_assignment: PropertiesDefinition
+
+    @model_validator(mode="after")
+    def validate_properties(self) -> Self:
+        """
+        Validate that the properties of interest are in the properties assignment.
+
+        Note, datasets will validate the properties_of_interest against available properties in the dataset,
+        so we do not need additional validation here.
+        """
+        for prop in self.properties_assignment.model_dump().values():
+            if prop not in self.properties_of_interest:
+                if prop is not None:
+                    raise ValueError(
+                        f"Property {prop} is not in the properties_of_interest."
+                    )
+
+        return self

--- a/modelforge/dataset/yaml_files/spice1openff.yaml
+++ b/modelforge/dataset/yaml_files/spice1openff.yaml
@@ -1,6 +1,62 @@
 dataset: spice1openff
-latest: full_dataset_v1
-latest_test: nc_1000_v1
+latest: full_dataset_v2
+latest_test: nc_1000_v2
+full_dataset_v2:
+  version: 2
+  gz_data_file:
+    doi:  10.5281/zenodo.14264431
+    length: 2545870978
+    md5: 8e172839e8812747cbbf84f117168dc0
+    name: SPICE1_OpenFF_dataset_v2.hdf5.gz
+  hdf5_data_file:
+    md5: 7fbf84cc98af8cd63235be88eed30f51
+    name: SPICE1_OpenFF_dataset_v2.hdf5
+  processed_data_file:
+    md5: null
+    name: SPICE1_OpenFF_dataset_v2_processed.npz
+  url: https://zenodo.org/records/14264431/files/spice_114_openff_dataset_v2.hdf5.gz
+nc_1000_v2:
+  version: 2
+  doi:  10.5281/zenodo.14269264
+  gz_data_file:
+    length: 2534128
+    md5: 9535d75cfee3facc8c1d62f1650fac07
+    name: SPICE1_OpenFF_dataset_v2_nc_1000.hdf5.gz
+  hdf5_data_file:
+    md5: 31e8a613f99d215b2fbfc33c77cdeff2
+    name: SPICE1_OpenFF_dataset_v2_nc_1000.hdf5
+  processed_data_file:
+    md5: null
+    name: SPICE1_OpenFF_dataset_v2_nc_1000_processed.npz
+  url: https://zenodo.org/records/14269264/files/spice_114_openff_dataset_v2_ntc_1000.hdf5.gz
+full_dataset_v2_HCNOFClS:
+  version: 2
+  doi:  10.5281/zenodo.14264561
+  gz_data_file:
+    length: 2306573715
+    md5: 9de6a9e9e490beddfecc24332cba7f11
+    name: SPICE1_OpenFF_dataset_v2_HCNOFClS.hdf5.gz
+  hdf5_data_file:
+    md5: 23c6da20754023daa37c5e24f4d3c432
+    name: SPICE1_OpenFF_dataset_v2_HCNOFClS.hdf5
+  processed_data_file:
+    md5: null
+    name: SPICE1_OpenFF_dataset_v2_HCNOFClS_processed.npz
+  url: https://zenodo.org/records/14264561/files/spice_114_openff_dataset_v2_HCNOFClS.hdf5.gz
+nc_1000_v2_HCNOFClS:
+  version: 2
+  doi: 10.5281/zenodo.14269058
+  gz_data_file:
+    length: 2534128
+    md5: fc07d6ac041b3ed835b20a50b97901d8
+    name: SPICE1_OpenFF_dataset_v2_nc_1000_HCNOFClS.hdf5.gz
+  hdf5_data_file:
+    md5:  03244a62f184611bbb6680d6ef6f13e3
+    name: SPICE1_OpenFF_dataset_v2_nc_1000_HCNOFClS.hdf5
+  processed_data_file:
+    md5: null
+    name: SPICE1_OpenFF_dataset_v2_nc_1000_HCNOFClS_processed.npz
+  url: https://zenodo.org/records/14269058/files/spice_114_openff_dataset_v2_ntc_1000_HCNOFClS.hdf5.gz
 full_dataset_v1:
   version: 1
   gz_data_file:

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -53,7 +53,7 @@ class AtomicNumber(BaseModel):
     number_of_per_atom_features: int = 32
 
 
-class Featurization(BaseModel):
+class Featurization(ParametersBase):
     properties_to_featurize: List[str]
     atomic_number: AtomicNumber = Field(default_factory=AtomicNumber)
 

--- a/modelforge/tests/data/config.toml
+++ b/modelforge/tests/data/config.toml
@@ -33,6 +33,12 @@ dataset_name = "QM9"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["atomic_numbers", "geometry", "internal_energy_at_0K", "dipole_moment"]
+
+[dataset.properties_assignment]
+atomic_numbers = "atomic_numbers"
+positions = "geometry"
+E = "internal_energy_at_0K"
 
 [training]
 number_of_epochs = 2

--- a/modelforge/tests/data/dataset_defaults/ani1x.toml
+++ b/modelforge/tests/data/dataset_defaults/ani1x.toml
@@ -3,3 +3,10 @@ dataset_name = "ANI1x"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["geometry", "atomic_numbers", "wb97x_dz.energy", "wb97x_dz.forces"]
+
+[dataset.properties_assignment]
+atomic_numbers="atomic_numbers"
+positions="geometry"
+E="wb97x_dz.energy"
+F="wb97x_dz.forces"

--- a/modelforge/tests/data/dataset_defaults/ani2x.toml
+++ b/modelforge/tests/data/dataset_defaults/ani2x.toml
@@ -3,3 +3,10 @@ dataset_name = "ANI2x"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["atomic_numbers", "geometry", "energies", "forces"]
+
+[dataset.properties_assignment]
+atomic_numbers = "atomic_numbers"
+positions = "geometry"
+E = "energies"
+F = "forces"

--- a/modelforge/tests/data/dataset_defaults/phalkethoh.toml
+++ b/modelforge/tests/data/dataset_defaults/phalkethoh.toml
@@ -3,3 +3,11 @@ dataset_name = "PHALKETHOH"
 version_select = "nc_1000_v1"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["geometry", "atomic_numbers", "dft_total_energy", "dft_total_force", "total_charge", "scf_dipole"]
+
+[dataset.properties_assignment]
+atomic_numbers = "atomic_numbers"
+positions = "geometry"
+E = "dft_total_energy"
+F = "dft_total_force"
+dipole_moment = "scf_dipole"

--- a/modelforge/tests/data/dataset_defaults/qm9.toml
+++ b/modelforge/tests/data/dataset_defaults/qm9.toml
@@ -3,3 +3,9 @@ dataset_name = "QM9"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["atomic_numbers", "geometry", "internal_energy_at_0K", "dipole_moment"]
+
+[dataset.properties_assignment]
+atomic_numbers = "atomic_numbers"
+positions = "geometry"
+E = "internal_energy_at_0K"

--- a/modelforge/tests/data/dataset_defaults/spice1.toml
+++ b/modelforge/tests/data/dataset_defaults/spice1.toml
@@ -3,3 +3,12 @@ dataset_name = "SPICE1"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["atomic_numbers", "geometry", "dft_total_energy", "dft_total_force", "total_charge", "scf_dipole"]
+
+[dataset.properties_assignment]
+atomic_numbers = "atomic_numbers"
+positions = "geometry"
+E = "dft_total_energy"
+F = "dft_total_force"
+total_charge = "total_charge"
+dipole_moment = "scf_dipole"

--- a/modelforge/tests/data/dataset_defaults/spice1_openff.toml
+++ b/modelforge/tests/data/dataset_defaults/spice1_openff.toml
@@ -3,3 +3,11 @@ dataset_name = "SPICE1_OPENFF"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["atomic_numbers", "geometry", "dft_total_energy", "dft_total_force", "total_charge"]
+
+[dataset.properties_assignment]
+atomic_numbers = "atomic_numbers"
+positions = "geometry"
+E = "dft_total_energy"
+F = "dft_total_force"
+total_charge = "total_charge"

--- a/modelforge/tests/data/dataset_defaults/spice2.toml
+++ b/modelforge/tests/data/dataset_defaults/spice2.toml
@@ -3,3 +3,12 @@ dataset_name = "SPICE2"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["atomic_numbers", "geometry", "dft_total_energy", "dft_total_force", "total_charge", "scf_dipole"]
+
+[dataset.properties_assignment]
+atomic_numbers = "atomic_numbers"
+positions = "geometry"
+E = "dft_total_energy"
+F = "dft_total_force"
+total_charge = "total_charge"
+dipole_moment = "scf_dipole"

--- a/modelforge/tests/data/dataset_defaults/tmqm.toml
+++ b/modelforge/tests/data/dataset_defaults/tmqm.toml
@@ -3,3 +3,11 @@ dataset_name = "tmqm"
 version_select = "nc_1000_v0"
 num_workers = 4
 pin_memory = true
+properties_of_interest = ["atomic_numbers", "geometry", "total_energy", "total_charge", "dipole_moment_computed", "dipole_moment_computed_scaled"]
+
+[dataset.properties_assignment]
+atomic_numbers = "atomic_numbers"
+positions = "geometry"
+E = "total_energy"
+total_charge = "total_charge"
+dipole_moment = "dipole_moment_computed"

--- a/modelforge/tests/test_dataset.py
+++ b/modelforge/tests/test_dataset.py
@@ -774,6 +774,33 @@ def test_dataset_splitting(
 
 
 @pytest.mark.parametrize("dataset_name", ["QM9"])
+def test_properties_assignment(
+    dataset_name,
+    datamodule_factory,
+    prep_temp_dir,
+):
+    """Test random_split on the the dataset."""
+    dm = datamodule_factory(
+        dataset_name=dataset_name,
+        batch_size=512,
+        version_select="nc_1000_v0",
+        local_cache_dir=str(prep_temp_dir),
+        properties_of_interest=[
+            "atomic_numbers",
+            "geometry",
+            "internal_energy_at_0K",
+            "dipole_moment",
+        ],
+        properties_assignment={
+            "E": "internal_energy_at_0K",
+            "positions": "geometry",
+            "atomic_numbers": "atomic_numbers",
+            "dipole_moment": "dipole_moment",
+        },
+    )
+
+
+@pytest.mark.parametrize("dataset_name", ["QM9"])
 def test_dataset_downloader(dataset_name, dataset_factory, prep_temp_dir):
     """
     Test the DatasetDownloader functionality.

--- a/modelforge/tests/test_parameter_models.py
+++ b/modelforge/tests/test_parameter_models.py
@@ -14,6 +14,17 @@ def test_dataset_parameter_model():
         "version_select": "latest",
         "num_workers": 4,
         "pin_memory": True,
+        "properties_of_interest": [
+            "atomic_numbers",
+            "geometry",
+            "internal_energy_at_0K",
+            "dipole_moment",
+        ],
+        "properties_assignment": {
+            "atomic_numbers": "atomic_numbers",
+            "positions": "geometry",
+            "E": "internal_energy_at_0K",
+        },
     }
 
     dataset_parameters = DatasetParameters(**dataset_parameter_dict)
@@ -24,6 +35,17 @@ def test_dataset_parameter_model():
         "version_select": "latest",
         "num_workers": -1,
         "pin_memory": True,
+        "properties_of_interest": [
+            "atomic_numbers",
+            "geometry",
+            "internal_energy_at_0K",
+            "dipole_moment",
+        ],
+        "properties_assignment": {
+            "atomic_numbers": "atomic_numbers",
+            "positions": "geometry",
+            "E": "internal_energy_at_0K",
+        },
     }
 
     with pytest.raises(ValidationError):
@@ -34,6 +56,17 @@ def test_dataset_parameter_model():
         "dataset_name": "QM9",
         "version_select": "latest",
         "num_workers": 4,
+        "properties_of_interest": [
+            "atomic_numbers",
+            "geometry",
+            "internal_energy_at_0K",
+            "dipole_moment",
+        ],
+        "properties_assignment": {
+            "atomic_numbers": "atomic_numbers",
+            "positions": "geometry",
+            "E": "internal_energy_at_0K",
+        },
     }
 
     with pytest.raises(ValidationError):
@@ -45,6 +78,17 @@ def test_dataset_parameter_model():
         "version_select": "latest",
         "num_workers": 4,
         "pin_memory": "totally_true",
+        "properties_of_interest": [
+            "atomic_numbers",
+            "geometry",
+            "internal_energy_at_0K",
+            "dipole_moment",
+        ],
+        "properties_assignment": {
+            "atomic_numbers": "atomic_numbers",
+            "positions": "geometry",
+            "E": "internal_energy_at_0K",
+        },
     }
 
     with pytest.raises(ValidationError):
@@ -57,6 +101,28 @@ def test_dataset_parameter_model():
     # check the validator that asserts number of workers must be greater than 0 during assignment
     with pytest.raises(ValidationError):
         dataset_parameters.num_workers = 0
+
+    # test the validator to  ensure properties_assignment has values in properties_of_interest
+    dataset_parameter_dict = {
+        "dataset_name": "QM9",
+        "version_select": "latest",
+        "num_workers": -1,
+        "pin_memory": True,
+        "properties_of_interest": [
+            "atomic_numbers",
+            "geometry",
+            "internal_energy_at_0K",
+            "dipole_moment",
+        ],
+        "properties_assignment": {
+            "atomic_numbers": "atomic_numbers",
+            "positions": "geometry",
+            "E": "internal_energy_at_300K",
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        dataset_parameters = DatasetParameters(**dataset_parameter_dict)
 
 
 def test_convert_str_to_unit():

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1701,6 +1701,8 @@ class PotentialTrainer:
                     name=experiment_name,
                 ),
             )
+
+            log.debug(f'tags: {self._generate_tags(["tensorboard"])}')
         elif self.training_parameter.experiment_logger.logger_name == "wandb":
             from modelforge.utils.io import check_import
 
@@ -1909,14 +1911,27 @@ class PotentialTrainer:
         """Generates tags for the experiment."""
         import modelforge
 
+        try:
+            version = modelforge.__version__
+        except:
+            # for editable local install
+            from modelforge._version import __version__
+
+            version = __version__
+        losses = [
+            f"loss-{loss}"
+            for loss in self.training_parameter.loss_parameter.loss_components
+        ]
         tags.extend(
             [
-                str(modelforge.__version__),
+                str(version),
                 self.dataset_parameter.dataset_name,
                 self.potential_parameter.potential_name,
-                f"loss-{'-'.join(self.training_parameter.loss_parameter.loss_components)}",
+                # f"loss-{'-'.join(self.training_parameter.loss_parameter.loss_components)}",
             ]
         )
+        tags.extend(losses)
+
         return tags
 
 

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -47,6 +47,7 @@ from modelforge.train.parameters import RuntimeParameters, TrainingParameters
 
 import matplotlib
 
+# Use Agg backend for matplotlib, to avoid tkinter issues when using profiler
 matplotlib.use("Agg")
 
 __all__ = [

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1638,6 +1638,8 @@ class PotentialTrainer:
                 split=self.training_parameter.splitting_strategy.data_split,
             ),
             regenerate_processed_cache=self.dataset_parameter.regenerate_processed_cache,
+            properties_of_interest=self.dataset_parameter.properties_of_interest,
+            properties_assignment=self.dataset_parameter.properties_assignment,
         )
         dm.prepare_data()
         dm.setup()

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -151,6 +151,10 @@ class CalculateProperties(torch.nn.Module):
         self.requested_properties = requested_properties
         self.include_force = "per_atom_force" in self.requested_properties
         self.include_charges = "per_system_total_charge" in self.requested_properties
+        # dipole_moment is calculated from charges, thus if dipole moment is requested
+        # we also need to calculate charges, even if we don't call per_system_total_charge
+        if "per_system_dipole_moment" in self.requested_properties:
+            self.include_charges = True
 
         # Ensure all requested properties are supported
         assert all(

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1914,7 +1914,9 @@ class PotentialTrainer:
         try:
             version = modelforge.__version__
         except:
-            # for editable local install
+            # Note, for an  editable local install (i.e., pip install -e )
+            # you often can't find __version__, but if you import directly from _version.py
+            # you can fake it, so you can still log version and not crash the code here
             from modelforge._version import __version__
 
             version = __version__

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1643,7 +1643,7 @@ class PotentialTrainer:
             ),
             regenerate_processed_cache=self.dataset_parameter.regenerate_processed_cache,
             properties_of_interest=self.dataset_parameter.properties_of_interest,
-            properties_assignment=self.dataset_parameter.properties_assignment,
+            properties_assignment=self.dataset_parameter.properties_assignment.model_dump(),
         )
         dm.prepare_data()
         dm.setup()

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -45,6 +45,10 @@ T_NNP_Parameters = TypeVar(
 from modelforge.train.losses import LossFactory, create_error_metrics
 from modelforge.train.parameters import RuntimeParameters, TrainingParameters
 
+import matplotlib
+
+matplotlib.use("Agg")
+
 __all__ = [
     "PotentialTrainer",
 ]


### PR DESCRIPTION
## Pull Request Summary
This provides changes aimed at improving the control over datasets.  Specifically, the switch to .toml files meant we could not easily toggle which properties to load from the hdf5 files nor which properties to assign to the key internal variables (energy, force, dipole_moment, etc.). 

This updates the pydantic dataset model whereby users now additionally define properties of interest (as a list) and then the association of these properties to the internal variable names (i.e used by the `Properties` class).  The pydantic model validates that anything in the Properties association also exists in the properties_of_interest list.   We do not validate that the properties_of_interest are actually in the hdf5 file via the pydantic model; this is handled when we assign those parameters while calling the `DataModule` class.  Since this is one of the earliest steps in the process, failure to properly define these should lead to a rapid failure.  this saves considerable extra code in the pydantic model, and having to make separate models for each dataset. 

 
### Key changes
Notable points that this PR has either accomplished or will accomplish.
 - [x] Allow better control over datasets via .toml files
 - [x] Fix buffer issue when logging to wandb
 - [x] Fix logic whereby using dipole moment in the loss required total charge as well (since dipole moment requires charges.  This is fixed such that charges are calculated if dipole moment is requested, even if total charge is not in the loss). 
 - [x] bug fix to spice1_openff curation (wrong tag for scf_dipole). 
 - [x] change backend for matplotlib to prevent issues when using debugger

### Associated Issue(s)
 - [ ] #326 
 - [ ] #325 
 - [ ] #324 

## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [x] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review