### PR TITLE
Adding additional versions of tmqm.

### DIFF
--- a/modelforge/curation/scripts/limit_tmqm.py
+++ b/modelforge/curation/scripts/limit_tmqm.py
@@ -1,0 +1,96 @@
+import h5py
+
+# This file will read in the tmqm hdf5 file and create a few datasets of restricted configurations
+# Functionality is being added to filter datasets at run time, but this is designed to be an intermediate solution.
+
+file_path = "/home/cri/datasets/hdf5_files/tmqm_dataset_v0.hdf5"
+
+
+# Create a dataset that contains transition metals Pd, Zn, Fe, Cu
+# This should be 27685 molecules
+primary_tm_to_extract = [46, 30, 26, 29]
+primary_tm_to_extract_list = []
+
+# a second set will include Pd, Zn, Fe, Cu, Ni, Pt, Ir, Rh, Cr, Ag
+# This will be 60637 molecules
+primary_and_secondary_tm_to_extract = [46, 30, 26, 29, 28, 78, 77, 45, 24, 47]
+primary_and_secondary_tm_to_extract_list = []
+
+# Limit organics to C, H, P, S O, N, F Cl, Br by excluding
+# any that contain B, Si, As, Se, I
+
+exclude_organics = [5, 14, 33, 16, 53]
+primary_tm_excluded_organics_list = []
+primary_and_secondary_tm_excluded_organics_list = []
+
+file_output_primary = "/home/cri/datasets/hdf5_files/tmqm_dataset_PdZnFeCu_v0.hdf5"
+file_output_primary_excluded_organics = (
+    "/home/cri/datasets/hdf5_files/tmqm_dataset_PdZnFeCu_CHPSONFClBr_v0.hdf5"
+)
+file_output_primary_secondary = (
+    "/home/cri/datasets/hdf5_files/tmqm_dataset_PdZnFeCuNiPtIrRhCrAg_v0.hdf5"
+)
+file_output_primary_secondary_excluded_organics = "/home/cri/datasets/hdf5_files/tmqm_dataset_PdZnFeCuNiPtIrRhCrAg_CHPSONFClBr_v0.hdf5"
+
+
+with h5py.File(file_path, "r") as f:
+    keys = list(f.keys())
+    for i in range(len(keys)):
+        key = keys[i]
+        atomic_numbers = f[key]["atomic_numbers"][()]
+
+        for tm_atomic_number in primary_tm_to_extract:
+            if tm_atomic_number in atomic_numbers:
+                primary_tm_to_extract_list.append(key)
+
+                add_mol = True
+                for organic_atomic_number in exclude_organics:
+                    if organic_atomic_number in atomic_numbers:
+                        add_mol = False
+                if add_mol:
+                    primary_tm_excluded_organics_list.append(key)
+
+        for tm_atomic_number in primary_and_secondary_tm_to_extract:
+            if tm_atomic_number in atomic_numbers:
+                primary_and_secondary_tm_to_extract_list.append(key)
+
+                add_mol = True
+                for organic_atomic_number in exclude_organics:
+                    if organic_atomic_number in atomic_numbers:
+                        add_mol = False
+                if add_mol:
+                    primary_and_secondary_tm_excluded_organics_list.append(key)
+
+with h5py.File(file_output_primary, "w") as fout:
+    with h5py.File(file_path, "r") as fin:
+        for key in primary_tm_to_extract_list:
+            fin.copy(fin[key], fout, key)
+
+with h5py.File(file_output_primary_excluded_organics, "w") as fout:
+    with h5py.File(file_path, "r") as fin:
+        for key in primary_tm_excluded_organics_list:
+            fin.copy(fin[key], fout, key)
+
+with h5py.File(file_output_primary_secondary, "w") as fout:
+    with h5py.File(file_path, "r") as fin:
+        for key in primary_and_secondary_tm_to_extract_list:
+            fin.copy(fin[key], fout, key)
+
+with h5py.File(file_output_primary_secondary_excluded_organics, "w") as fout:
+    with h5py.File(file_path, "r") as fin:
+        for key in primary_and_secondary_tm_excluded_organics_list:
+            fin.copy(fin[key], fout, key)
+
+print("number of molecules in primary set: ", len(primary_tm_to_extract_list))
+print(
+    "number of molecules in primary set excluding organics: ",
+    len(primary_tm_excluded_organics_list),
+)
+print(
+    "number of molecules in primary and secondary set: ",
+    len(primary_and_secondary_tm_to_extract_list),
+)
+print(
+    "number of molecules in primary and secondary set excluding organics: ",
+    len(primary_and_secondary_tm_excluded_organics_list),
+)

--- a/modelforge/dataset/yaml_files/tmqm.yaml
+++ b/modelforge/dataset/yaml_files/tmqm.yaml
@@ -29,3 +29,59 @@ nc_1000_v0:
     md5: null
     name: tmqm_dataset_v0_nc_1000_processed.npz
   url: https://zenodo.org/records/14188628/files/tmqm_dataset_v0_ntc_1000.hdf5.gz
+subset_v0_PdZnFeCu:
+  version: 0
+  doi: 10.5281/zenodo.14662046
+  gz_data_file:
+    length: 328369864
+    md5: ac6238ed997edf3c5dd004c65948938e
+    name: tmqm_dataset_v0_PdZnFeCu.hdf5.gz
+  hdf5_data_file:
+    md5: 473c51eb0a7f7aa505b5b2f6d8ab7a2e
+    name: tmqm_dataset_v0_PdZnFeCu.hdf5
+  processed_data_file:
+    md5: null
+    name: tmqm_dataset_v0_PdZnFeCu_processed.npz
+  url: https://zenodo.org/records/14662046/files/tmqm_dataset_PdZnFeCu_v0.hdf5.gz
+subset_v0_PdZnFeCu_CHPSONFClBr:
+  version: 0
+  doi: 10.5281/zenodo.14662151
+  gz_data_file:
+    length: 219402320
+    md5: 3848feb003ee0741a9605b80dd0442e0
+    name: tmqm_dataset_v0_PdZnFeCu_CHPSONFClBr.hdf5.gz
+  hdf5_data_file:
+    md5: 6b347b14a99dfaff0806e27c3eb95822
+    name: tmqm_dataset_v0_PdZnFeCu_CHPSONFClBr.hdf5
+  processed_data_file:
+    md5: null
+    name: tmqm_dataset_v0_PdZnFeCu_CHPSONFClBr_processed.npz
+  url: https://zenodo.org/records/14662151/files/tmqm_dataset_PdZnFeCu_CHPSONFClBr_v0.hdf5.gz
+subset_v0_PdZnFeCuNiPtIrRhCrAg:
+  version: 0
+  doi: 10.5281/zenodo.14662309
+  gz_data_file:
+    length: 718394696
+    md5: 574f18b68f61d1d8a2390e31fb821836
+    name: tmqm_dataset_v0_PdZnFeCuNiPtIrRhCrAg.hdf5.gz
+  hdf5_data_file:
+    md5: 868757f857992f9ae1deba6988852bde
+    name: tmqm_dataset_v0_PdZnFeCuNiPtIrRhCrAg.hdf5
+  processed_data_file:
+    md5: null
+    name: tmqm_dataset_v0_PdZnFeCuNiPtIrRhCrAg_processed.npz
+  url: https://zenodo.org/records/14662309/files/tmqm_dataset_PdZnFeCuNiPtIrRhCrAg_v0.hdf5.gz
+subset_v0_PdZnFeCuNiPtIrRhCrAg_CHPSONFClBr:
+  version: 0
+  doi: 10.5281/zenodo.14662340
+  gz_data_file:
+    length: 483656824
+    md5: 5afa78ba84f575332dc10b4c9aa5c924
+    name: tmqm_dataset_v0_PdZnFeCuNiPtIrRhCrAg_CHPSONFClBr.hdf5.gz
+  hdf5_data_file:
+    md5: 413fe18c26c2962620f491d8b5b248bf
+    name: tmqm_dataset_v0_PdZnFeCuNiPtIrRhCrAg_CHPSONFClBr.hdf5
+  processed_data_file:
+    md5: null
+    name: tmqm_dataset_v0_PdZnFeCuNiPtIrRhCrAg_CHPSONFClBr_processed.npz
+  url: https://zenodo.org/records/14662340/files/tmqm_dataset_PdZnFeCuNiPtIrRhCrAg_CHPSONFClBr_v0.hdf5.gz


### PR DESCRIPTION
## Pull Request Summary
Provide 4 additional subsets of the tmqm dataset

### Key changes
various subsets:
- Pd, Zn, Fe, Cu: 27685 molecules
- Pd, Zn, Fe, Cu and then exclude any molecules that contain elements not in the set: C, H, P, S, O, N, F, Cl, Br: 18515 molecules
- Pd, Zn, Fe, Cu, Ni, Pt, Ir, Rh, Cr, Ag: 60637 molecules
- Pd, Zn, Fe, Cu, Ni, Pt, Ir, Rh, Cr, Ag and then exclude any molecules that contain elements not in the set: C, H, P, S, O, N, F, Cl, Br: 40866 molecules


### Associated Issue(s)
 - [ ] #329 

## Pull Request Checklist
 - [ ] Issue(s) raised/addressed and linked
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) added/updated
 - [ ] Appropriate .rst doc file(s) added/updated
 - [ ] PR is ready for review