### PR TITLE
Bug fix: dimers + unique_pairs_only

### DIFF
--- a/modelforge-curate/modelforge/curate/examples/basic_usage.ipynb
+++ b/modelforge-curate/modelforge/curate/examples/basic_usage.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "from modelforge.curate import Record, SourceDataset\n",
     "from modelforge.curate.units import GlobalUnitSystem\n",
-    "from modelforge.curate.properties import AtomicNumbers, Positions, Energies, Forces, MetaData\n",
+    "from modelforge.curate import AtomicNumbers, Positions, Energies, Forces, MetaData\n",
     "\n",
     "from openff.units import unit\n",
     "\n",
@@ -40,7 +40,7 @@
    "metadata": {},
    "source": [
     "## Set up a new dataset\n",
-    "To start, we will create an instance of the `SourceDataset` class to store the dataset, providing a `name` for the dataset as a string. "
+    "Next, we will create an instance of the `SourceDataset` class to store the dataset, providing a `name` for the dataset as a string. "
    ]
   },
   {
@@ -48,15 +48,7 @@
    "execution_count": 2,
    "id": "bad426d0-eb06-44b3-8ec5-7bb7cb016e0a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2025-03-08 22:36:55.240\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mmodelforge.curate.curate\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m481\u001b[0m - \u001b[33m\u001b[1mDatabase file test_dataset.sqlite already exists in ./. Removing it.\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "new_dataset = SourceDataset(name=\"test_dataset\")"
    ]
@@ -90,18 +82,20 @@
     "The curate packages provides pydantic models for many common properties reported in datasets. \n",
     "\n",
     "Each record must include a few basic elements to be considered complete, namely:\n",
-    "- atomic numbers\n",
-    "- positions\n",
-    "- energies\n",
+    "- **atomic numbers**\n",
+    "- **positions**\n",
+    "- **energies**\n",
     "  \n",
     "Records may of course contain other properties/metadata, but this is the minimal set of information required by modelforge during training. \n",
     "\n",
+    "### Property classifications\n",
+    "Properties are classified into four categories. These categories are used to validate the inputs (including the shape of the underlying arrays).  These classifications are also used within modelforge to know how to parse information from the dataset (as the shape of the associated array itself may not be sufficient).  \n",
     "\n",
-    "Note, properties are classified into four categories. These categories are used to validate the inputs (including the shape of the underlying arrays).  These classifications are also used within modelforge to know how to parse information from the dataset.  The four categories as as follows: \n",
-    "- atomic_numbers -- array must have a shape (n_atoms,1); regardless of the number of configurations in a property, the atomic numbers must be consistent\n",
-    "- per_system -- array must have a at least 2 dimensions, where the first dimensions (n_configs, X) -- Energy is an example of a per_system property with shape (n_configs, 1)\n",
-    "- per_atom -- array must have at least 3 dimensions, where the first two dimensions correspond to (n_configs, n_atoms, X). Partial charge is an example of a per_atom property with shape (n_config, n_atoms, 1)\n",
-    "- meta_data -- there are no shape requirements for meta_data, however, input is limited to (string, float, int, list, numpy_array)\n",
+    "The four categories as as follows: \n",
+    "- **atomic_numbers** -- array must have a shape (n_atoms,1). Regardless of the number of configurations in a property, the atomic numbers must be consistent, and thus do not need to be defined separately for each configuration.\n",
+    "- **per_system** -- array must have a at least 2 dimensions, where the first dimension corresponds to the configuration, i.e., (n_configs, X). Energy is an example of a per_system property with shape (n_configs, 1)\n",
+    "- **per_atom** -- array must have at least 3 dimensions, where the first two dimensions correspond to the configuration, and the second the atom, i.e., (n_configs, n_atoms, X). Partial charge is an example of a per_atom property with shape (n_config, n_atoms, 1)\n",
+    "- **meta_data** -- there are no shape requirements for meta_data, however, input is limited to the following types: string, float, int, list, numpy array\n",
     "\n",
     "Users do not need to set the classification of a property for the pre-defined models within the module; the appropriate value is defined by default. "
    ]
@@ -112,7 +106,7 @@
    "metadata": {},
    "source": [
     "### Defining atomic numbers\n",
-    "Let us first start by considering how to initialize atomic numbers, in this case for an example CH molecule:"
+    "Let us consider how to initialize atomic numbers, in this case for a methane CH4:"
    ]
   },
   {
@@ -122,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "atomic_numbers = AtomicNumbers(value=np.array([[1], [6]]))"
+    "atomic_numbers = AtomicNumbers(value=np.array([[6], [1], [1], [1], [1]]))"
    ]
   },
   {
@@ -142,7 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "atomic_numbers = AtomicNumbers(value=[[1], [6]])"
+    "atomic_numbers = AtomicNumbers(value=[[6], [1], [1], [1], [1]])"
    ]
   },
   {
@@ -152,11 +146,11 @@
    "source": [
     "### Defining positions\n",
     "\n",
-    "To define positions, we will use the `Positions` pydantic model.  Since positions must have units associated with them, they must also be set at the time of initialization; the model does not include a default unit. \n",
+    "To define positions, we will use the `Positions` pydantic model.  Since positions must have units associated with them, they must be set at the time of initialization.  The property models do not include a default unit, unless the property does not require units (e.g., such as `AtomicNumbers`). \n",
     "\n",
-    "Units can be passed as an openff.units `Unit` or a string that can be understood by openff.units. An error will be raised if units are not defined, or if the units passed are not compatible (i.e., not a length measurement).\n",
+    "Units can be passed as an openff.units `Unit` or a string that can be understood by openff.units. An error will be raised if units are not defined, or if the units passed are not compatible (i.e., not a length measurement for `Positions`).\n",
     "\n",
-    "Positions are a \"per_atom\" property storing the x,y, and z positions, and thus must be 3d array with shape (n_configs, n_atoms, 3).\n",
+    "Positions are a \"per_atom\" property storing the x,y, and z positions and thus must be 3d array with shape (n_configs, n_atoms, 3).\n",
     "If `value.shape[2] !=3` or `len(value.shape) != 3`, this will raise an error.  \n",
     "\n"
    ]
@@ -169,7 +163,7 @@
    "outputs": [],
    "source": [
     "positions = Positions(\n",
-    "    value=np.array([[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]]]), \n",
+    "    value=np.array([[[0.0, 0.0, 0.0], [0.109, 0.0, 0.0], [-0.054, 0.094, 0.0], [-0.054, -0.094, 0.0], [0.0, 0.0, 0.109]]]), \n",
     "    units=\"nanometer\"\n",
     ")"
    ]
@@ -192,8 +186,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "name='positions' value=array([[[1., 1., 1.],\n",
-      "        [2., 2., 2.]]]) units=<Unit('nanometer')> classification='per_atom' property_type='length' n_configs=1 n_atoms=2\n"
+      "name='positions' value=array([[[ 0.   ,  0.   ,  0.   ],\n",
+      "        [ 0.109,  0.   ,  0.   ],\n",
+      "        [-0.054,  0.094,  0.   ],\n",
+      "        [-0.054, -0.094,  0.   ],\n",
+      "        [ 0.   ,  0.   ,  0.109]]]) units=<Unit('nanometer')> classification='per_atom' property_type='length' n_configs=1 n_atoms=5\n"
      ]
     }
    ],
@@ -246,7 +243,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "smiles = MetaData(name='smiles', value='[CH]')"
+    "smiles = MetaData(name='smiles', value='C')"
    ]
   },
   {
@@ -256,7 +253,7 @@
    "source": [
     "### Other properties\n",
     "\n",
-    "Pydantic models have been defined for the following properties:\n",
+    "Pydantic models have been defined for the following properties at the time of creating this tutorial:\n",
     "- `atomic_numbers`\n",
     "- `Energies`\n",
     "- `Positions`\n",
@@ -274,11 +271,11 @@
     "- `BondOrders`\n",
     "- `MetaData`\n",
     "\n",
-    "Note, each of thes emodels inherits from a more general `PropertyBaseClass` pydantic model; this model can be used to define any additional properties, but requires the user to provide the classification (e.g., per_atom, per_system) and the property_type (for the purposes of unit conversion, e.g., length, energy, force, charge, etc.). \n",
+    "Note, each of these models inherits from a more general `PropertyBaseClass` pydantic model; this model can be used to define any additional properties, but requires the user to provide the classification (e.g., per_atom, per_system) and the property_type (for the purposes of unit conversion, e.g., length, energy, force, charge, etc.). \n",
     "\n",
     "Classes for additional properties can be added to the module as well; this set was generated based on what was encountered within the current datasets supported by `modelforge`.\n",
     "\n",
-    "##### More information on defining properties is provided in the \"defining_properties.ipynb\" notebook. "
+    "**More information on defining properties is provided in the \"defining_properties.ipynb\" notebook.**"
    ]
   },
   {
@@ -327,7 +324,7 @@
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
       "Cell \u001b[0;32mIn[11], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mrecord_mol1\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43madd_property\u001b[49m\u001b[43m(\u001b[49m\u001b[43menergies\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/PycharmProjects/modelforge/modelforge-curate/modelforge/curate/curate.py:413\u001b[0m, in \u001b[0;36mRecord.add_property\u001b[0;34m(self, property)\u001b[0m\n\u001b[1;32m    409\u001b[0m     error_msg \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mProperty with name \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mproperty\u001b[39m\u001b[38;5;241m.\u001b[39mname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m already exists in the record \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    410\u001b[0m     error_msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    411\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSet append_property=True to append to the existing property.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    412\u001b[0m     )\n\u001b[0;32m--> 413\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(error_msg)\n\u001b[1;32m    415\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m (\n\u001b[1;32m    416\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mper_system[\u001b[38;5;28mproperty\u001b[39m\u001b[38;5;241m.\u001b[39mname]\u001b[38;5;241m.\u001b[39mvalue\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m    417\u001b[0m     \u001b[38;5;241m==\u001b[39m \u001b[38;5;28mproperty\u001b[39m\u001b[38;5;241m.\u001b[39mvalue\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m    418\u001b[0m )\n\u001b[1;32m    419\u001b[0m temp_array \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mproperty\u001b[39m\u001b[38;5;241m.\u001b[39mvalue\n",
+      "File \u001b[0;32m~/PycharmProjects/modelforge/modelforge-curate/modelforge/curate/record.py:425\u001b[0m, in \u001b[0;36mRecord.add_property\u001b[0;34m(self, property)\u001b[0m\n\u001b[1;32m    421\u001b[0m     error_msg \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mProperty with name \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mproperty\u001b[39m\u001b[38;5;241m.\u001b[39mname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m already exists in the record \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    422\u001b[0m     error_msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    423\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSet append_property=True to append to the existing property.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    424\u001b[0m     )\n\u001b[0;32m--> 425\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(error_msg)\n\u001b[1;32m    427\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m (\n\u001b[1;32m    428\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mper_system[\u001b[38;5;28mproperty\u001b[39m\u001b[38;5;241m.\u001b[39mname]\u001b[38;5;241m.\u001b[39mvalue\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m    429\u001b[0m     \u001b[38;5;241m==\u001b[39m \u001b[38;5;28mproperty\u001b[39m\u001b[38;5;241m.\u001b[39mvalue\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m]\n\u001b[1;32m    430\u001b[0m )\n\u001b[1;32m    431\u001b[0m temp_array \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mproperty\u001b[39m\u001b[38;5;241m.\u001b[39mvalue\n",
       "\u001b[0;31mValueError\u001b[0m: Property with name energies already exists in the record mol1.Set append_property=True to append to the existing property."
      ]
     }
@@ -389,18 +386,24 @@
      "output_type": "stream",
      "text": [
       "name: mol1\n",
-      "* n_atoms: 2\n",
+      "* n_atoms: 5\n",
       "* n_configs: 1\n",
       "* atomic_numbers:\n",
-      " -  name='atomic_numbers' value=array([[1],\n",
-      "       [6]]) units=<Unit('dimensionless')> classification='atomic_numbers' property_type='atomic_numbers' n_configs=None n_atoms=2\n",
+      " -  name='atomic_numbers' value=array([[6],\n",
+      "       [1],\n",
+      "       [1],\n",
+      "       [1],\n",
+      "       [1]]) units=<Unit('dimensionless')> classification='atomic_numbers' property_type='atomic_numbers' n_configs=None n_atoms=5\n",
       "* per-atom properties: (['positions']):\n",
-      " -  name='positions' value=array([[[1., 1., 1.],\n",
-      "        [2., 2., 2.]]]) units=<Unit('nanometer')> classification='per_atom' property_type='length' n_configs=1 n_atoms=2\n",
+      " -  name='positions' value=array([[[ 0.   ,  0.   ,  0.   ],\n",
+      "        [ 0.109,  0.   ,  0.   ],\n",
+      "        [-0.054,  0.094,  0.   ],\n",
+      "        [-0.054, -0.094,  0.   ],\n",
+      "        [ 0.   ,  0.   ,  0.109]]]) units=<Unit('nanometer')> classification='per_atom' property_type='length' n_configs=1 n_atoms=5\n",
       "* per-system properties: (['energies']):\n",
       " -  name='energies' value=array([[0.1]]) units=<Unit('hartree')> classification='per_system' property_type='energy' n_configs=1 n_atoms=None\n",
       "* meta_data: (['smiles'])\n",
-      " -  name='smiles' value='[CH]' units=<Unit('dimensionless')> classification='meta_data' property_type='meta_data' n_configs=None n_atoms=None\n",
+      " -  name='smiles' value='C' units=<Unit('dimensionless')> classification='meta_data' property_type='meta_data' n_configs=None n_atoms=None\n",
       "\n"
      ]
     }
@@ -427,14 +430,20 @@
      "data": {
       "text/plain": [
        "{'name': 'mol1',\n",
-       " 'n_atoms': 2,\n",
+       " 'n_atoms': 5,\n",
        " 'n_configs': 1,\n",
-       " 'atomic_numbers': AtomicNumbers(name='atomic_numbers', value=array([[1],\n",
-       "        [6]]), units=<Unit('dimensionless')>, classification='atomic_numbers', property_type='atomic_numbers', n_configs=None, n_atoms=2),\n",
-       " 'per_atom': {'positions': Positions(name='positions', value=array([[[1., 1., 1.],\n",
-       "          [2., 2., 2.]]]), units=<Unit('nanometer')>, classification='per_atom', property_type='length', n_configs=1, n_atoms=2)},\n",
+       " 'atomic_numbers': AtomicNumbers(name='atomic_numbers', value=array([[6],\n",
+       "        [1],\n",
+       "        [1],\n",
+       "        [1],\n",
+       "        [1]]), units=<Unit('dimensionless')>, classification='atomic_numbers', property_type='atomic_numbers', n_configs=None, n_atoms=5),\n",
+       " 'per_atom': {'positions': Positions(name='positions', value=array([[[ 0.   ,  0.   ,  0.   ],\n",
+       "          [ 0.109,  0.   ,  0.   ],\n",
+       "          [-0.054,  0.094,  0.   ],\n",
+       "          [-0.054, -0.094,  0.   ],\n",
+       "          [ 0.   ,  0.   ,  0.109]]]), units=<Unit('nanometer')>, classification='per_atom', property_type='length', n_configs=1, n_atoms=5)},\n",
        " 'per_system': {'energies': Energies(name='energies', value=array([[0.1]]), units=<Unit('hartree')>, classification='per_system', property_type='energy', n_configs=1, n_atoms=None)},\n",
-       " 'meta_data': {'smiles': MetaData(name='smiles', value='[CH]', units=<Unit('dimensionless')>, classification='meta_data', property_type='meta_data', n_configs=None, n_atoms=None)}}"
+       " 'meta_data': {'smiles': MetaData(name='smiles', value='C', units=<Unit('dimensionless')>, classification='meta_data', property_type='meta_data', n_configs=None, n_atoms=None)}}"
       ]
      },
      "execution_count": 14,
@@ -444,6 +453,46 @@
    ],
    "source": [
     "record_mol1.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3dd8692-cec0-4ef8-80b8-bd4999615637",
+   "metadata": {},
+   "source": [
+    "Records can be converted to RDKit molecules. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d18eaf81-3596-4be9-83fa-aafd514a9016",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rd_mol = record_mol1.to_rdkit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "af51c524-45c6-4d63-b366-7f1eea0b1d16",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAK9klEQVR4nO3de0zV9R/H8c/3cDBA0QgHx0U/NsNz6NiFVGquQxdzMqytdVmSZenstvxDECO0FZkZtFzSlnNJXnDpVmORf5jdNHMt10Y7hqntoOYEdgYIEnA4cjl8f3+czcrKA3y+3+/n4Hk+xhzg+4/XHOfF+3PO93vUdF0XAICxsqkOAADjGzUKAFKoUQCQQo0CgBRqFACkUKMAIMWuOgAU+OGHH7799lshRHJycklJScT5o0ePfv7550IITdPKy8tNzweMKxrXjcagioqKtWvXCiEcDoff7484v3PnzmXLloU/5wcGuAyHegCQQo0CgBRqFACkUKMAIIUaBQAp1CgASKFGAUAKNQoAUqhRAJDCzaAxrbW1derUqRHH+vv7LQgDjFPUaEzTdb2jo0N1CmB8o0Zjms1mmzZtWsSxvr6+CxcuWJAHGI+o0ZiWlpbW3Nwcceyvb00C4DK8xAQAUqhRAJBCjQKAFGoUAKRQowAghRoFACnUKABIoUYBQAo1CgBSqFEAkMLNoLHogQceSE9PF0IkJSWNZN7j8Wzbtk0IoWmaucmAcUjTdV11BgAYxzjUY0QGBwfff//9goICfu8Cl2EbxYj09vY6nU6/37979+7FixerjgNEEbZRjMikSZM2bNgghCgtLQ0EAqrjAFGEGsVIPfPMM7m5uS0tLe+++67qLEAU4VCPUThy5Mhdd92VkJBw8uTJzMxM1XGAqMA2ilGYO3fuokWLgsFgWVmZ6ixAtGAbxeg0NzdnZ2cHAoHDhw/n5eWpjgOoxzaK0cnIyCgpKRFCrFy5cnh4WHUcQD22UYxaMBjMzs4+d+7cjh07li5dqjoOoBg1irHYvXv3U089lZ6e7vP5Jk+erDoOoBKHeozF4sWLPR5Pa2trZWWl6iyAYmyjGKOff/75jjvusNvtx48fz8rKUh0HUIZtFGM0e/bsJ598cmBggIufEOPYRjF2LS0t2dnZvb2933zzzfz581XHAdRgG8XYXX/99a+88ooQYvXq1aFQSHUcQA22UUi5ePHiTTfddPbs2a1btz733HOq4wAKUKOQ9emnny5atCgtLc3n802ZMkV1HMBqHOoh6/HHH7/77rvb2treeust1VkABdhGYQCv1ztnzhy73X7s2DGn06k6DmAptlEY4Pbbb1+6dOnAwMDLL7+sOgtgNbZRGKOtrc3pdP7xxx9ffvllfn6+6jiAddhGYYy0tLQ1a9YIIVatWjU0NKQ6DmAdahSGKS4unjFjxokTJz788EPVWQDrcKiHkerq6h555JGUlJTGxsbU1FTVcQArsI3CSA8//PCCBQsuXLjw5ptvqs4CWIRtFAY7ceLEbbfdJoTwer0333yz6jiA6dhGYTC32/3ss88ODQ0VFxerzgJYgW0Uxuvs7JwxY0ZnZ+e+ffsWLlyoOg5gLmoUxqupqamrq9u7d29GRsbp06cnTJhw5fna2tqmpiYhhNvtjoZrTquqqsKPi/z8fLfbHXG+urq6t7dXCOHxeHJzc03Ph2ijA0ZzuVyXfsA2bdoUcf7ee+8NDz/99NMWxIvoUvgdO3aMZN7hcITn3377bZOjIRrx3CjMtW7duvPnz6tOAZiIGoWJpk+f3tXV9frrr6sOApiIGoWJ5s2bFx8fv3Xr1oaGBtVZALNQozBRamrqiy++GAqFuPgJVzG76gC4ym36+uuSuLjQwYMBh2PixIn/MpGYeGNi4iGrcwGGoUZholXbtsV1dGSGX/tubf2vsRUpKdusCwUYjEM9TJTS1SV0PdTQsNDlulGI6rIycfr03z727BFCaFy8jPGMGoXp4rKySjZvPiNEyebN/sREMX36nx/TpqlOB8iiRmGF+++//8EHH+zp6eHiJ1x9eG4UJgqFQvFCzJw586KmDQ4Oapr20Ucf7d+//5prrgkP3BkM7hGiu7tbbc7/Ulpaun79+ohj7e3tFoRB1KJGYSJd14UQv//+e/Av32xpabn0+f+EEEIMDw+Hv9y1a9euXbusy/d3DofD7/f/9Tvt7e1UJCKiRmG6SZMmxQkhhOjv7x8cHFScZjQSEhLs9siPkUAgoPMqWQzjuVGYKNxBbW1tPT09Xq/XZrPZbLb6+vpL7+nw3XffCSGuvfba8Lzatya5bBUVQmzZsqVnBNLT0y3+h0VUoUZhkaKiov7+/uXLl8+ePVt1FsBI1CiscODAgX379iUnJ/N/NOHqw3OjMF3o1KmNL700XYiyFSscfX3izJk//+4f52hg3KFGYSLdZhNCxN166/7w15WVorLyX8Y0zdJYgKGoUZiotqCg8JdfmpqaQqGQw+FISkr6l6HExM2JiaK+3vJ0gDGoUZioITv7yA03fPDBB/PmzTtw4MB/jZ2+7z4rUwHGokZhoo6Ojpqamri4uKqqKtVZALPwSj1MdPDgwcHBwRdeeOGWW25RnQUwCzUKE505cyYlJWXdunWqgwAmokZhrvLy8qlTp6pOAZhI07kXGEarqampq6vbu3dvZmZmY2NjfHz8ledra2ubmpqEEG63Oz8/35KMV1JVVRV+XOTn57vd7ojz1dXVvb29QgiPx5Obm2t6PkQZahTGa29vdzqdXV1dX3zxRUFBgeo4gLk41MN4r732WldX1/z58+lQxAK2URjs+PHjOTk5QoijR4/OnDlTdRzAdGyjMFhxcfHQ0NCKFSvoUMQItlEY6bPPPnv00Uevu+46n8+XmpqqOg5gBbZRGGZgYKCsrEwIsX79ejoUsYMahWHee++9xsZGt9v9/PPPq84CWIdDPYzR2trqdDq7u7u/+uqrBQsWqI4DWIdtFMZYs2ZNd3f3Qw89RIci1rCNwgBer3fOnDl2u/3YsWNOp1N1HMBSbKMwQFFR0fDw8MqVK+lQxCC2Ucj65JNPCgsL09LSfD7flClTVMcBrMY2CinBYDB8kdOGDRvoUMQmahRSNm7cePbs2ZycnGXLlqnOAqjBoR5j19LS4nK5AoHAoUOH7rnnHtVxADXYRjF2ZWVlgUDgscceo0MRy9hGMUY//fTT3LlzJ0yY8Ouvv2ZlZamOAyjDNoqx0HW9pKQk/CcdihjHNoqx+Pjjj5csWZKenu7z+SZPnqw6DqAS2yhGLRgMvvrqq0KId955hw4FqFGMWkVFxblz52bNmrVkyRLVWQD1ONRjdJqbm10uVzAY/P777/Py8lTHAdRjG8XorF69uq+vr7CwkA4FwthGMQo//vijx+NJSEg4efJkZmam6jhAVGAbxUgNDw8XFRXpul5aWkqHApewjWKktm/fvnz58oyMjN9++23ixImq4wDRghrFiPT09LhcLr/fv2fPnieeeEJ1HCCKxL3xxhuqM2Ac0DTNbrfbbLaKigpN01THAaII2ygASLGrDgAFGhoa6uvrhRBJSUmFhYUR50+dOnX48GEhhKZpvK8ocBm20VhUUVGxdu1aIYTD4fD7/RHnd+7ceak9+YEBLsMFTwAghRoFACnUKABIoUYBQAo1CgBSqFEAkEKNAoAUahQApFCjACCFm0Fj2vnz52fNmhVxrLOz04IwwDhFjca0oaEhr9erOgUwvnGoBwAp1GhMczgcoRHYvn276qRA9OJQH+tstsi/SnmfZuAK2EYBQAo1CgBSqFEAkEKNAoAUahQApFCjACCFGgUAKdQoAEihRgFACncxxaK8vLzy8nIhRHJy8kjmc3JywvPczgT8k6bruuoMADCOcagHACnUKABIoUYBQAo1CgBSqFEAkEKNAoCU/wPxDy1LWvfXLAAAAGp6VFh0cmRraXRQS0wgcmRraXQgMjAyNC4wMy41AAB4nHu/b+09BiAQAGJGBghgBWIWIG5gZFPQAAmwMEJoRlw0N1ArEwMDM1ifE0hI3A1qICPMRDiQb+22h7ELbbn2X19cYI/E3o+uVgwAXR8Qu7bnLOQAAAC8elRYdE1PTCByZGtpdCAyMDI0LjAzLjUAAHichZBBDsIgEEX3nOJfoM2MhQXLAo0aU5ooegf33j8OKtJGrQOLYXjM/I9CjmM4XG94RxeUAmhlW2tx6YhIjcgJ3LDdR/jUu1Lx0zmmEwy0vJC1JPs0jaXC8KCWHvEtKdwGO3BL9h/XCddQa/Tr3uofoF6AzQpphPycWMUUbohhYe1p1k0xVLMsRrh6YtHLVTqLKq4CWUbzvPu8Vz6XL5dc3QFG9FbwxxAzYQAAAE56VFh0U01JTEVTIHJka2l0IDIwMjQuMDMuNQAAeJyL9oh11oj2iNUEE0CsUKNhqGdgqWOgY20AInQN9ExNdAz0LE1gbF0IByQLUqlZAwAtZg8eJTQRdQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<rdkit.Chem.rdchem.RWMol at 0x779f88f40720>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rd_mol."
    ]
   },
   {
@@ -460,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "56329f06-7440-44e9-82aa-4a1a38e1b874",
    "metadata": {
     "scrolled": true
@@ -480,29 +529,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "bac9ccc5-867a-4f54-a2ea-4f74cebb6cf0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 510.13it/s]\n",
-      "\u001b[32m2025-03-08 22:38:34.940\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mmodelforge.curate.curate\u001b[0m:\u001b[36mvalidate_records\u001b[0m:\u001b[36m1180\u001b[0m - \u001b[1mAll records validated successfully.\u001b[0m\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "new_dataset.validate_records()"
    ]
@@ -516,31 +546,72 @@
     "\n",
     "To save ths to an hdf5 file, we call the `to_hdf5` function of the `SourceDataset` class, passing the output path and filename. This will automatically perform the validation discussed above before we write to the file. \n",
     "\n",
-    "Additionally, when writing the file, it will convert records to a consistent unit system (by default, kilojoules_per_mole and nanometers are the base unit system for energy and distance), as defined by the `GlobalUnitSystem` class (discussed below).\n",
+    "Additionally, when writing the file, it will convert records to a consistent unit system (by default, `kilojoules_per_mole` and `nanometers` are the base unit system for energy and distance), as defined by the `GlobalUnitSystem` class (discussed below).\n",
     "\n",
     "Note this returns the md5 checksum of the file. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "5f32cd4f-330d-4ebf-a27f-1a36b6751103",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2025-03-08 22:38:35.781\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mmodelforge.curate.curate\u001b[0m:\u001b[36mto_hdf5\u001b[0m:\u001b[36m1312\u001b[0m - \u001b[1mValidating records\u001b[0m\n",
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 377.80it/s]\n",
-      "\u001b[32m2025-03-08 22:38:35.785\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mmodelforge.curate.curate\u001b[0m:\u001b[36mvalidate_records\u001b[0m:\u001b[36m1180\u001b[0m - \u001b[1mAll records validated successfully.\u001b[0m\n",
-      "\u001b[32m2025-03-08 22:38:35.786\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mmodelforge.curate.curate\u001b[0m:\u001b[36mto_hdf5\u001b[0m:\u001b[36m1315\u001b[0m - \u001b[1mWriting records to .//test_dataset.hdf5\u001b[0m\n",
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 413.31it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "checksum = new_dataset.to_hdf5(file_path=\"./\", file_name=\"test_dataset.hdf5\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49fe5937-552e-4948-a3f1-559c65181184",
+   "metadata": {},
+   "source": [
+    "## Reading from an HDF5 file\n",
+    "\n",
+    "Any hdf5 files generate with the `modelforge.curate` module can also be loaded into an instance of `SourceDataset` using the `create_dataset_from_hdf5` function. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "098624a0-c6a3-40b1-9f32-da3799fdfc01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from modelforge.curate import create_dataset_from_hdf5\n",
+    "\n",
+    "new_dataset_from_hdf5 = create_dataset_from_hdf5(hdf5_filename=\"test_dataset.hdf5\", dataset_name=\"test_dataset2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4803c448-8e18-485d-bd7a-813a3e6fe436",
+   "metadata": {},
+   "source": [
+    "If we examine the original dataset and the one loaded from the hdf5 file we will see they contain the same information. \n",
+    "\n",
+    "Note that, because we convert units when we write to file (as discussed above), the \"energies\" property is in units of `kilojoules_per_mole` for the dataset read in from the file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b23c1b6-6fda-49b9-8144-f8de08ca42c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"original dataset\\n\")\n",
+    "print(\" -records:\", new_dataset.keys())\n",
+    "print(\" -total records: \",new_dataset.total_records())\n",
+    "print(\" -total configs: \", new_dataset.total_configs())\n",
+    "print(\" -record mol1: \\n\\n\", new_dataset.get_record(\"mol1\"))\n",
+    "\n",
+    "print(\"***************\\n\")\n",
+    "print(\"dataset generated from hdf5\\n\")\n",
+    "print(\" -records:\", new_dataset_from_hdf5.keys())\n",
+    "print(\" -total records: \",new_dataset_from_hdf5.total_records())\n",
+    "print(\" -total configs: \", new_dataset_from_hdf5.total_configs())\n",
+    "print(\" -record mol1: \\n\\n\", new_dataset_from_hdf5.get_record(\"mol1\"))\n"
    ]
   },
   {
@@ -548,7 +619,7 @@
    "id": "70d3c511-e525-4eee-bd5c-3aa00b38847d",
    "metadata": {},
    "source": [
-    "## Unit system and unit validation\n",
+    "## Global Unit system and unit validation\n",
     "\n",
     "When defining individual properties, units are also validated.  When defining a property, users can specify any unit that is:\n",
     "- (1) supported by openff.units\n",
@@ -561,23 +632,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "08fe229e-be4c-4648-80d8-8f0143aa8021",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValidationError",
-     "evalue": "1 validation error for Positions\n  Value error, Unit angstrom ** 2 of positions are not compatible with the property type length.\n [type=value_error, input_value={'value': [[[1.0, 1.0, 1....<Unit('angstrom ** 2')>}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.8/v/value_error",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[18], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m pos \u001b[38;5;241m=\u001b[39m \u001b[43mPositions\u001b[49m\u001b[43m(\u001b[49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m[\u001b[49m\u001b[43m[\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m1.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m1.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m1.0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m2.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m2.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m2.0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m3.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m3.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m3.0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43munits\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43munit\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mangstrom\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43munit\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mangstrom\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/anaconda3/envs/modelforge311/lib/python3.11/site-packages/pydantic/main.py:193\u001b[0m, in \u001b[0;36mBaseModel.__init__\u001b[0;34m(self, **data)\u001b[0m\n\u001b[1;32m    191\u001b[0m \u001b[38;5;66;03m# `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks\u001b[39;00m\n\u001b[1;32m    192\u001b[0m __tracebackhide__ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[0;32m--> 193\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__pydantic_validator__\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalidate_python\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mself_instance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "\u001b[0;31mValidationError\u001b[0m: 1 validation error for Positions\n  Value error, Unit angstrom ** 2 of positions are not compatible with the property type length.\n [type=value_error, input_value={'value': [[[1.0, 1.0, 1....<Unit('angstrom ** 2')>}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.8/v/value_error"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pos = Positions(value=[[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]], units=unit.angstrom*unit.angstrom)\n"
    ]
@@ -592,34 +650,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "4684a979-8564-4639-96c4-806c0ab55a8e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "area : nanometer ** 2\n",
-      "atomic_numbers : dimensionless\n",
-      "charge : elementary_charge\n",
-      "dimensionless : dimensionless\n",
-      "dipole_moment : elementary_charge * nanometer\n",
-      "energy : kilojoule_per_mole\n",
-      "force : kilojoule_per_mole / nanometer\n",
-      "frequency : gigahertz\n",
-      "heat_capacity : kilojoule_per_mole / kelvin\n",
-      "length : nanometer\n",
-      "name : default\n",
-      "octupole_moment : elementary_charge * nanometer ** 3\n",
-      "polarizability : nanometer ** 3\n",
-      "quadrupole_moment : elementary_charge * nanometer ** 2\n",
-      "wavenumber : 1 / centimeter\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from modelforge.curate.curate import GlobalUnitSystem\n",
+    "from modelforge.curate import GlobalUnitSystem\n",
     "print(GlobalUnitSystem())"
    ]
   },
@@ -633,18 +669,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "13a1259d-3b2c-46df-b7ce-0d26ea572282",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "angstrom\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "GlobalUnitSystem.set_global_units('length', unit.angstrom)\n",
     "\n",
@@ -661,18 +689,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "97b5878b-9ad7-4bef-97af-79031c5ea269",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "standard_atmosphere\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "GlobalUnitSystem.set_global_units('pressure', unit.atmosphere)\n",
     "\n",
@@ -689,23 +709,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "a1fcc5e4-350c-4b37-bbcf-49d77f9c017a",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValidationError",
-     "evalue": "1 validation error for Positions\n  Value error, Unit angstrom of positions are not compatible with the property type length.\n [type=value_error, input_value={'value': [[[1.0, 1.0, 1....ts': <Unit('angstrom')>}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.8/v/value_error",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[22], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m GlobalUnitSystem\u001b[38;5;241m.\u001b[39mset_global_units(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mlength\u001b[39m\u001b[38;5;124m'\u001b[39m, unit\u001b[38;5;241m.\u001b[39mhartree)\n\u001b[0;32m----> 2\u001b[0m pos \u001b[38;5;241m=\u001b[39m \u001b[43mPositions\u001b[49m\u001b[43m(\u001b[49m\u001b[43mvalue\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m[\u001b[49m\u001b[43m[\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m1.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m1.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m1.0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m2.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m2.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m2.0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m3.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m3.0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m3.0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43munits\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43munit\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mangstrom\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/anaconda3/envs/modelforge311/lib/python3.11/site-packages/pydantic/main.py:193\u001b[0m, in \u001b[0;36mBaseModel.__init__\u001b[0;34m(self, **data)\u001b[0m\n\u001b[1;32m    191\u001b[0m \u001b[38;5;66;03m# `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks\u001b[39;00m\n\u001b[1;32m    192\u001b[0m __tracebackhide__ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[0;32m--> 193\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__pydantic_validator__\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalidate_python\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mself_instance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "\u001b[0;31mValidationError\u001b[0m: 1 validation error for Positions\n  Value error, Unit angstrom of positions are not compatible with the property type length.\n [type=value_error, input_value={'value': [[[1.0, 1.0, 1....ts': <Unit('angstrom')>}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.8/v/value_error"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "GlobalUnitSystem.set_global_units('length', unit.hartree)\n",
     "pos = Positions(value=[[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]], units=unit.angstrom)"
@@ -713,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "29ebda4c-cb79-42ed-bb34-05a264427d08",
    "metadata": {},
    "outputs": [],
@@ -726,13 +733,84 @@
    "id": "f23d946a-668c-4cbe-9e9e-1ff43742f066",
    "metadata": {},
    "source": [
-    "When hdf5 files are generated, quantities are automatically convert to the units specified in the `GlobalUnitSystem`. \n"
+    "When hdf5 files are generated, quantities are automatically convert to the units specified in the `GlobalUnitSystem`. Note, this is not an inplace transformation, it does not change the values of the underlying properties. \n",
+    "\n",
+    "\n",
+    "### Converting units of properties stored in the dataset\n",
+    "\n",
+    "The following will perform an inplace unit conversion of a property (i.e., that updates the values stored in the property).  This will check for unit compatibility. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "3b63ca3b-b33d-4918-94e8-48116d9e80d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print out initial energies property\n",
+    "\n",
+    "print(energies)\n",
+    "\n",
+    "# perform unit conversion \n",
+    "energies.convert_units(unit.kilocalorie_per_mole)\n",
+    "\n",
+    "print(energies)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41e00671-4f81-4f63-ad28-b55283edd859",
+   "metadata": {},
+   "source": [
+    "The following will convert all properties in a record to the `GlobalUnitSystem`.  note this will not perform unit conversion for meta_data. Note, since `positions` are already in units of `nanometer` these will not be changed, but `energies`  will be converted from `hartrees` to `kilojoule_per_mole`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c3b71f8-be34-4e92-87d0-d6646b0b326f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#first print out the record\n",
+    "print(record_mol1)\n",
+    "\n",
+    "# convert units \n",
+    "\n",
+    "record_mol1.convert_to_global_unit_system()\n",
+    "\n",
+    "print(record_mol1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00c82a10-12ff-420e-99e8-3d17d00761a7",
+   "metadata": {},
+   "source": [
+    "All records and properties in a dataset can be converted as well using the `convert_to_global_unit_system`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3123e13c-9406-4bfd-9f0b-122732d3d567",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print the initial dataset \n",
+    "print(new_dataset.get_record('mol1'))\n",
+    "\n",
+    "new_dataset.convert_to_global_unit_system()\n",
+    "\n",
+    "#print out after conversion\n",
+    "print(new_dataset.get_record('mol1'))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c635199-0e01-4d60-96a7-0e767a4f8e9c",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -814,6 +814,12 @@ class ANI2xCore(torch.nn.Module):
             The calculated per-atom properties and the scalar representation of AEVs.
         """
 
+        # print(pairlist_output.r_ij)
+        # print(pairlist_output.d_ij)
+        # print(data.atomic_numbers)
+        # print(data.positions)
+        # print(data.atomic_subsystem_indices)
+
         # Compute AEVs (atomic environment vectors)
         representation = self.ani_representation_module(
             data, pairlist_output, atom_index

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -283,6 +283,7 @@ class ANIRepresentation(nn.Module):
             atom_index=atom_index,
             pairlist_output=pairlist_output,
         )
+
         processed_radial_feature_vector = postprocessed_radial_aev_and_additional_data[
             "radial_aev"
         ]

--- a/modelforge/potential/ani.py
+++ b/modelforge/potential/ani.py
@@ -404,10 +404,10 @@ class ANIRepresentation(nn.Module):
         species = atom_index
         species12 = species[
             atom_index12
-        ]  # Shape [2, num_pairs], this is the pair index but now with optimzied indexing
+        ]  # Shape [2, num_pairs], this is the pair index but now with optimiZed indexing
 
         # What are we doing here? we generate an atomic environment vector with
-        # fixed dimensinos (nr_of_supported_elements, 16 (represents number of
+        # fixed dimensions (nr_of_supported_elements, 16 (represents number of
         # radial symmetry functions)) for each **element** per atom (in a pair)
 
         # this is a magic indexing function that works
@@ -813,12 +813,6 @@ class ANI2xCore(torch.nn.Module):
         Dict[str, torch.Tensor]
             The calculated per-atom properties and the scalar representation of AEVs.
         """
-
-        # print(pairlist_output.r_ij)
-        # print(pairlist_output.d_ij)
-        # print(data.atomic_numbers)
-        # print(data.positions)
-        # print(data.atomic_subsystem_indices)
 
         # Compute AEVs (atomic environment vectors)
         representation = self.ani_representation_module(

--- a/modelforge/potential/neighbors.py
+++ b/modelforge/potential/neighbors.py
@@ -432,7 +432,7 @@ class NeighborlistForInference(torch.nn.Module):
             positions[self.i_pairs], positions[self.j_pairs], box_vectors, is_periodic
         )
 
-        in_cutoff = (d_ij < self.cutoff_plus_skin).squeeze()
+        in_cutoff = (d_ij < self.cutoff_plus_skin).squeeze().reshape(-1)
         # self.nlist_i_pairs = self.i_pairs[in_cutoff]
         # self.nlist_j_pairs = self.j_pairs[in_cutoff]
 
@@ -562,7 +562,7 @@ class NeighborlistForInference(torch.nn.Module):
             data.box_vectors,
             data.is_periodic,
         )
-        in_cutoff = (d_ij <= self.cutoff).squeeze()
+        in_cutoff = (d_ij <= self.cutoff).squeeze().reshape(-1)
         total_pairs = in_cutoff.sum()
 
         if self.only_unique_pairs:
@@ -683,7 +683,7 @@ class NeighborlistForInference(torch.nn.Module):
             )
 
         # identify which pairs in the neighbor list are within the cutoff
-        in_cutoff = (d_ij <= self.cutoff).squeeze()
+        in_cutoff = (d_ij <= self.cutoff).squeeze().reshape(-1)
         total_pairs = in_cutoff.sum()
 
         # we can take advantage of the pairwise nature to just copy the unique pairs to non-unique pairs
@@ -824,7 +824,7 @@ class NeighborListForTraining(torch.nn.Module):
         r_ij = self.calculate_r_ij(pair_indices, positions)
         d_ij = self.calculate_d_ij(r_ij)
 
-        in_cutoff = (d_ij <= self.cutoff).squeeze()
+        in_cutoff = (d_ij <= self.cutoff).squeeze().reshape(-1)
         # Get the atom indices within the cutoff
         pair_indices_within_cutoff = pair_indices[:, in_cutoff]
 
@@ -876,7 +876,6 @@ class NeighborListForTraining(torch.nn.Module):
                 i_final_pairs = i_indices[unique_pairs_mask]
                 j_final_pairs = j_indices[unique_pairs_mask]
                 pair_list = torch.stack((i_final_pairs, j_final_pairs))
-
         pairlist_output = self._calculate_interacting_pairs(
             positions=positions,
             atomic_subsystem_indices=atomic_subsystem_indices,

--- a/modelforge/potential/representation.py
+++ b/modelforge/potential/representation.py
@@ -155,7 +155,7 @@ class AngularSymmetryFunction(nn.Module):
         Compute the angular subAEV terms of the center atom given neighbor
         pairs.
 
-        This correspond to equation (4) in the ANI paper. This function just
+        This corresponds to equation (4) in the ANI paper. This function just
         compute the terms. The sum in the equation is not computed.
 
         Parameters
@@ -175,7 +175,7 @@ class AngularSymmetryFunction(nn.Module):
         fcj12_prod = fcj12.prod(dim=0)  # Shape: (n_pairs,)
 
         # cos_angles: (n_pairs,)
-
+        # multiplied by 0.95  to prevent acos from returning NaN.
         cos_angles = 0.95 * torch.nn.functional.cosine_similarity(
             vectors12[0], vectors12[1], dim=-1
         )
@@ -214,8 +214,10 @@ class AngularSymmetryFunction(nn.Module):
 
         # Flatten the last two dimensions to get the final subAEV
         # ret: (n_pairs, ShfZ_size * ShfA_size)
-        ret = ret.reshape(distances12.size(dim=1), -1)
+        ret = ret.flatten(start_dim=1)
 
+        # The following fails when ret is empty; flatten  as used above, does not fail
+        # ret = ret.reshape(distances12.size(dim=1), -1)
         return ret
 
 

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -263,7 +263,7 @@ def test_forward_and_backward(mode):
 
 
 def test_representation():
-    # Compare the reference radial symmetry function output against the the
+    # Compare the reference radial symmetry function output against the
     # implemented radial symmetry function
     import torch
     from modelforge.potential import (

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -300,3 +300,59 @@ def test_representation():
     # cutoff values
     reference_rsf = provide_reference_values_for_test_ani_test_compare_rsf()
     assert torch.allclose(calculated_rsf, reference_rsf, rtol=1e-4)
+
+
+def test_dimer_representation():
+    import torch
+    from modelforge.potential.ani import ANIRepresentation
+    from modelforge.potential.neighbors import NeighborListForTraining
+    from modelforge.utils.prop import NNPInput
+
+    # set up representation
+    angle_sections = 4
+    maximum_interaction_radius = 0.51
+    minimum_interaction_radius = 0.08
+    number_of_radial_basis_functions = 16
+    maximum_interaction_radius_for_angular_features = 0.35
+    minimum_interaction_radius_for_angular_features = 0.08
+    angular_dist_divisions = 8
+
+    representation = ANIRepresentation(
+        radial_max_distance=maximum_interaction_radius,
+        radial_min_distance=minimum_interaction_radius,
+        number_of_radial_basis_functions=number_of_radial_basis_functions,
+        maximum_interaction_radius_for_angular_features=maximum_interaction_radius_for_angular_features,
+        minimum_interaction_radius_for_angular_features=minimum_interaction_radius_for_angular_features,
+        angular_dist_divisions=angular_dist_divisions,
+        angle_sections=angle_sections,
+    )
+
+    # set up NNP input
+    atomic_numbers = torch.tensor([17, 17], dtype=torch.int32)
+    positions = torch.tensor(
+        [[0.0000e00, 0.0000e00, 1.0118e-01], [1.2391e-17, 0.0000e00, -1.0118e-01]]
+    )
+    atomic_subsystem_indices = torch.tensor([0, 0], dtype=torch.int32)
+    per_system_total_charge = torch.tensor([0], dtype=torch.int32)
+    pair_list = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+
+    dimer_system = NNPInput(
+        atomic_numbers=atomic_numbers,
+        positions=positions,
+        atomic_subsystem_indices=atomic_subsystem_indices,
+        per_system_total_charge=per_system_total_charge,
+        pair_list=pair_list,
+    )
+
+    # set up neighbor list
+    nlist = NeighborListForTraining(
+        cutoff=0.51,
+        only_unique_pairs=True,
+    )
+
+    nlist_output = nlist.forward(dimer_system)
+
+    representation_output = representation(
+        dimer_system, nlist_output, torch.tensor([6, 6])
+    )
+    assert representation_output.aevs.shape == (2, 1008)

--- a/modelforge/tests/test_pairlist.py
+++ b/modelforge/tests/test_pairlist.py
@@ -193,6 +193,52 @@ def test_pairlist():
     assert not pair_indices.shape == neighbor_indices.shape
 
 
+def test_neighborlists_for_dimer():
+    import torch
+    from modelforge.utils.prop import NNPInput
+
+    atomic_numbers = torch.tensor([17, 17], dtype=torch.int32)
+    positions = torch.tensor(
+        [[0.0000e00, 0.0000e00, 1.0118e-01], [1.2391e-17, 0.0000e00, -1.0118e-01]]
+    )
+    atomic_subsystem_indices = torch.tensor([0, 0], dtype=torch.int32)
+    per_system_total_charge = torch.tensor([0], dtype=torch.int32)
+    pair_list = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+
+    test_system = NNPInput(
+        atomic_numbers=atomic_numbers,
+        positions=positions,
+        atomic_subsystem_indices=atomic_subsystem_indices,
+        per_system_total_charge=per_system_total_charge,
+        pair_list=pair_list,
+    )
+
+    from modelforge.potential.neighbors import (
+        NeighborListForTraining,
+        NeighborlistForInference,
+        OrthogonalDisplacementFunction,
+    )
+
+    nlist_inf = NeighborlistForInference(
+        cutoff=0.51,
+        only_unique_pairs=True,
+        displacement_function=OrthogonalDisplacementFunction(),
+    )
+
+    nlist_inf_output = nlist_inf.forward(test_system)
+    assert nlist_inf_output.pair_indices.shape == (2, 1)
+    assert nlist_inf_output.r_ij.shape == (1, 3)
+    assert nlist_inf_output.d_ij.shape == (1, 1)
+
+    nlist_train = NeighborListForTraining(cutoff=0.51, only_unique_pairs=True)
+
+    nlist_train_output = nlist_train.forward(test_system)
+
+    assert nlist_train_output.pair_indices.shape == (2, 1)
+    assert nlist_train_output.r_ij.shape == (1, 3)
+    assert nlist_train_output.d_ij.shape == (1, 1)
+
+
 def test_pairlist_precomputation():
     import numpy as np
     import torch

--- a/modelforge/tests/test_pairlist.py
+++ b/modelforge/tests/test_pairlist.py
@@ -238,6 +238,23 @@ def test_neighborlists_for_dimer():
     assert nlist_train_output.r_ij.shape == (1, 3)
     assert nlist_train_output.d_ij.shape == (1, 1)
 
+    nlist_inf = NeighborlistForInference(
+        cutoff=0.51,
+        only_unique_pairs=False,
+        displacement_function=OrthogonalDisplacementFunction(),
+    )
+
+    nlist_inf_output = nlist_inf.forward(test_system)
+    assert nlist_inf_output.pair_indices.shape == (2, 2)
+    assert nlist_inf_output.r_ij.shape == (2, 3)
+    assert nlist_inf_output.d_ij.shape == (2, 1)
+
+    nlist_train = NeighborListForTraining(cutoff=0.51, only_unique_pairs=False)
+    nlist_train_output = nlist_train.forward(test_system)
+    assert nlist_train_output.pair_indices.shape == (2, 2)
+    assert nlist_train_output.r_ij.shape == (2, 3)
+    assert nlist_train_output.d_ij.shape == (2, 1)
+
 
 def test_pairlist_precomputation():
     import numpy as np


### PR DESCRIPTION
## Pull Request Summary

This fixes a bug where the shape of the underlying tensors in the PairListData was incorrect when evaluating the neighbors of a dimer with unique_pairs_only. 

This issue stemmed from squeezing the array for masking; when that mask only had dimension 1, it was squashed. The addition of a reshape(-1) fixes this issue. Tests for the dimer edge case were also added. 

This also addresses the issue with calculating the AngularSymmetryFunction for dimers.  As discussed in the linked issue, for a dimer, where there are no angles, this tensor is empty.  Reshaping the empty tensor was undefined; changing this to use flatten instead works for all cases.   This edge case was missed in the ani testing due to the fact the 1000 conformer test say does not feature one of the ~10 dimer systems in the dataset (and thus failure was only observed when training with the full dataset).  Additional tests still are required to cover this edge case. 





### Associated Issue(s)
 - [x] #347 

## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [x] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review