### PR TITLE
revise aimnet2 output layer

### DIFF
--- a/devtools/conda-envs/test_env_mac_modelforge_openmm.yaml
+++ b/devtools/conda-envs/test_env_mac_modelforge_openmm.yaml
@@ -27,6 +27,8 @@ dependencies:
   - graphviz
   - openmm
   - openmm-torch
+  - tad-dftd3
+  - tad-mctc==0.4.3
 
   # Testing
   - pytest>=2.1

--- a/devtools/conda-envs/test_env_modelforge_openmm.yaml
+++ b/devtools/conda-envs/test_env_modelforge_openmm.yaml
@@ -27,6 +27,8 @@ dependencies:
   - graphviz
   - openmm
   - openmm-torch
+  - tad-dftd3
+  - tad-mctc==0.4.3
 
   # Testing
   - pytest>=2.1

--- a/modelforge/potential/aimnet2.py
+++ b/modelforge/potential/aimnet2.py
@@ -101,7 +101,7 @@ class AimNet2Core(torch.nn.Module):
         # Define output layers to calculate per-atom predictions
         self.output_layers = nn.ModuleDict()
         for property, dim in zip(predicted_properties, predicted_dim):
-            self.output_layers[property] = mlp_factory(
+            self.output_layers[property] = mlp_init(
                 n_in_features=number_of_per_atom_features,
                 n_out_features=int(dim),
                 activation_function=self.activation_function,
@@ -263,14 +263,30 @@ from torch import Tensor
 from typing import Tuple
 
 
-def mlp_factory(
+def mlp_init(
     n_in_features: int,
     n_out_features: int,
     activation_function: nn.Module,
     hidden_layers: List[int],
 ) -> nn.Sequential:
     """
-    Helper function to create a dense layer with an activation function.
+    Helper function to create a sequence of dense layers with an activation function.
+
+
+    Parameters
+    ----------
+    n_in_features : int
+        Number of input features for the first layer.
+    n_out_features : int
+        Number of output features for the last layer.
+    activation_function : nn.Module
+        Activation function to be applied after each hidden layer.
+    hidden_layers : List[int]
+        List of integers specifying the number of features for each hidden layer.
+        First element is the number of output features of the first layer,
+        and the last element is the number of input features of the final layer.
+        If only a single value is provided, it will be used as the output size of the first layer
+        and input size of the final layer (no intermediate layers will be created).
     """
 
     # Single MLP producing combined outputs
@@ -334,7 +350,7 @@ class AIMNet2InteractionModule(nn.Module):
             )
 
         # Single MLP producing combined outputs
-        self.mlp = mlp_factory(
+        self.mlp = mlp_init(
             n_in_features=self.number_of_input_features,
             n_out_features=self.number_of_per_atom_features + 2,
             activation_function=activation_function,

--- a/modelforge/potential/aimnet2.py
+++ b/modelforge/potential/aimnet2.py
@@ -108,17 +108,6 @@ class AimNet2Core(torch.nn.Module):
                 hidden_layers=output_module_hidden_layers,
             )
 
-            # self.output_layers[property] = nn.Sequential(
-            #     Dense(
-            #         number_of_per_atom_features,
-            #         number_of_per_atom_features,
-            #         activation_function=self.activation_function,
-            #     ),
-            #     Dense(
-            #         number_of_per_atom_features,
-            #         int(dim),
-            #     ),
-            # )
         from modelforge.potential.processing import ChargeConservation
 
         self.charge_conservation = ChargeConservation()

--- a/modelforge/potential/parameters.py
+++ b/modelforge/potential/parameters.py
@@ -230,6 +230,7 @@ class AimNet2Parameters(ParametersBase):
         interaction_module_hidden_layers: List[
             List[int]
         ]  # for each interaction module, a list of the sizes of the hidden layers
+        output_module_hidden_layers: List[int]
         activation_function_parameter: ActivationFunctionConfig
         featurization: Featurization
         predicted_properties: List[str]

--- a/modelforge/potential/potential.py
+++ b/modelforge/potential/potential.py
@@ -327,10 +327,18 @@ class Potential(torch.nn.Module):
             torch.jit.script(neighborlist) if jit_neighborlist else neighborlist
         )
         # note cannot jit compile the dispersion interactions as tad-dftd3 is not compatible with torchscript
+        if "per_system_vdw_energy" in postprocessing._registered_properties:
+            log.warning(
+                "JIT compiling the postprocessing module with vdw interactions will not work."
+            )
+            log.warning(
+                "The tad-DFTD3 packaged used is not compatible with torchscript."
+            )
+            log.warning("Disabling JIT compilation by setting jit=False.")
+
         self.postprocessing = (
             torch.jit.script(postprocessing) if jit else postprocessing
         )
-        self.postprocessing = postprocessing
 
     def _add_total_charge(
         self, core_output: Dict[str, torch.Tensor], input_data: NNPInput

--- a/modelforge/potential/processing.py
+++ b/modelforge/potential/processing.py
@@ -1066,16 +1066,6 @@ class DispersionPotential(torch.nn.Module):
             ),
             -1,
         )
-        energies = torch.sum(
-            d3.dftd3(
-                numbers=atomic_numbers,
-                positions=positions,
-                param=self.params,
-                cutoff=self.cutoff,
-                ref=d3.Reference(device=device, dtype=positions.dtype),
-            ),
-            -1,
-        )
 
         data["per_system_vdw_energy"] = (
             energies.reshape(-1, 1) * self.energy_conversion_factor

--- a/modelforge/potential/processing.py
+++ b/modelforge/potential/processing.py
@@ -7,7 +7,9 @@ from typing import Dict, Iterator, Union, List
 
 import torch
 from openff.units import unit
-from modelforge.utils.units import GlobalUnitSystem, chem_context
+import tad_dftd3 as d3
+import tad_mctc as mctc
+
 
 from modelforge.dataset.utils import _ATOMIC_NUMBER_TO_ELEMENT
 
@@ -283,7 +285,7 @@ def default_charge_conservation(
 
     Parameters
     ----------
-    partial_charges : torch.Tensor
+    per_atom_charge : torch.Tensor
         Tensor of partial charges for all atoms in all molecules.
     per_system_total_charge : torch.Tensor
         Tensor of desired total charges for each molecule.
@@ -978,7 +980,13 @@ class DispersionPotential(torch.nn.Module):
 
     """
 
-    def __init__(self, cutoff: float, parameter_set: str = "wB97M-D3(BJ)"):
+    def __init__(
+        self,
+        cutoff: float,
+        length_conversion_factor: float,
+        energy_conversion_factor: float,
+        parameter_set: str = "wB97M-D3(BJ)",
+    ):
         """
         Initializes the Dispersion potential module.
 
@@ -986,6 +994,12 @@ class DispersionPotential(torch.nn.Module):
         ----------
         cutoff : float
             The cutoff distance for the dispersion interaction in nanometers.
+        length_conversion_factor : float
+            The conversion factor to convert the length values from the global unit system to bohr.
+            This factor is provided here rather than using the global unit system directly.
+        energy_conversion_factor : float
+            The conversion factor to convert the energy returned by DFT-D3 (hartrees) to the global unit system.
+            This factor is provided here rather than using the global unit system directly.
         parameter_set : str, optional
             The parameter set to use for the dispersion calculation.
             Default is "wB97M-D3(BJ)".
@@ -1007,22 +1021,22 @@ class DispersionPotential(torch.nn.Module):
                 s8=torch.tensor(0.3908),
                 a2=torch.tensor(3.1280),
             )
+        self.length_conversion_factor = length_conversion_factor
+        self.energy_conversion_factor = energy_conversion_factor
+
         # dftd3 uses bohr for length, so we need to convert the cutoff
-        self.cutoff = (cutoff * GlobalUnitSystem.get_units("length")).to("bohr").m
+        self.cutoff = cutoff * self.length_conversion_factor
 
     def forward(self, data: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
-        import tad_dftd3 as d3
-        import tad_mctc as mctc
 
         atomic_numbers = data["atomic_numbers"]
+
         atomic_subsystem_indices = data["atomic_subsystem_indices"]
 
         device = atomic_subsystem_indices.device
 
         # need to convert the positions to bohr units
-        positions = (
-            (data["positions"] * GlobalUnitSystem.get_units("length")).to("bohr").m
-        )
+        positions = data["positions"] * self.length_conversion_factor
 
         # let us get the atomic subsystem counts so we can breakup the systems properly for batch processing
         mol_ids, atomic_subsystem_counts = torch.unique(
@@ -1052,11 +1066,19 @@ class DispersionPotential(torch.nn.Module):
             ),
             -1,
         )
+        energies = torch.sum(
+            d3.dftd3(
+                numbers=atomic_numbers,
+                positions=positions,
+                param=self.params,
+                cutoff=self.cutoff,
+                ref=d3.Reference(device=device, dtype=positions.dtype),
+            ),
+            -1,
+        )
 
         data["per_system_vdw_energy"] = (
-            (energies.reshape(-1, 1) * unit.hartree)
-            .to(GlobalUnitSystem.get_units("energy"), "chem")
-            .m
+            energies.reshape(-1, 1) * self.energy_conversion_factor
         )
 
         return data

--- a/modelforge/tests/data/potential_defaults/aimnet2.toml
+++ b/modelforge/tests/data/potential_defaults/aimnet2.toml
@@ -6,7 +6,8 @@ number_of_radial_basis_functions = 64
 number_of_vector_features = 8
 maximum_interaction_radius = "5.0 angstrom"
 number_of_interaction_modules = 3
-interaction_module_hidden_layers = [[128,128], [128,128], [128,128]]
+interaction_module_hidden_layers = [[512,380], [512,380], [512,380, 380]]
+output_module_hidden_layers = [128,128]
 predicted_properties = ["per_atom_energy"]
 predicted_dim = [1]
 

--- a/modelforge/tests/test_aimnet2.py
+++ b/modelforge/tests/test_aimnet2.py
@@ -158,71 +158,71 @@ def test_forward(single_batch_with_batchsize, prep_temp_dir, dataset_temp_dir):
 
     ref_per_system_energy = torch.tensor(
         [
-            [0.2630],
-            [-0.5150],
-            [-0.2999],
-            [-0.0297],
-            [-0.4382],
-            [-0.1805],
-            [0.5974],
-            [0.1770],
-            [0.0842],
-            [-0.2955],
-            [0.1295],
-            [-0.4067],
-            [0.4135],
-            [0.3202],
-            [0.2481],
-            [0.6696],
-            [0.0380],
-            [0.0834],
-            [-0.2613],
-            [-0.8373],
-            [0.2033],
-            [0.1554],
-            [0.0624],
-            [-0.3643],
-            [-0.7861],
-            [-0.0398],
-            [-0.4675],
-            [-0.1000],
-            [0.3265],
-            [0.2546],
-            [-0.1597],
-            [-0.9611],
-            [0.0653],
-            [-0.4411],
-            [0.2587],
-            [-0.1082],
-            [0.0461],
-            [0.0407],
-            [0.6725],
-            [0.3874],
-            [0.3393],
-            [0.1747],
-            [0.4048],
-            [0.1001],
-            [0.1496],
-            [0.2432],
-            [0.3578],
-            [0.2792],
-            [-0.3365],
-            [-0.3329],
-            [-0.8465],
-            [0.0463],
-            [-0.4385],
-            [0.1224],
-            [-0.0442],
-            [0.1029],
-            [-0.4559],
-            [-1.1701],
-            [-0.2714],
-            [0.0318],
-            [-0.8579],
-            [-0.3836],
-            [0.2487],
-            [-0.2728],
-        ],
+            [-0.2266],
+            [-0.0809],
+            [-0.0964],
+            [-0.0579],
+            [-0.0161],
+            [-0.1187],
+            [-0.2539],
+            [-0.2212],
+            [-0.1264],
+            [-0.0572],
+            [-0.1718],
+            [-0.2028],
+            [-0.3489],
+            [-0.3419],
+            [-0.3395],
+            [-0.2923],
+            [-0.2463],
+            [-0.2625],
+            [-0.3212],
+            [-0.3001],
+            [-0.5242],
+            [-0.4224],
+            [-0.0185],
+            [0.0447],
+            [0.1060],
+            [-0.0768],
+            [-0.0089],
+            [-0.1425],
+            [-0.1875],
+            [-0.2198],
+            [-0.1267],
+            [-0.1189],
+            [-0.2076],
+            [-0.1135],
+            [-0.2596],
+            [-0.3231],
+            [-0.2326],
+            [-0.2488],
+            [-0.4488],
+            [-0.4252],
+            [-0.4315],
+            [-0.3634],
+            [-0.3612],
+            [-0.3296],
+            [-0.4591],
+            [-0.3175],
+            [-0.2176],
+            [-0.2271],
+            [-0.4224],
+            [-0.1699],
+            [-0.2058],
+            [-0.0360],
+            [-0.0941],
+            [-0.8663],
+            [-0.6293],
+            [-0.1353],
+            [-0.0477],
+            [-0.1618],
+            [-0.2111],
+            [-0.2212],
+            [-0.2753],
+            [-0.2646],
+            [-0.3484],
+            [-0.2535],
+        ]
     )
 
     print(y_hat["per_system_energy"])
@@ -286,6 +286,30 @@ def test_mlp_initialization():
     assert interaction.mlp[2].out_features == hidden_layers[2]
     assert interaction.mlp[3].in_features == hidden_layers[2]
     assert interaction.mlp[3].out_features == num_per_atom_features + 2
+
+
+def test_mlp_init():
+    """mlp init function makes it easier to set up the MLP layers,
+    as we use the same basic structure also for the output layer"""
+
+    from modelforge.potential.aimnet2 import mlp_init
+
+    from modelforge.potential.utils import ACTIVATION_FUNCTIONS
+
+    mlp = mlp_init(
+        n_in_features=128,
+        n_out_features=2,
+        hidden_layers=[512, 256],
+        activation_function=ACTIVATION_FUNCTIONS["GeLU"](),
+    )
+
+    assert len(mlp) == 3, "MLP should have 3 layers."
+    assert mlp[0].in_features == 128
+    assert mlp[0].out_features == 512
+    assert mlp[1].in_features == 512
+    assert mlp[1].out_features == 256
+    assert mlp[2].in_features == 256
+    assert mlp[2].out_features == 2
 
 
 @pytest.mark.xfail(raises=NotImplementedError)

--- a/modelforge/tests/test_potentials.py
+++ b/modelforge/tests/test_potentials.py
@@ -238,6 +238,14 @@ def test_electrostatics():
 
 def test_dispersion_potential():
     from modelforge.potential.processing import DispersionPotential
+    from modelforge.utils.units import GlobalUnitSystem, chem_context
+
+    length_conversion_factor = (
+        (1.0 * GlobalUnitSystem.get_units("length")).to("bohr").magnitude
+    )
+    energy_conversion_factor = (
+        (1.0 * unit.hartree).to(GlobalUnitSystem.get_units("energy"), "chem").m
+    )
 
     # set up a minimal dict that would represent the core output for 2 non-interacting methane molecules
     core_output_dict = {}
@@ -255,7 +263,12 @@ def test_dispersion_potential():
         ]
     )
 
-    vdw = DispersionPotential(cutoff=100.0)
+    vdw = DispersionPotential(
+        cutoff=100.0,
+        length_conversion_factor=length_conversion_factor,
+        energy_conversion_factor=energy_conversion_factor,
+    )
+
     vdw_output = vdw(core_output_dict)
     assert vdw_output["per_system_vdw_energy"].shape == (1, 1)
     assert torch.allclose(
@@ -285,7 +298,11 @@ def test_dispersion_potential():
         ]
     )
 
-    vdw = DispersionPotential(cutoff=100.0)
+    vdw = DispersionPotential(
+        cutoff=100.0,
+        length_conversion_factor=length_conversion_factor,
+        energy_conversion_factor=energy_conversion_factor,
+    )
     vdw_output = vdw(core_output_dict)
     assert vdw_output["per_system_vdw_energy"].shape == (2, 1)
     assert torch.allclose(

--- a/modelforge/utils/units.py
+++ b/modelforge/utils/units.py
@@ -197,14 +197,11 @@ class GlobalUnitSystem:
         )
 
     def __getitem__(self, item):
-        # if item in cls.__dict__.keys():
-        #     return getattr(cls, item)
-        # else:
-        #     return None
         try:
             return getattr(self, item)
         except AttributeError:
             raise AttributeError(f"Unit {item} not found in the unit system.")
+            return getattr(self, item)
 
 
 def print_modelforge_unit_system():

--- a/modelforge/utils/units.py
+++ b/modelforge/utils/units.py
@@ -201,7 +201,6 @@ class GlobalUnitSystem:
             return getattr(self, item)
         except AttributeError:
             raise AttributeError(f"Unit {item} not found in the unit system.")
-            return getattr(self, item)
 
 
 def print_modelforge_unit_system():


### PR DESCRIPTION
## Pull Request Summary
As discussed in #369, this provides a means to adjust the hidden layers in the output layer of Aimnet2.  This is similar to PR #367 which revised this for the main interaction layer. 

Since the logic is the same for setting up output layer as the individual interaction  layers, I created a helper function to initialize the nn.Sequential instance that can be reused for both. 

### Associated Issue(s)
 - [ ] #367 

## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [x] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review