### PR TITLE
Curate: different strategies for generating records with a set maximum number of configurations

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -28,7 +28,7 @@ dependencies:
   - wandb>=0.18.5
   - pytorch
   - tad-dftd3
-  - tad-mctc==0.4.3
+  - tad-mctc #==0.4.3
 
   # Testing
   - pytest>=2.1

--- a/devtools/conda-envs/test_env_mac_modelforge_openmm.yaml
+++ b/devtools/conda-envs/test_env_mac_modelforge_openmm.yaml
@@ -28,7 +28,7 @@ dependencies:
   - openmm
   - openmm-torch
   - tad-dftd3
-  - tad-mctc==0.4.3
+  - tad-mctc #==0.4.3
 
   # Testing
   - pytest>=2.1

--- a/devtools/conda-envs/test_env_modelforge_openmm.yaml
+++ b/devtools/conda-envs/test_env_modelforge_openmm.yaml
@@ -28,7 +28,7 @@ dependencies:
   - openmm
   - openmm-torch
   - tad-dftd3
-  - tad-mctc==0.4.3
+  - tad-mctc #==0.4.3
 
   # Testing
   - pytest>=2.1

--- a/modelforge-curate/modelforge/curate/datasets/scripts/curate_tmqm_openff.py
+++ b/modelforge-curate/modelforge/curate/datasets/scripts/curate_tmqm_openff.py
@@ -25,7 +25,7 @@ def main():
 
     # We'll want to provide some simple means of versioning
     # if we make updates to either the underlying dataset, curation modules, or parameters given to the code
-    version = "1.1"
+    version = "1.2"
     # version of the dataset to curate
     version_select = f"v_0"
 
@@ -35,15 +35,15 @@ def main():
         version_select=version_select,
     )
 
-    # tmqm_openff.process(
-    #     qcportal_view_filename="dataset_419_view.sqlite",
-    #     qcportal_view_path="~/mf_datasets/tmqm_openff_dataset/download_dataset",
-    #     force_download=False,
-    # )
-    tmqm_openff.load_from_db(
-        local_db_dir="/home/cri/mf_datasets/tmqm_openff_dataset",
-        local_db_name="tmqm_openff.sqlite",
+    tmqm_openff.process(
+        qcportal_view_filename="dataset_419_view_july.sqlite",
+        qcportal_view_path="/home/cri/mf_datasets/tmqm_openff_dataset/dataset_download_30July25",
+        force_download=False,
     )
+    # tmqm_openff.load_from_db(
+    #     local_db_dir="/home/cri/mf_datasets/tmqm_openff_dataset",
+    #     local_db_name="tmqm_openff.sqlite",
+    # )
     available_properties = (
         [
             "atomic_numbers",

--- a/modelforge-curate/modelforge/curate/datasets/tmqm_openff_curation.py
+++ b/modelforge-curate/modelforge/curate/datasets/tmqm_openff_curation.py
@@ -103,7 +103,7 @@ class tmQMOpenFFCuration(DatasetCuration):
 
         ds = client.get_dataset_by_id(dataset_id)
         qcportal_view_full_path = f"{qcportal_view_path}/{qcportal_view_filename}"
-        logger.debug(f"Using qcportal view file: {qcportal_view_full_path}")
+        # logger.debug(f"Using qcportal view file: {qcportal_view_full_path}")
         ds.use_view_cache(qcportal_view_full_path)
 
         # ds = client.get_dataset(dataset_type=dataset_type, dataset_name=dataset_name)

--- a/modelforge-curate/modelforge/curate/examples/record_and_sourcedataset.ipynb
+++ b/modelforge-curate/modelforge/curate/examples/record_and_sourcedataset.ipynb
@@ -45,7 +45,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2025-05-28 16:07:50.486\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mmodelforge.curate.sourcedataset\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m66\u001b[0m - \u001b[33m\u001b[1mDatabase file test_dataset.sqlite already exists in ./. Removing it.\u001b[0m\n"
+      "\u001b[32m2025-08-25 12:06:03.587\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mmodelforge.curate.sourcedataset\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m66\u001b[0m - \u001b[33m\u001b[1mDatabase file test_dataset.sqlite already exists in ./. Removing it.\u001b[0m\n"
      ]
     }
    ],
@@ -540,6 +540,7 @@
     "- atomic_numbers_to_limit:  An array of atomic species to limit the dataset to. Any molecules that contain elements outside of this list will be igonored\n",
     "- max_force: If set, configurations with forces greater than this value will be removed.\n",
     "- final_configuration_only: If True, only the final configuration of each record will be included in the subset.\n",
+    "- max_configurations_per_record_order: Can be \"start\", \"end\", or \"random\", which defines whether configurations are taking from the start of the underlying array, the end of the array, or randomly chosen, respectively.  Note, users can also pass the \"seed\" used to initialize the random number generator used to perform random record selection to ensure reproducibility and/or generate unique subsets.\n",
     "\n",
     "Note, `total_records` and `total_configurations` can not be used in conjunction. \n",
     "\n",
@@ -556,7 +557,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2025-05-28 16:07:59.475\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mmodelforge.curate.sourcedataset\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m66\u001b[0m - \u001b[33m\u001b[1mDatabase file dataset_subset.sqlite already exists in ./. Removing it.\u001b[0m\n"
+      "\u001b[32m2025-08-25 12:09:41.588\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mmodelforge.curate.sourcedataset\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m66\u001b[0m - \u001b[33m\u001b[1mDatabase file dataset_subset.sqlite already exists in ./. Removing it.\u001b[0m\n"
      ]
     },
     {

--- a/modelforge-curate/modelforge/curate/sourcedataset.py
+++ b/modelforge-curate/modelforge/curate/sourcedataset.py
@@ -634,11 +634,11 @@ class SourceDataset:
                             )
                             if max_configurations_per_record_order == "start":
                                 record = record.slice_record(0, n_to_add)
-                            if max_configurations_per_record_order == "end":
+                            elif max_configurations_per_record_order == "end":
                                 record = record.slice_record(
                                     record.n_configs - n_to_add, record.n_configs
                                 )
-                            if max_configurations_per_record_order == "random":
+                            elif max_configurations_per_record_order == "random":
                                 indices = rng.choice(
                                     record.n_configs, n_to_add, replace=False
                                 )

--- a/modelforge-curate/modelforge/curate/sourcedataset.py
+++ b/modelforge-curate/modelforge/curate/sourcedataset.py
@@ -645,6 +645,10 @@ class SourceDataset:
                                 record = record.remove_configs(
                                     indices_to_include=indices
                                 )
+                            else:
+                                raise ValueError(
+                                    "max_configurations_per_record_order must be one of 'start', 'end', or 'random'"
+                                )
 
                         if final_configuration_only:
                             record = record.slice_record(

--- a/modelforge-curate/modelforge/curate/tests/test_curate.py
+++ b/modelforge-curate/modelforge/curate/tests/test_curate.py
@@ -1128,6 +1128,34 @@ def test_dataset_subsetting(prep_temp_dir):
     record_temp = ds_subset.get_record("mol0")
     assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.2]]))
 
+    # check max_configurations_per_record with different strategies for total_records
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3a2",
+        total_records=2,
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="start",
+    )
+    assert ds_subset.total_configs() == 4
+    assert ds_subset.total_records() == 2
+    # grab a record and check the energy values to ensure we took the first 2 configurations
+    record_temp = ds_subset.get_record("mol0")
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.2]]))
+
+    # check max_configurations_per_record with different strategies for total_configurations
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3a3",
+        total_configurations=4,
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="start",
+    )
+    assert ds_subset.total_configs() == 4
+    assert ds_subset.total_records() == 2
+    # grab a record and check the energy values to ensure we took the first 2 configurations
+    record_temp = ds_subset.get_record("mol0")
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.2]]))
+
+    # check max_configurations_per_record with different strategies for total_configurations
+
     ds_subset = ds.subset_dataset(
         new_dataset_name="test_dataset_sub3b",
         max_configurations_per_record=2,
@@ -1136,6 +1164,32 @@ def test_dataset_subsetting(prep_temp_dir):
     assert ds_subset.total_configs() == 20
     record_temp = ds_subset.get_record("mol0")
     assert np.all(record_temp.per_system["energies"].value == np.array([[0.4], [0.5]]))
+
+    # check max_configurations_per_record with different strategies for total_records
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3b2",
+        total_records=2,
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="end",
+    )
+    assert ds_subset.total_configs() == 4
+    assert ds_subset.total_records() == 2
+    record_temp = ds_subset.get_record("mol0")
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.4], [0.5]]))
+
+    # check max_configurations_per_record with different strategies for total_configurations
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3b3",
+        total_configurations=4,
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="end",
+    )
+    assert ds_subset.total_configs() == 4
+    assert ds_subset.total_records() == 2
+    record_temp = ds_subset.get_record("mol0")
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.4], [0.5]]))
+
+    # check for random subsetting
 
     ds_subset = ds.subset_dataset(
         new_dataset_name="test_dataset_sub3c",
@@ -1149,13 +1203,56 @@ def test_dataset_subsetting(prep_temp_dir):
     assert record_temp.n_configs == 2
     assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.4]]))
 
+    # check max_configurations_per_record with different strategies for total_records
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3c2",
+        total_records=2,
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="random",
+        seed=57,
+    )
+    assert ds_subset.total_configs() == 4
+    assert ds_subset.total_records() == 2
+    record_temp = ds_subset.get_record("mol0")
+    assert record_temp.n_configs == 2
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.4]]))
+
+    # check max_configurations_per_record with different strategies for total_configurations
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3c3",
+        total_configurations=4,
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="random",
+        seed=57,
+    )
+    assert ds_subset.total_configs() == 4
+    assert ds_subset.total_records() == 2
+    record_temp = ds_subset.get_record("mol0")
+    assert record_temp.n_configs == 2
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.4]]))
+
     # check that this fails if we give a bad value to max_configurations_per_record_order
     with pytest.raises(ValueError):
         ds_subset = ds.subset_dataset(
-            new_dataset_name="test_dataset_sub3c",
+            new_dataset_name="test_dataset_sub3d",
             max_configurations_per_record=2,
             max_configurations_per_record_order="totally_wrong",
             seed=57,
+        )
+    with pytest.raises(ValueError):
+        ds_subset = ds.subset_dataset(
+            new_dataset_name="test_dataset_sub3e",
+            total_records=1,
+            max_configurations_per_record=2,
+            max_configurations_per_record_order="totally_wrong",
+        )
+
+    with pytest.raises(ValueError):
+        ds_subset = ds.subset_dataset(
+            new_dataset_name="test_dataset_sub3f",
+            total_configurations=10,
+            max_configurations_per_record=2,
+            max_configurations_per_record_order="totally_wrong",
         )
     # check total_conformers
     ds_subset = ds.subset_dataset(

--- a/modelforge-curate/modelforge/curate/tests/test_curate.py
+++ b/modelforge-curate/modelforge/curate/tests/test_curate.py
@@ -1069,6 +1069,9 @@ def test_dataset_validation(prep_temp_dir):
 
 
 def test_dataset_subsetting(prep_temp_dir):
+    # test breaking up a dataset into smaller datasets that apply some filtering
+    # for example, total_records or total_configurations, max_configurations_per_record
+    # including strategies for picking configurations
     ds = SourceDataset(name="test_dataset10", local_db_dir=str(prep_temp_dir))
 
     assert ds.local_db_dir == str(prep_temp_dir)
@@ -1103,7 +1106,7 @@ def test_dataset_subsetting(prep_temp_dir):
 
     assert ds_subset.name == "test_dataset_sub1"
     assert ds_subset.local_db_name == "test_dataset_sub1.sqlite"
-    assert ds_subset.local_db_dir == ds.local_db_dir
+    assert ds_subset.local_db_dir == ds.local_db_dirs
 
     ds_subset = ds.subset_dataset(new_dataset_name="test_dataset_sub2", total_records=3)
     assert ds_subset.total_configs() == 15

--- a/modelforge-curate/modelforge/curate/tests/test_curate.py
+++ b/modelforge-curate/modelforge/curate/tests/test_curate.py
@@ -211,7 +211,6 @@ def test_record_failures():
         )
         record.add_property(positions)
 
-    print(record.per_system.keys())
     # this will fail because the property already exists, but with different type
     with pytest.raises(ValueError):
         energies = Energies(
@@ -245,7 +244,6 @@ def test_record_to_rdkit():
     rdkit_mol = record.to_rdkit()
     assert rdkit_mol.GetNumAtoms() == 2
     assert rdkit_mol.GetNumConformers() == 2
-    print(rdkit_mol.GetConformer(0).GetAtomPosition(0))
     assert np.allclose(
         np.array(rdkit_mol.GetConformer(0).GetAtomPosition(0)),
         np.array([10.0, 10.0, 10.0]),
@@ -401,14 +399,12 @@ def test_record_repr(capsys):
     energies = Energies(value=np.array([[0.1]]), units=unit.hartree)
     atomic_numbers = AtomicNumbers(value=np.array([[1], [6]]))
     smiles = MetaData(name="smiles", value="[CH]")
-    print(record)
     out, err = capsys.readouterr()
 
     assert "n_atoms: cannot be determined" in out
     assert "n_configs: cannot be determined" in out
 
     record.add_properties([positions, energies, atomic_numbers, smiles])
-    print(record)
     out, err = capsys.readouterr()
     assert "name: mol1" in out
     assert "n_atoms: 2" in out
@@ -1151,7 +1147,6 @@ def test_dataset_subsetting(prep_temp_dir):
     # grab a record and check the energy values to ensure we took 2 random configurations
     record_temp = ds_subset.get_record("mol0")
     assert record_temp.n_configs == 2
-    print(record_temp.per_system["energies"].value)
     assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.4]]))
 
     # check that this fails if we give a bad value to max_configurations_per_record_order

--- a/modelforge-curate/modelforge/curate/tests/test_curate.py
+++ b/modelforge-curate/modelforge/curate/tests/test_curate.py
@@ -1118,6 +1118,39 @@ def test_dataset_subsetting(prep_temp_dir):
     assert ds_subset.total_configs() == 6
     assert ds_subset.total_records() == 3
 
+    # check max_configurations_per_record with different strategies
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3a",
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="start",
+    )
+    assert ds_subset.total_configs() == 20
+    # grab a record and check the energy values to ensure we took the first 2 configurations
+    record_temp = ds_subset.get_record("mol0")
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.2]]))
+
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3b",
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="end",
+    )
+    assert ds_subset.total_configs() == 20
+    record_temp = ds_subset.get_record("mol0")
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.4], [0.5]]))
+
+    ds_subset = ds.subset_dataset(
+        new_dataset_name="test_dataset_sub3c",
+        max_configurations_per_record=2,
+        max_configurations_per_record_order="random",
+        seed=57,
+    )
+    assert ds_subset.total_configs() == 20
+    # grab a record and check the energy values to ensure we took 2 random configurations
+    record_temp = ds_subset.get_record("mol0")
+    assert record_temp.n_configs == 2
+    print(record_temp.per_system["energies"].value)
+    assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.4]]))
+
     # check total_conformers
     ds_subset = ds.subset_dataset(
         new_dataset_name="test_dataset_sub4", total_configurations=20

--- a/modelforge-curate/modelforge/curate/tests/test_curate.py
+++ b/modelforge-curate/modelforge/curate/tests/test_curate.py
@@ -399,12 +399,14 @@ def test_record_repr(capsys):
     energies = Energies(value=np.array([[0.1]]), units=unit.hartree)
     atomic_numbers = AtomicNumbers(value=np.array([[1], [6]]))
     smiles = MetaData(name="smiles", value="[CH]")
+    print(record)
     out, err = capsys.readouterr()
 
     assert "n_atoms: cannot be determined" in out
     assert "n_configs: cannot be determined" in out
 
     record.add_properties([positions, energies, atomic_numbers, smiles])
+    print(record)
     out, err = capsys.readouterr()
     assert "name: mol1" in out
     assert "n_atoms: 2" in out

--- a/modelforge-curate/modelforge/curate/tests/test_curate.py
+++ b/modelforge-curate/modelforge/curate/tests/test_curate.py
@@ -1106,7 +1106,7 @@ def test_dataset_subsetting(prep_temp_dir):
 
     assert ds_subset.name == "test_dataset_sub1"
     assert ds_subset.local_db_name == "test_dataset_sub1.sqlite"
-    assert ds_subset.local_db_dir == ds.local_db_dirs
+    assert ds_subset.local_db_dir == ds.local_db_dir
 
     ds_subset = ds.subset_dataset(new_dataset_name="test_dataset_sub2", total_records=3)
     assert ds_subset.total_configs() == 15

--- a/modelforge-curate/modelforge/curate/tests/test_curate.py
+++ b/modelforge-curate/modelforge/curate/tests/test_curate.py
@@ -1154,6 +1154,14 @@ def test_dataset_subsetting(prep_temp_dir):
     print(record_temp.per_system["energies"].value)
     assert np.all(record_temp.per_system["energies"].value == np.array([[0.1], [0.4]]))
 
+    # check that this fails if we give a bad value to max_configurations_per_record_order
+    with pytest.raises(ValueError):
+        ds_subset = ds.subset_dataset(
+            new_dataset_name="test_dataset_sub3c",
+            max_configurations_per_record=2,
+            max_configurations_per_record_order="totally_wrong",
+            seed=57,
+        )
     # check total_conformers
     ds_subset = ds.subset_dataset(
         new_dataset_name="test_dataset_sub4", total_configurations=20


### PR DESCRIPTION
## Pull Request Summary
This adds functionality to the SourceDataset class to allow us to use different strategies for restricting a record to at max "N" configurations.  
Previously, this simply restricted to the first N configurations in the array; this PR now adds functionality to extract starting from the end of the array or randomly select records. 

Users just need to specify "max_configurations_per_record_order" to change from the default behavior of "start". 

To ensure both reproducibility and allow for unique datasets, a seed can be passed as well.  This initializes a numpy random number generator instance (i.e., does not use the global state). 

### Key changes
Notable points that this PR has either accomplished or will accomplish.
 - [x] Add in different options to the subsetting routines in a SourceDataset. 

### Associated Issue(s)
 - [x] #374 
 
## Pull Request Checklist
 - [x] Issue(s) raised/addressed and linked
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) added/updated
 - [x] Appropriate .rst doc file(s) added/updated
 - [x] PR is ready for review