### PR TITLE
Enable defining a fixed test subset, while still randomizing train/val split

### DIFF
--- a/modelforge/train/parameters.py
+++ b/modelforge/train/parameters.py
@@ -346,6 +346,7 @@ class TrainingParameters(ParametersBase):
         )
         data_split: List[float]
         seed: int
+        test_seed: Optional[int] = None
 
         @field_validator("data_split")
         def data_split_must_sum_to_one_and_length_three(cls, v) -> List[float]:

--- a/modelforge/train/training.py
+++ b/modelforge/train/training.py
@@ -1716,6 +1716,7 @@ class PotentialTrainer:
             ](
                 seed=self.training_parameter.splitting_strategy.seed,
                 split=self.training_parameter.splitting_strategy.data_split,
+                test_seed=self.training_parameter.splitting_strategy.test_seed,
             ),
             properties_of_interest=self.dataset_parameter.properties_of_interest,
             properties_assignment=self.dataset_parameter.properties_assignment.model_dump(),


### PR DESCRIPTION
## Pull Request Summary

In some cases, we may wish to have a fixed subset of test systems, while allowing the remaining molecules to be able to be randomly distributed between training and validation.  

This is likely not particularly useful for production level training runs, but could be especially useful for testing purposes. 
E.g., this could be useful for allowing us to get error bars (by changing the split between training/validation) while exploring the impact of hyper parameters, while removing any impacts on fitness that could result form having different molecules in the test set. 
 
To enable this, the random splitting algorithms now accept an optional second seed, `test_seed`. 

If `test_seed` is defined, randomization will be done in two steps. 

-Step one, randomize the indices using a random generator based on `test_seed`.  Here we will split the dataset into a test subset and a subset contains training+val.  Runs that use the same `test_seed` (on the same dataset) will therefore have test subsets with identical systems.

-Step two, randomize the indices in the training+val subset (using a random generator associated with the main `seed`), splitting this into the appropriately sized training and validation subsets.   Changing the value of `seed` will randomize the molecules in these two subsets.


### Associated Issue(s)
 - [ ] #373 

## Pull Request Checklist
 - [ ] Issue(s) raised/addressed and linked
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) added/updated
 - [ ] Appropriate .rst doc file(s) added/updated
 - [ ] PR is ready for review