### PR TITLE
Improving speed of CI testing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -79,7 +79,8 @@ jobs:
       - name: Run tests
         # conda setup requires this special shell
         run: |
-          pytest -n ${{matrix.n_procs}} --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
+          pytest -n 4 --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
+          # pytest -n ${{matrix.n_procs}} --dist loadgroup -v --cov=modelforge --cov-report=xml --color=yes --durations=50 modelforge/tests/
 
       - name: CodeCov
         uses: codecov/codecov-action@v4

--- a/modelforge/tests/test_training.py
+++ b/modelforge/tests/test_training.py
@@ -271,6 +271,7 @@ import pytest
 from modelforge.train.parameters import TrainingParameters
 
 
+@pytest.mark.xdist_group(name="training_tests")
 @pytest.mark.parametrize("potential_name", ["ANI2x"])
 @pytest.mark.parametrize("dataset_name", ["PHALKETHOH"])
 @pytest.mark.parametrize(
@@ -308,6 +309,7 @@ def test_learning_rate_scheduler(
     get_trainer(config).train_potential().save_checkpoint("test.chp")  # save checkpoint
 
 
+@pytest.mark.xdist_group(name="training_tests")
 @pytest.mark.xdist_group(name="test_training_with_lightning")
 @pytest.mark.skipif(ON_MACOS, reason="Skipping this test on MacOS GitHub Actions")
 @pytest.mark.parametrize(
@@ -349,6 +351,7 @@ def test_train_with_lightning(loss, potential_name, dataset_name, prep_temp_dir)
     # get_trainer(config).train_potential()
 
 
+@pytest.mark.xdist_group(name="training_tests")
 def test_train_from_single_toml_file(prep_temp_dir):
     from modelforge.utils.io import get_path_string
 
@@ -361,6 +364,7 @@ def test_train_from_single_toml_file(prep_temp_dir):
     read_config_and_train(config_path, local_cache_dir=local_cache_dir)
 
 
+@pytest.mark.xdist_group(name="training_tests")
 def test_train_from_single_toml_file_element_filter():
     from modelforge.utils.io import get_path_string
 
@@ -392,6 +396,7 @@ def test_train_from_single_toml_file_element_filter():
     assert np.all(np.array(trainer.datamodule.element_filter) == np.array([[6, 1]]))
 
 
+@pytest.mark.xdist_group(name="training_tests")
 def test_error_calculation(
     single_batch_with_batchsize, prep_temp_dir, dataset_temp_dir
 ):
@@ -457,6 +462,7 @@ def test_error_calculation(
     assert torch.allclose(torch.mean(F_error), reference_F_error)
 
 
+@pytest.mark.xdist_group(name="training_tests")
 def test_loss_with_dipole_moment(
     single_batch_with_batchsize, prep_temp_dir, dataset_temp_dir
 ):
@@ -552,6 +558,7 @@ def test_loss_with_dipole_moment(
     ).all(), "Total loss contains non-finite values."
 
 
+@pytest.mark.xdist_group(name="training_tests")
 def test_per_atom_charge_loss(
     single_batch_with_batchsize, prep_temp_dir, dataset_temp_dir
 ):
@@ -592,6 +599,7 @@ def test_per_atom_charge_loss(
     assert torch.allclose(scaled_loss_value, torch.tensor([[0.51]]))
 
 
+@pytest.mark.xdist_group(name="training_tests")
 def test_loss(single_batch_with_batchsize, prep_temp_dir, dataset_temp_dir):
     from modelforge.train.losses import Loss
 


### PR DESCRIPTION
## Pull Request Summary
This PR is focused on trying different strategies to speed up our CI testing. 

One issue is that the training tests are very memory intensive and only a single can be run at a time.  I've tried putting these into a single xdist group (which will mean they will all execute on the same worker thus multiple will not be running at the same time); I've upped the number of workers to 4, since many of the other tests are not memory intensive (or cpu intensive), and can more can easily run concurrently. 

this drops CI testing from 43 minutes to 23 minutes.


### Associated Issue(s)
 - [ ] #379 

## Pull Request Checklist
 - [ ] Issue(s) raised/addressed and linked
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) added/updated
 - [ ] Appropriate .rst doc file(s) added/updated
 - [ ] PR is ready for review