### PR TITLE
fix minor bug in indexing in dipole moment

### DIFF
--- a/modelforge-curate/modelforge/curate/datasets/curation_baseclass.py
+++ b/modelforge-curate/modelforge/curate/datasets/curation_baseclass.py
@@ -98,14 +98,31 @@ class DatasetCuration(ABC):
         ----------
         atomic_numbers: np.ndarray, required
             atomic numbers of the atoms in the system
+            shape [n_atoms, 1]
         positions: np.ndarray, required
-            positions of the atoms in the system
-
+            positions of the atoms in the system for a single configuration
+            shape [n_atoms, 3]
         Returns
         -------
         np.ndarray
             center of mass of the system
         """
+
+        # let us validate the input shapes to ensure we do not have any broadcasting issues
+
+        if len(atomic_numbers.shape) != 2 or atomic_numbers.shape[1] != 1:
+            raise ValueError(
+                f"atomic_numbers must be a 2D array withs shape [n_atoms, 1], found shape {atomic_numbers.shape}"
+            )
+        if len(positions.shape) != 2 or positions.shape[1] != 3:
+            raise ValueError(
+                f"positions must be a 2D array with shape [n_atoms, 3], found shape {positions.shape}"
+            )
+
+        if atomic_numbers.shape[0] != positions.shape[0]:
+            raise ValueError(
+                f"atomic_numbers and positions must have the same number of atoms, found {atomic_numbers.shape[0]} and {positions.shape[0]}"
+            )
 
         from openff.units.elements import MASSES
         from openff.units import unit

--- a/modelforge-curate/modelforge/curate/datasets/curation_baseclass.py
+++ b/modelforge-curate/modelforge/curate/datasets/curation_baseclass.py
@@ -167,13 +167,9 @@ class DatasetCuration(ABC):
         dipole_moment_list = []
         # compute the center of mass
         for config in range(positions.value.shape[0]):
-            # center_of_mass = np.einsum(
-            #     "i,ij->j",
-            #     atomic_masses,
-            #     positions.value[config] / np.sum(atomic_masses),
-            # )
+
             center_of_mass = self._calc_center_of_mass(
-                atomic_numbers.value[config], positions.value[config]
+                atomic_numbers.value, positions.value[config]
             )
             pos = positions.value[config] - center_of_mass
 

--- a/modelforge-curate/modelforge/curate/tests/test_curation_baseclass.py
+++ b/modelforge-curate/modelforge/curate/tests/test_curation_baseclass.py
@@ -61,6 +61,74 @@ def setup_test_dataset(dataset_name, local_cache_dir):
     return TestCuration(dataset_name=dataset_name, local_cache_dir=local_cache_dir)
 
 
+def test_center_of_mass(prep_temp_dir):
+    class TestCuration(DatasetCuration):
+        def _init_dataset_parameters(self):
+            pass
+
+    # test first where a molecule has the center of mass at zero
+    atomic_numbers = np.array([[6], [1], [1], [1], [1]])
+    # note this helper function accepts just a single molecule at a time
+    # so the shape of positions is (n_atoms, 3)
+    positions = np.array([[0, 0, 0], [-1, 0, 0], [1, 0, 0], [0, 1, 0], [0, -1, 0]])
+
+    dataset_curation = TestCuration(
+        dataset_name="test_dataset", local_cache_dir=str(prep_temp_dir)
+    )
+
+    center_of_mass = dataset_curation._calc_center_of_mass(
+        atomic_numbers=atomic_numbers, positions=positions
+    )
+
+    assert np.allclose(center_of_mass, np.array([0.0, 0.0, 0.0]))
+
+    # test a molecule where the center of mass is not at zero
+    atomic_numbers = np.array([[8], [1], [1]])
+    positions = np.array([[8.0, 0.0, 0.0], [9.0, 0.0, 0.0], [7.0, 0.0, 0.0]])
+
+    center_of_mass = dataset_curation._calc_center_of_mass(
+        atomic_numbers=atomic_numbers, positions=positions
+    )
+    assert np.allclose(center_of_mass, np.array([8.0, 0.0, 0.0]))
+
+    # first test that we fail if we do not have the same number of atoms in atomic_numbers and positions
+    with pytest.raises(ValueError):
+        atomic_numbers = np.array([[8], [1], [1]])
+        positions = np.array([[8.0, 0.0, 0.0], [9.0, 0.0, 0.0]])
+        center_of_mass = dataset_curation._calc_center_of_mass(
+            atomic_numbers=atomic_numbers, positions=positions
+        )
+    # test that we raise an error if the atomic_number shape is wrong
+    with pytest.raises(ValueError):
+        atomic_numbers = np.array([8, 1, 1])
+        positions = np.array([[8.0, 0.0, 0.0], [9.0, 0.0, 0.0], [7.0, 0.0, 0.0]])
+        center_of_mass = dataset_curation._calc_center_of_mass(
+            atomic_numbers=atomic_numbers, positions=positions
+        )
+    with pytest.raises(ValueError):
+        atomic_numbers = np.array([[8, 1], [1, 1]])
+        positions = np.array([[8.0, 0.0, 0.0], [9.0, 0.0, 0.0], [7.0, 0.0, 0.0]])
+        center_of_mass = dataset_curation._calc_center_of_mass(
+            atomic_numbers=atomic_numbers, positions=positions
+        )
+
+    # test that we raise an error if the positions shape is wrong
+    with pytest.raises(ValueError):
+        atomic_numbers = np.array([[8], [1], [1]])
+        positions = np.array([[[8.0, 0.0, 0.0], [9.0, 0.0, 0.0], [7.0, 0.0, 0.0]]])
+        center_of_mass = dataset_curation._calc_center_of_mass(
+            atomic_numbers=atomic_numbers, positions=positions
+        )
+    with pytest.raises(ValueError):
+        atomic_numbers = np.array([[8], [1], [1]])
+        positions = np.array(
+            [[[8.0, 0.0, 0.0, 1.0], [9.0, 0.0, 0.0, 1.0], [7.0, 0.0, 0.0, 1.0]]]
+        )
+        center_of_mass = dataset_curation._calc_center_of_mass(
+            atomic_numbers=atomic_numbers, positions=positions
+        )
+
+
 def test_dipolemoment_calculation(prep_temp_dir):
     class TestCuration(DatasetCuration):
         def _init_dataset_parameters(self):
@@ -304,6 +372,11 @@ def test_dipolemoment_calculation(prep_temp_dir):
         dataset_name="test_dataset", local_cache_dir=str(prep_temp_dir)
     )
 
+    com = dataset_curation._calc_center_of_mass(
+        atomic_numbers.value.reshape(-1, 1), positions.value[0]
+    )
+    print(com)
+
     dipole_moment_comp = dataset_curation.compute_dipole_moment(
         atomic_numbers=atomic_numbers, positions=positions, partial_charges=charges
     )
@@ -315,20 +388,59 @@ def test_dipolemoment_calculation(prep_temp_dir):
     )
 
     # scf dipole: [[0.11519327, 0.04117512, 0.0367095]]
-    # computed from partial charges: [[0.11143426, 0.04153308, 0.05102292]]
+    # computed from partial charges: [[0.09112792, 0.05734182, 0.05859077]]
     # reasonably close
-    assert np.allclose(
-        scf_dipole_moment.value, dipole_moment_comp.value, atol=1e-1, rtol=1e-3
-    )
 
-    assert np.allclose(
-        dipole_moment_comp.value, np.array([[0.11143426, 0.04153308, 0.05102292]])
-    )
+    assert np.all(scf_dipole_moment.value - dipole_moment_comp.value < 0.05)
 
     assert np.allclose(
         np.linalg.norm(dipole_moment_scaled_comp.value).reshape(1, 1),
         scf_dipole_magnitude.value,
     )
+
+    atomic_numbers = AtomicNumbers(value=np.array([[8], [1], [1]]))
+    positions = Positions(
+        value=np.array([[[8.0, 0.0, 0.0], [9.0, 0.0, 0.0], [7.0, 0.0, 0.0]]]),
+        units=unit.nanometer,
+    )
+    charges = PartialCharges(
+        value=np.array([[[-2], [1], [1]]]),
+        units=unit.elementary_charge,
+    )
+
+    dipole_moment_comp = dataset_curation.compute_dipole_moment(
+        atomic_numbers=atomic_numbers, positions=positions, partial_charges=charges
+    )
+    assert np.allclose(dipole_moment_comp.value, np.array([[0.0, 0.0, 0.0]]))
+
+    charges = PartialCharges(
+        value=np.array([[[-1], [1], [2]]]),
+        units=unit.elementary_charge,
+    )
+    dipole_moment_comp = dataset_curation.compute_dipole_moment(
+        atomic_numbers=atomic_numbers, positions=positions, partial_charges=charges
+    )
+    assert np.allclose(dipole_moment_comp.value, np.array([[-1.0, 0.0, 0.0]]))
+
+    positions = Positions(
+        value=np.array(
+            [
+                [[8, 0.0, 0.0], [9.0, 0.0, 0.0], [7.0, 0.0, 0.0]],
+                [[0, 0, 2], [0, 0, 3], [0, 0, 0]],
+            ]
+        ),
+        units=unit.nanometer,
+    )
+    charges = PartialCharges(
+        value=np.array([[[-2], [1], [1]], [[-1], [1], [1]]]),
+        units=unit.elementary_charge,
+    )
+    dipole_moment_comp = dataset_curation.compute_dipole_moment(
+        atomic_numbers=atomic_numbers, positions=positions, partial_charges=charges
+    )
+    assert np.allclose(dipole_moment_comp.value[0], np.array([0, 0, 0]))
+
+    assert np.allclose(dipole_moment_comp.value[1], [0.0, 0.0, -0.9441], atol=1e-3)
 
 
 def test_base_convert_element_string_to_atomic_number(prep_temp_dir):


### PR DESCRIPTION
## Pull Request Summary
This fixes a bug in the center of mass calculation in the curation base class... it indexes into a the atomic numbers by "configuration" even though atomic numbers are not encoded with the first dimension as configuration number (i.e., the  size [n_atoms, 1], not [n_configs, n_atoms, 1].  This seemed to elude the test which produced a very good estimate of the  dipole moment (likely because the center of mass was already really close to zero).

Tests have been be revised to ensure this will not be an issue. 

I'll note, this isn't used within training, only as a helper function  for datasets. 

## Pull Request Checklist
 - [ ] Issue(s) raised/addressed and linked
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) added/updated
 - [ ] Appropriate .rst doc file(s) added/updated
 - [ ] PR is ready for review