### PR TITLE
Refactor neighborlist part 1

### DIFF
--- a/modelforge/potential/neighbors.py
+++ b/modelforge/potential/neighbors.py
@@ -919,8 +919,8 @@ class NeighborlistForInference(torch.nn.Module):
                 pair_indices=torch.empty(
                     2, 0, dtype=torch.int64, device=positions.device
                 ),
-                d_ij=torch.empty(0, dtype=d_ij.dtype, device=d_ij.device),
-                r_ij=torch.empty(0, dtype=r_ij.dtype, device=r_ij.device),
+                d_ij=torch.empty((0, 1), dtype=d_ij.dtype, device=d_ij.device),
+                r_ij=torch.empty((0, 3), dtype=r_ij.dtype, device=r_ij.device),
                 only_unique_pairs=self.vdw_only_unique_pairs,
             )
         if self.use_electrostatic_cutoff:
@@ -935,8 +935,8 @@ class NeighborlistForInference(torch.nn.Module):
                 pair_indices=torch.empty(
                     2, 0, dtype=torch.int64, device=positions.device
                 ),
-                d_ij=torch.empty(0, dtype=d_ij.dtype, device=d_ij.device),
-                r_ij=torch.empty(0, dtype=r_ij.dtype, device=r_ij.device),
+                d_ij=torch.empty((0, 1), dtype=d_ij.dtype, device=d_ij.device),
+                r_ij=torch.empty((0, 3), dtype=r_ij.dtype, device=r_ij.device),
                 only_unique_pairs=self.electrostatic_only_unique_pairs,
             )
         # return a dictionary of PairlistData objects for each cutoff
@@ -1194,8 +1194,12 @@ class NeighborListForTraining(torch.nn.Module):
                 pair_indices=torch.empty(
                     2, 0, dtype=torch.int64, device=positions.device
                 ),
-                d_ij=torch.empty(0, dtype=torch.int64, device=positions.device),
-                r_ij=torch.empty(0, dtype=torch.int64, device=positions.device),
+                d_ij=torch.empty(
+                    (0, 1), dtype=positions.dtype, device=positions.device
+                ),
+                r_ij=torch.empty(
+                    (0, 3), dtype=positions.dtype, device=positions.device
+                ),
                 only_unique_pairs=self.vdw_only_unique_pairs,
             )
         # electrostatics only uses the half neighborlist
@@ -1214,8 +1218,12 @@ class NeighborListForTraining(torch.nn.Module):
                 pair_indices=torch.empty(
                     2, 0, dtype=torch.int64, device=positions.device
                 ),
-                d_ij=torch.empty(0, dtype=torch.int64, device=positions.device),
-                r_ij=torch.empty(0, dtype=torch.int64, device=positions.device),
+                d_ij=torch.empty(
+                    (0, 1), dtype=positions.dtype, device=positions.device
+                ),
+                r_ij=torch.empty(
+                    (0, 3), dtype=positions.dtype, device=positions.device
+                ),
                 only_unique_pairs=self.electrostatic_only_unique_pairs,
             )
 

--- a/modelforge/potential/neighbors.py
+++ b/modelforge/potential/neighbors.py
@@ -226,7 +226,8 @@ class Pairlist(torch.nn.Module):
             # concatenate to form final (2, n_pairs) vector
             pair_indices = np.stack((i_final_pairs, j_final_pairs))
 
-            return pair_indices, npairs_by_molecule / 2
+            # use integer division to keep per-molecule pair counts as integer dtype
+            return pair_indices, npairs_by_molecule // 2
 
         else:
             # filter out identical pairs where i==j

--- a/modelforge/potential/processing.py
+++ b/modelforge/potential/processing.py
@@ -646,6 +646,9 @@ class CoulombPotential(torch.nn.Module):
 
         idx_i = data["electrostatic_pair_indices"][0]
         idx_j = data["electrostatic_pair_indices"][1]
+
+        # note, this is now explicitly as part of the neighborlist
+        # we likely can remove the unique check
         # only unique paris
         unique_pairs_mask = idx_i < idx_j
         idx_i = idx_i[unique_pairs_mask]

--- a/modelforge/tests/test_ani.py
+++ b/modelforge/tests/test_ani.py
@@ -351,7 +351,7 @@ def test_dimer_representation():
     # set up neighbor list
     nlist = NeighborListForTraining(
         local_cutoff=0.51,
-        only_unique_pairs=True,
+        local_only_unique_pairs=True,
     )
 
     nlist_output = nlist.forward(dimer_system)

--- a/modelforge/tests/test_pairlist_neighborlist.py
+++ b/modelforge/tests/test_pairlist_neighborlist.py
@@ -872,7 +872,7 @@ def test_neighborlist_multiple_cutoffs():
     assert torch.allclose(output.local_cutoff.r_ij, torch.tensor([[1.0, 0.0, 0.0]]))
     assert torch.allclose(output.local_cutoff.d_ij, torch.tensor([[1.0]]))
 
-    assert output.vdw_cutoff.only_unique_pairs == False
+    assert torch.all(output.vdw_cutoff.only_unique_pairs == False)
     assert torch.allclose(
         output.vdw_cutoff.pair_indices,
         torch.tensor(
@@ -901,7 +901,7 @@ def test_neighborlist_multiple_cutoffs():
 
     # the electrostatic neighborlist returns the half neighborlist, i.e only_unique_pairs=True
 
-    assert output.electrostatic_cutoff.only_unique_pairs == True
+    assert torch.all(output.electrostatic_cutoff.only_unique_pairs == True)
     assert torch.allclose(
         output.electrostatic_cutoff.pair_indices,
         torch.tensor([[0, 0, 1, 2], [1, 2, 2, 3]]),
@@ -934,7 +934,7 @@ def test_neighborlist_multiple_cutoffs():
     # vdw cutoff will return the full neighborlist
 
     print(output.vdw_cutoff)
-    assert output.vdw_cutoff.only_unique_pairs == False
+    assert torch.all(output.vdw_cutoff.only_unique_pairs == False)
 
     assert torch.allclose(
         output.vdw_cutoff.pair_indices,

--- a/modelforge/tests/test_pairlist_neighborlist.py
+++ b/modelforge/tests/test_pairlist_neighborlist.py
@@ -154,7 +154,7 @@ def test_neighborlist_unique_pairs_only_local():
     )
 
     # test with smaller cutoff
-    cutoff = unit.Quantity(2.0, unit.nanometer).to(unit.nanometer).m
+    cutoff = 2.0
     nlist = NeighborListForTraining(local_cutoff=cutoff, only_unique_pairs=True)
     r = nlist(TestInput(positions, atomic_subsystem_indices, None)).local_cutoff
     pair_indices = r.pair_indices

--- a/notebooks/neighborlists.ipynb
+++ b/notebooks/neighborlists.ipynb
@@ -1,0 +1,506 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fe7a90ba-3161-4cde-8778-eea792f5b667",
+   "metadata": {},
+   "source": [
+    "# Neighbor lists\n",
+    "\n",
+    "The neighbor list classes in modelforge return not just pairs of interacting particles, but also the displacement vector (r_ij) and distance (d_ij) betweent the pairs.  This was done to separate out the distance computations from the core of the network, allowing for increased flexibility. \n",
+    "\n",
+    "Additionally, this avoisd recomputation of distances for the various types of interactions we might calculate (local, vdw, and electrostatics), as the neighbor list supports the use of multiple cutoffs simultaneously for the local, vdw, and electrostatics calculations. \n",
+    "\n",
+    "In modelforge, there are two separate neighbor list classes, `NeighborListForTraining` and `NeighborListForInference`.  \n",
+    "\n",
+    "As the name suggests the `NeighborListForTraining` is used during training of the NNPs. It is designed specifically to operate on batches of systems simultaneously and take as input a list of pre-computed pairs (i.e., all possible pairs for each system in the batch).  Pre-computing all possible pairs for each system significantly reduces the computational cost and memory footprint, as compared to calculating these for each batch.  While calculating the interacting pairs could also be pre-computed, the cost of calculating these for each batch is minimal; furthermore, while the r_ij and d_ij vectors could be precomputed for each system (as the systems do not change during training), storing these additional values would signficantly increase the memory usage.  \n",
+    "\n",
+    "Similarly, the `NeighborListForInference` class is designed to be used during inference.  In inference mode, we will be operating on a single system, where it is possible that particle positions will change over time (e.g., using the NNP as part of a simulation).  This class supports both a brute force appropriate (whereby interacting particles are determined via an N^2 algorithm), typically suitable only for very small systems,  as well as using as supporting the Verlet scheme, which allows delayed rebuilding of the neighbor list, substantially reducing cost relatively to the brute force approach. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "068ae6fe-86de-401f-87fc-8457bcdb12a4",
+   "metadata": {},
+   "source": [
+    "## Using the NeighborListForTraining\n",
+    "\n",
+    "Let us consider instantiating and using the `NeighborListForTraining` class.   First import this as well as the `NNPInput` class, which is a container that holds relevant information passed to the neighbor list forward call. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "initial_id",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from modelforge.potential.neighbors import NeighborListForTraining\n",
+    "from modelforge.utils.prop import NNPInput"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ddcef94-ecd8-4197-9270-c1f81e656e6f",
+   "metadata": {},
+   "source": [
+    "### Populating NNPInput\n",
+    "\n",
+    "We will need to specify the input to the forward call by populating `NNPInput`.\n",
+    "\n",
+    "Let us just set up a quick helper to set a molecule using rdkit and export atomic_numbers and positions to a tensor. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "8ecca935-55a3-4d83-abf7-e8d9cf6842d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem\n",
+    "from rdkit.Chem import AllChem, Draw\n",
+    "\n",
+    "def smiles_to_pytorch(smiles):\n",
+    "\n",
+    "    mol = Chem.MolFromSmiles(smiles)\n",
+    "    mol = Chem.AddHs(mol)\n",
+    "\n",
+    "    AllChem.EmbedMolecule(mol, AllChem.ETKDG())\n",
+    "\n",
+    "    AllChem.MMFFOptimizeMolecule(mol)\n",
+    "\n",
+    "    atomic_numbers = [atom.GetAtomicNum() for atom in mol.GetAtoms()]\n",
+    "    atomic_numbers_tensor = torch.tensor(atomic_numbers, dtype=torch.long)\n",
+    "\n",
+    "\n",
+    "    conformer = mol.GetConformer()\n",
+    "    coords = conformer.GetPositions()  \n",
+    "    positions_tensor = torch.tensor(coords, dtype=torch.float)/10.0 # convert to nm\n",
+    "\n",
+    "    return atomic_numbers_tensor, positions_tensor, mol"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "8e2b9f52-4bad-4a7a-ab20-f4c7d48b739a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atomic_numbers, positions, mol = smiles_to_pytorch(\"C\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "0bb0760a-7ee8-46f1-8426-968bc56d05c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAEsASwDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiivNpPiNqKfG2PwOLO1+wuuTP8AN5v/AB7mX1x1GOnSgD0miivPPix8QNQ8AaZp11p9pbXD3UzRsLjdgALnjBFAHodFQ2cxuLKCdgA0kauQOgJGamoAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvn/ULq3sv2r4ri7uIreBE+aSVwirmzIGSeByQK+gK+cfFGgWPij9pptG1JXazuEXzBG21vltdwwfqooA93/wCEq8O/9B7S/wDwMj/xrxn9ofV9M1LQdFSw1G0umS5cssE6uVG3vg113/CgvAv/AD733/gUf8K8x+M3w58P+CNJ0u50aO4SS4naOTzZi4wFzxQB9J6Z/wAgmz/64J/6CKtVV0z/AJBNn/1wT/0EVaoAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvC5rO6/wCGroLr7NN9n2f63Ydn/HmR16deK90ooAK8V/aMtLm70DRFtreWYrdOSI0LY+X2r0vVvEw0vxf4e0D7J5p1j7T++8zHk+TGH+7j5s5x1GPet+gCrpoI0qzBBBECZB/3RVqiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAPP/ABTz8YvAA/ux6if/ACCtegV5/wCJOfjN4IH922vz/wCQxXoFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAHn+v8/GrweP7tlen/x0V6BXn+t8/G7wsP7unXZ/lXoFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAHn+rc/HLw6P7uk3J/8AHhXoFef6jz8dtFH93RZz/wCRBXoFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAHn97z8etMH93QJT/wCRq9Arz+45+P8AZj+74cc/+R69AoAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA8/fn9oOIf3fC5P/kzXoFefrz+0Ix/u+FgP/JqvQKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAPP4ef2gLo/3fDSD/AMmK9Arz+05+Pmon+74fjH/kavQKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigArgviX8Sh8OotNc6SdQ+2tIMfaPK2bNv8AstnO726V3teCftMf8evhr/fuf5R0Ae91j+Ktd/4RjwvqGtG2+0/Y4vM8nfs38gYzg46+lbFcd8Vf+SXeIf8Ar1P8xQBd8CeLB428Kwa4LL7H5runk+b5mNrEfewPT0rpK8y+B00Vv8I7OaeVIoklnZ3dgqqN55JPSuouviH4Nss+d4n0rI6hLpHI/BSTQB0tFcFJ8ZPBG8x2upT3sg/gtbOZz+e3H600/FH7Rxp3gvxZd56P/Z/lof8AgTNQB39Fef8A/CYeO7v/AI8fhzLGp/5aXmqRR4/4DjNHn/Fi8/1dl4V05T/z2lmlcf8AfPFAHoFFef8A/CO/Em8H+k+OrGxB6rZ6Ukn5Fzmj/hXGrXX/ACEviF4mlz1FpMtsP/HQaAPQKzrvX9G0/P23V7C2x1865RP5muQ/4U54Wm/5CUur6n6/bNRkbP8A3yRWjafCzwNZY8rwzYNj/nspl/8AQyaAC7+Kfgayz5viawbH/PFzL/6ADWd/wuTwrMcacuq6me32PTpWz/30BXXWnh7RNPx9i0fT7bHTybZEx+QrSoA8Ps/iBHH8WdS1mTwz4kWF9LitzD/Z5M0YD7g7pnhD2NdvafF/wRcyeTLrH2KcdYryCSEr9Sy4/WoPDf7/AOM3jeX/AJ97ewh/76jLV3N1Y2l9H5d3awXEf92aMOPyNAFTT/EWiatj+ztYsLsnoILlHP6GtKuR1D4XeB9Tz9o8NWKk9TboYD/44RWZ/wAKl0+050XxF4j0jHRLbUGMf4qwOR+NAHoNFefjwv8AELTv+Qf47hvUHSLUtOX9XQ5NH9q/FHTv+Prw3oWrqP8AoH3rQE/9/RQB6BRXn3/CzL6y41rwJ4ks8dZLeAXMa/VlI/lVi0+L/ge5k8qTWRaTd4ryCSEr9Sy4/WgDuaKzdP8AEGi6tj+ztXsLvPQQXCOf0NaVABRRRQAUUV5XpPj3W7z45ah4TleD+y4Fcooiw/CKw+b6k0AeqUUV5X8ZPHut+CZ/D6aO8Ci+aYTebFvztMeMen3zQB6pRRRQAUUUUAFFFFABXgn7TH/Hr4a/37n+Ude914J+0x/x6+Gv9+5/lHQBq/8ADOWg/wDQe1f80/8AiawvGfwN0fw54O1TWINY1KaW0h8xY5Sm1jkDnA96+g6474q/8ku8Q/8AXqf5igDA+Cdpb3/wdtrS7hSa3mkuI5I3GVdS5BBFdraeDfDFjg2vh3SYSP4ks4wfzxmuQ+BH/JKbD/rvP/6Ga9KoAZHFHCgSJFRB0VRgU+iigAooooAKKKKACiiigAooooA8/wDAv77x78QLr+9fwQ5/65xY/rXoFef/AAw/fXXjW6/56eJLpAfUIFAr0CgAooooAKKKKACq93YWd/H5d5aQXKf3Zow4/I1YooA5DUPhZ4H1LJn8NWKE97dTAf8AyGRWd/wqeys+dF8S+JNJx92O31AtH+KsDn869AooA8/Phn4iafzp/jm2vkH3YtS05R+bocmk/tj4pad/x9+F9E1YDqdPvzAT/wB/a9BooA5Xw74t1LWNSbT9S8JatpEojMnnTBXgOCBt8wHrzwMdjXkFtrOnaD+0xrN9qt5FaWqq6mWU4AJiXAr6Jr5zj0HTPEn7Sus6dq9ot1aMHcxsxAJES4PBBoA9e/4Wj4H/AOhm0/8A7+f/AFq8b+OvinQ/Et14Y/sXU7e++zvP5vktnZuMWM/Xafyr1r/hT3gD/oXIP+/0v/xVeQfG/wAHaB4TuvDX9h6aln9pefztjs2/aYtv3iem4/nQB9L0UUUAFFFFABRRRQAVDPa291t+0W8Uu3p5iBsfnU1FABTZI0ljaORFdG4KsMg/hTqKAGQwxW8YjhiSNB0VFAH5Cn0UUAFFFFABRRRQAUUUUAFFFFABRRTZHEcbSN91QSfwoA4H4QfvPCuo3X/P1rF3Nn1y+P6V6BXA/BdCvwp0iR/vzNPK34zP/TFd9QAUUUUAFFFFABRRRQAUUUUAFFFFABXi2ieH9Yh/aP1TV5dLu002RHCXbQsImzGo4bGOor2migArxb4+eH9Y1248MHSdLu74QPcGU28LPsyYsZwOM4P5GvaaKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigArO8QT/ZvDeqT5x5VpK+fohNaNc54/n+z/DvxHJnB/s24A+pjIH86AKfwtg+z/DDw8mMZtFf/AL6Jb+tdfWF4Jg+zeA/D0OMFNNtwfr5a5rdoAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAri/i3P8AZ/hX4gfOM24T/vp1X+tdpXAfGfMnwzvrUZzc3FtDx7zIf6UAdnpMH2bR7GDGPKt40/JQKuUdKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA4iT4kWsfxRj8DHT5jcOM/avMGwfujL069Biu3rwS4/5O2tv9z/ANs2r3ugDjfiF8Qbb4fWFnd3NhLeC6lMYWNwu3Aznmuttpxc2kM4UqJUVwD2yM14r+0p/wAi7of/AF9v/wCgV7JpX/IHsv8Ar3j/APQRQBbooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAPmvxnoLeJ/2kX0db6axNxGn+kQ/eTbbbuOR124/Guu/4UJP/wBDzq//AHyf/i6yrj/k7a2/3P8A2zave6APlb4s/DqTwVpWnXL+IL3U/tE7R7LgYCYXOR8xr6e0r/kD2X/XvH/6CK8b/aU/5F3Q/wDr7f8A9Ar2TSv+QPZf9e8f/oIoAt0UUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAFM6Vpx1EaibC1N8Olz5K+aOMfexnpx9KuUUUAVb7TNP1NETULG2u0Q5VbiJZAp9RkHFWVVUUKoCqBgADAApaKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/9k=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASwAAAEsCAIAAAD2HxkiAAAUGklEQVR4AWL8//8/wygYDYHREBg4wDRwVo/aPBoCoyEAAqOZEBQKo3g0BAYQjGbCAQz8UatHQwAERjMhKBRG8WgIDCAYzYQDGPijVo+GAAiMZkJQKIzi0RAYQDCaCQcw8EetHg0BEBjNhKBQGMWjITCAYDQTDmDgj1o9GgIgMJoJQaEwikdDYADBaCYcwMAftXo0BEBgNBOCQmEUj4bAAILRTDiAgT9q9WgIgMBoJgSFwigeDYEBBKOZcAADf9Tq0RAAgdFMCAqFUTwaAgMIRjPhAAb+qNWjIQACo5kQFAqjeDQEBhCMZsIBDPxRq0dDAARGMyEoFEbxaAgMIBjNhAMY+KNWj4YACIxmQlAojOLREBhAMJoJBzDwR60eDQEQGM2EoFAYxaMhMIBgNBMOYOCPWj0aAiAwmglBoTCKR0NgAAHLANo9ajXBEEhMTLx//z5E2f79+xkZGSFs/OS8efMWLVoEUdPY2Ghvbw9hj5KDE4xmwsEZL1BXnTp16tq1axDO////icyE9+/fP3jwIETX69evIYxRctCC0ebooI2aUYeNFDCaCUdKTI/6c9CC0Uw4aKNm1GEjBYxmwpES06P+HLRgNBMO2qgZddhIAaOZcKTE9Kg/By0YzYSDNmpGHTZSwGgmHCkxPerPQQtGM+GgjZpRh40UMJoJR0pMj/pz0ILRZWuDNmrQHebr64suhIN/69YtHDKjwoMRjGbCwRgrWN20bds2rOKjgkMdjDZHh3oMjrp/yIPRmnDIRGFDQwORuyj27dsH30UxZLw3gsFoJhwykV9bW8vERFTL5ffv36OZcAgBoiJ1CPln1KmjITDkwGgmHHJRNurg4QZGM+Fwi9FR/ww5MJoJh1yUjTp4uIHRTDjcYnTUP0MOjGbCIRdlow4ebmA0Ew63GB31z5ADo5lwyEXZqIOHGxjNhMMtRkf9M+TAaCYcclE26uDhBkYz4XCL0VH/DDkwunZ0UEdZTEzM8+fPIU4kcvU2AwODpaVlbm4uRJeqqiqEMUoOWsD4////Qeu4UYeNhsBIAKPN0ZEQy6N+HNRgNBMO6ugZddxIAKOZcCTE8qgfBzUYzYSDOnrwO05YWFhISGi0Vz/UwejAzFCNwb9//7KwsDAzM//582eo+mHU3WAwWhOCg2EIEn///mVgYGBmZh6Cbh91MgoYzYQowTGEOJAKkIVldKZ3yIPRTDhUo3C0Jhw2YDQTDtWoHM2EwwaMZsKhGpWjzdFhA0Yz4VCNytGacNiA0Uw4VKNyNBMOGzCaCYdqVI42R4cNGM2EQzUqR2vCYQNGM+FQjcrRTDhswGgmHKpROdocHTZgNBMO1agcrQmHDRjNhEM1Kkcz4bABo5lwqEblaHN02IDRTDhUo3K0Jhw2YDQTDtWoHM2EwwaMZsKhGpWjzdFhA0Yz4VCNytGacNiA0Uw4VKNyNBMOGzCaCYdqVI42R4cNGM2EQzUqR2vCYQNGM+FQjcrRTDhswGgmHKpROdocHTZgNBMO1agcrQmHDRjNhEM1Kkcz4bABo5lwqEblaHN02IDRTDhUo3K0Jhw2YDQTDtWoHM2EwwaMZsKhGpWjzdFhA0Yz4VCNytGacNiA0Uw4VKNyNBMOGzCaCYdqVI42R4cNGM2EQzUqR2vCYQNGM+FQjcrRTDhswGgmHKpROdocHTZgNBMO1agcrQmHDRjNhEM1Kkcz4bABo5lwqEblaCYcNmA0Ew7VqBztEw4bMJoJh2pUjtaEwwaMZsKhGpWjmXDYgNFMOFSjcrQ5OmzAaCYcqlE5WhMOGzCaCYdqVI5mwmEDRjPhUI3K0ebosAGjmXCoRuVoTThswGgmHKpROZoJhw0YzYRDNSpHm6PDBoxmwqEalaM14bABo5lwqEblaCYcNmA0Ew7VqBxtjg4bMJoJh2pUjtaEwwaMZsKhGpWjmXDYgNFMOFSjEtIcZWZmHqoeGHU3DIxmQlhIDDUaUhOysLAMNYePuhcdjGZC9BAZKnxIJhytCYcBGM2EQzUSR5ujwwaMZsKhGpWQmnC0OToMwGgmHKqRCMmEo83RYQBGM+FQjcTR5uiwAaOZcKhGJaQmHG2ODgMwmgmHaiRCMuFoc3QYgNFMOFQjcbQ5OmzAaCYcqlEJqQlHm6PDAIxmwqEaiZBMONocHQZgNBMO1UgcbY4OGzCaCYdqVEJqwtHm6DAAo5lwqEYiJBOONkeHARjNhEM1Ekebo8MGjGbCoRqVkJpwtDk6DMBoJhyqkQjJhKPN0WEARjPhUI3E0ebosAGjmXCoRiWkJhxtjg4DMJoJh2okQjLhaHN0GIDRTDhUI3G0OTpsAOP///+HjWdGlEcYGRkZGBhGo28YgNGacEhG4mg1OJzAaCYckrEJ6RCOjsoMDzCaCYdkPEIy4eiozPAAo5lwSMbjaHN0OIHRTDgkYxNSE442R4cHGM2EQzIeIZlwtDk6PMBoJhyS8TjaHB1OYDQTDkkAqQlHm6PDA4xmwiEZj5BMONocHR5gNBMOyXgcbY4OJzCaCYdkbEJqwtHm6PAAo5lwSMYjJBOONkeHBxjNhEMyHkcz4XACo5lwSMYmpE842hwdHmA0Ew7JeBytCYcTGM2EQzI2RzPhcAKjmXBIxuZoc3Q4gdFMOCRjc7QmHE5gNBMOydgczYTDCYxmwiEZm6PN0eEERjPhkIzN0ZpwOIHRTDgkY3M0Ew4nMJoJh2RsjjZHhxMYzYRDMjZHa8LhBEYz4ZCMzdFMOJzAaCYckrE52hwdToAmmdDIyIgHDPj4+IgPrIaGBrAmELFlyxbiNY40ld+/f3/8+DEDA8O3b98gVeJIC4FhBlho4Z+vYMDAwAC5L4FIK37+/Pn161eIYkhJD2GPWPL9+/f3wODZs2fPnz+/d+8ehPHgwYN///7x8vJu3ryZk5NTVVVVW1tbS0sLQmpoaIzuMxxagCaZcGgFwcC69s2bN4/B4OHDh48fP37y5MkjMHj+/DmukoiDg4OXl/f169e8vLyfP3++BgZwX3BycmpqamqDASRnKigoMDHRpMkDt3SUQQkYzYSUhB6xen/+/Pn06VNIPQau26B12u3btz99+oTLFEFBQSUlJUlJSSkpKSUwgLAVFBRaWlrq6+sLCwurqqru3Llz7dq1q1evnj179tq1aw8ePDgHBnBj2djYVFRUIPUkhNTU1BzNloMHjGZCasYFZgMS0oZ88eIFrjvMODg40PIYJOMpKipycXHhctz79+8ZGBgEBQXZ2dnBdZ52aGgoRPGnT59u37599epVSM68du3a/fv3wZXlNYgCBgaG0Ww5qMBoJiQ5Ot6/f49Zp927d+/Ro0e4GpDs7OzS0tKQegySxyAZT0VFhZ+fn2QXMDC8e/cOkgkx9fLx8RmDAVyKmGzJzs6urKwMqSch5GhtSTcwmgmxB/WPHz+ePXsGqceQB0Vu3br1+fNn7HrAVRNyHoOzqd4rg9SEQkJCuFyCLI6ZLT9+/Hjnzh38tSUfH5+qqiqkVwkhFRUVSRppQ3bDYGDfunVr9erVEJdYW1s7ODhA2ATJtrY2SENGWFg4IyODoHpSFYzoTPj79+/Xr18j5zF4h43UBqSSkpKsrCwrKyupEUCeejw1ITEG8vPzgytLY7hizGx57969s2AAVzPUs+W1a9dqamog3qmoqCA+E9bU1EAyoZqa2mgmhAQgySTlDUh4nUZ2A5JkR+PVQFJNiNckqCRmtvzw4cPdu3eRa0vMbMnPz6+iogKpJyHkUK8tBwQMn5qQkgYkPI/BGVRvQFI3dimsCYlxjICAAFptCRl2gmfLs2fPPn/+HFxZnoUbOJotyQBDLBPiaUA+f/4cl/8FBQUxB0WUlJTk5OSG6KmBkJpQUFAQl5dpIS4oKIiZLeF5EjIYi5ktBQQElJWVIfUkhFRSUqKF84YuGAKZ8MqVK42NjZBZ7BcvXvz79w9rcHNyciooKMjIyMjKysqBAYQtLy/PycmJVcsQFfz27dvPnz+5uLg4ODgG1guCgoI2YAB3xvv375Gz5ZUrV168eIFWW45mSzRA20z4//9/cXFxNCtxcb98+YJV6vfv32vWrIFLQaaw4e1G8CQ2aEZbUlJySI/dwT1IkAFpixI5NErQNOoqIJgtL1++/PLlS7RsCYlTLS0tY2NjyLSnpKQkdR02mE2jbSZkYGB49eoVhf5XVVVdvny5rKysvLy8pKTk6MLIAWmLkh2JBLPlpUuXXr16BcmWixcvhlgkKCgIabtCSB0dHQkJCYjU8CNpngkpDzIeHp6IiAjKzRk2JgzmmpCYQCaYLS9evPj69eujYAA3EC1b6urqEt/IghsyOBm0zYSMjIzEb0pauHDhqlWrBmcwDSpXDa2akJigG+HZkraZkIGBwcvLi5hoYGBgOHz4MJEqR7iyoV4TEhN9uLIlZJH61atXL1269P79e3BleRRuIFptqaenJyYmBpcdtAyaZ8JB6/Oh67DhVxMSAzCz5YMHD65fv37lyhXI7Mj169cxs+WOHTvc3d2JMX8A1YxmwgEMfDKtHpmZEBMogIGnpydc6tmzZ5AMCSEvXryopqYGl0VmnD59ur+/H1lkANmjmXAAA59Mq0dCc5Q8IAUGLi4uEO3//v3DNWu1FwwgygacHM2EAx4FJDsAkgnpvFyGZFcOAg1DZePyaCYcBImFRCdAmqODc7KeRK8MmHJZWVkFBQUiraf1kOFoJiQyIgaRstGakHIQHR3d3t5OpDlMTEyQrUxEqidV2ej5P6SG2MCrH60JhxkYzYRDL0JHa8JhBkYz4RCL0H///n38+JGJiYm8w2mGmG9HBhjNhEMsnj9+/Pjv3z9+fv7RhezDBoxmwiEWlaNt0eEHaDI62tXV9fHjR1KPwQ8LC9PU1IQEsbEx4gwiiMgoCQmB0VGZ4Qdokgn9/f3JCClDMCBD44jSMloTDj8w2hwdYnE6WhMOPzCaCYdYnEJqwtHlMsMJjGbCIRabkJpwdOHocAKjmXCIxeZoJhx+gCYDM8MvmAaPj0abo2QDXl5eDQ0NiHaSdtxrampCDtpUVFSEaKcuOZoJqRueNDdttCYkGzg7O1+/fp0M7VevXiVDF/FaRpujxIfVoFA5WhMOPzCaCYdYnEIy4ejAzHACo5lwiMUmpDk6OkUxnMBoJhxisTlaEw4/wEjTLcPDL7wG1ke/fv1iZ2dnY2P7+fPnwLpk1HYqgtGakIqBSXOjINXgaFt0mIHRTDiUIhSSCUdHZYYZGM2EQylCR0dlhiUYzYRDKVpHa8JhCUYz4VCK1tGacFiC0Uw4lKJ1tCYclmA0Ew6laIXUhKMDM8MMjGbCoRShkEw4OkUxzMBoJhxKEQppjo5mwmEGRjPhUIpQSE042hwdZmA0Ew6lCB2tCYclGM2EQylaR2vCYQlGM+FQitbRmnBYgtFdFEMpWtnY2H7//v3r1y9WVtah5O5Rt+IFozUh3uAZTJKfPn36/fs3Ly/vaA4cZmA0Ew6ZCIV0CEfnJ4YfGM2EQyZOIR3C0fmJ4QdGM+GQidPRmnC4gtFMOGRidrQmHK5gNBMOmZgdrQmHKxjNhEMmZkdrwuEKRjPhkIlZSE04OjAz/MBoJhwycQrJhKNTFMMPjGbCIROno83R4QpGM+GQidnRmnC4gtFMOGRiFlITjjZHhx8YzYRDJk4hNeHowMzwA6OZcMjE6WhNOFzB6FamoRGzf/78YWNjY2Zm/vXrFyMj49Bw9KgriQOjNSFx4TTQqj58+PD//38BAYHRHDj8wGgmHBpxOtoWHcZgNBMOjciFZMLRUZlhCUYz4dCIVsjQ6Oj8xLAEo5lwaETraE04jMFoJhwakfv3719+fv7R5uiwBKNTFMMyWkc9NZTAaE04lGJr1K3DEoxmwmEZraOeGkpgNBMOpdgadeuwBCzD0ldDzlPd3d2PHz+GOLu3t5fI43137dq1ZcsWiK74+HhjY2MIe5QcWmA0Ew6K+Fq+fPn58+chTuno6CAyE546dWry5MkQXebm5qOZcIiC0eboEI24UWcPHzCaCYdPXI76ZIiC0Uw4RCNu1NnDB4xmwuETl6M+GaJgNBMO0YgbdfbwAaOZcPjE5ahPhigYzYRDNOJGnT18wGgmHD5xOeqTIQpGM+EQjbhRMHzAaCYcPnE56pMhCkaXrQ26iKurq2NhISpejh07NuhcP+og0gFRkU26saM6yA+B3t5e8jWP6hyCYLQ5OgQjbdTJwwuM1oSDLj4DAwOZmZmJcdb169evXr1KjMpRNYMZjGbCQRc7S5Ys4eLiIsZZLS0ttbW1xKgcVTOYwWhzdDDHzqjbRgQYzYQjIppHPTmYwWgmHMyxM+q2EQFGM+GIiOZRTw5mMJoJB3PsjLptRIDRTDgionnUk4MZjGbCwRw7o24bEWA0E46IaB715GAGo5lwMMfOqNtGBBjNhCMimkc9OZjBaCYczLEz6rYRAUbXjg6KaDYxMeHj44M4hcjV2wwMDPLy8vb29hBd4uLiEMYoOeTA6CWhQy7KRh083MBoc3S4xeiof4YcGM2EQy7KRh083MBoJhxuMTrqnyEHRjPhkIuyUQcPNzCaCYdbjI76Z8iB0Uw45KJs1MHDDYxmwuEWo6P+GXJgNBMOuSgbdfBwA6OZcLjF6Kh/hhwYzYRDLspGHTzcwGgmHG4xOuqfIQdGM+GQi7JRBw83MJoJh1uMjvpnyIHRTDjkomzUwcMNjGbC4Rajo/4ZcmA0Ew65KBt18HADo5lwuMXoqH+GHBjNhEMuykYdPNzAaCYcbjE66p8hB0Yz4ZCLslEHDzcwmgmHW4yO+mfIgdFMOOSibNTBww2MZsLhFqOj/hlyYDQTDrkoG3XwcAOjmXC4xeiof4YcGM2EQy7KRh0M2HALAQCOtyLap3l21QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=RGB size=300x300>"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Draw.MolToImage(mol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "68a4f28a-5a39-4e63-b529-a1587b19446c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[-2.2734e-09,  2.9669e-09, -1.1576e-08],\n",
+       "        [-5.1103e-03, -7.4684e-02,  7.9531e-02],\n",
+       "        [ 9.0984e-02, -1.5246e-02, -5.8468e-02],\n",
+       "        [ 1.3011e-03,  9.9972e-02,  4.3966e-02],\n",
+       "        [-8.7175e-02, -1.0042e-02, -6.5029e-02]])"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "positions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8423afa9-4c1a-4d38-aa74-08d3c30182db",
+   "metadata": {},
+   "source": [
+    "To set up the input, we also need to define the `atomic_subsystem_indices` which indicate which system the atomic mumbers and positions correspond to, as this is designed to work with batched. E.g., a batch with two systems (and 2 atoms each), would have a tensor [0,0,1,1]. Note, while the `NeighborlistForTraining` is designed to take the pre-computed pairs as input (via the `NNPInput` class) for efficiency purposes, if they are not defined they will be computed (as is done here)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "b318e8e1-94a0-4ba9-bec9-3aa5bd84d54a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = NNPInput(atomic_numbers=atomic_numbers, positions=positions, atomic_subsystem_indices=torch.tensor([0,0,0,0,0], dtype=torch.int64), per_system_total_charge=None)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a377120-9733-438d-87db-c281a5961ee1",
+   "metadata": {},
+   "source": [
+    "### Using the neighbor list\n",
+    "Here we will instantiate the neighbor list with a cutoff value;  since the neighbor list is not necessarily designed to be a user facing class, it uses internal units (which by default uses nanometers for distance).\n",
+    "\n",
+    "When instantiating, we must define the cutoff distance as well as defined whether or not we will consider only unique pairs of particles; i.e., will we compute the `half` neighbor list (using only unique pairs) or the `full` neighbor list (not restricting to unique pairs).   By unique pairs we mean that the neighbor list would treat a pair of (0, 1) identical to (1, 0).  Most of the NNPs require the `full` neighbor list. \n",
+    "\n",
+    "Here we will instantiate for the `local` interactions by specifying the `local_cutoff` along with `local_only_unique_pairs` set to True.  As we can see from the positions tensor, a cutoff of 0.5 nm will include all the pairs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "c5f3b70a-e46a-463b-85fd-7c54eefb54a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutoff = 0.5\n",
+    "\n",
+    "nlist = NeighborListForTraining(local_cutoff=cutoff, local_only_unique_pairs=True)\n",
+    "\n",
+    "output = nlist(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f019cdcd-20c0-434d-a13b-c22a611f4580",
+   "metadata": {},
+   "source": [
+    "If we print the result we can see the structure of the structure of the output returned by the neighbor list. The output is a dataclass that contains 3 keys: `local_cutoff`, `vdw_cutoff`, `electrostatic_cutoff`.  Even if do not calculate the interacting pairs for the vdw or electrostatic cutoffs, we have place holder tensors in the output. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "6f6622b7-0f98-4bda-927a-293617adeb6b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PairlistOutputs(local_cutoff=PairlistData(pair_indices=tensor([[0, 0, 0, 0, 1, 1, 1, 2, 2, 3],\n",
+       "        [1, 2, 3, 4, 2, 3, 4, 3, 4, 4]]), d_ij=tensor([[0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1784],\n",
+       "        [0.1784],\n",
+       "        [0.1784],\n",
+       "        [0.1784],\n",
+       "        [0.1784],\n",
+       "        [0.1784]]), r_ij=tensor([[-0.0051, -0.0747,  0.0795],\n",
+       "        [ 0.0910, -0.0152, -0.0585],\n",
+       "        [ 0.0013,  0.1000,  0.0440],\n",
+       "        [-0.0872, -0.0100, -0.0650],\n",
+       "        [ 0.0961,  0.0594, -0.1380],\n",
+       "        [ 0.0064,  0.1747, -0.0356],\n",
+       "        [-0.0821,  0.0646, -0.1446],\n",
+       "        [-0.0897,  0.1152,  0.1024],\n",
+       "        [-0.1782,  0.0052, -0.0066],\n",
+       "        [-0.0885, -0.1100, -0.1090]]), only_unique_pairs=tensor(True)), vdw_cutoff=PairlistData(pair_indices=tensor([], size=(2, 0), dtype=torch.int64), d_ij=tensor([], dtype=torch.int64), r_ij=tensor([], dtype=torch.int64), only_unique_pairs=tensor(False)), electrostatic_cutoff=PairlistData(pair_indices=tensor([], size=(2, 0), dtype=torch.int64), d_ij=tensor([], dtype=torch.int64), r_ij=tensor([], dtype=torch.int64), only_unique_pairs=tensor(True)))"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44a6d38b-c635-4e23-b307-178ebe43cf43",
+   "metadata": {},
+   "source": [
+    "Let us access the information associated with the `local_cutoff`, we we see that this is an instance of the `PairListData` dataclass, that contains `pair_indices`, `d_ij`, `r_ij`, and `only_unique_pairs`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "e731d841-5f7b-4216-89f2-b78608bf9a21",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PairlistData(pair_indices=tensor([[0, 0, 0, 0, 1, 1, 1, 2, 2, 3],\n",
+       "        [1, 2, 3, 4, 2, 3, 4, 3, 4, 4]]), d_ij=tensor([[0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1784],\n",
+       "        [0.1784],\n",
+       "        [0.1784],\n",
+       "        [0.1784],\n",
+       "        [0.1784],\n",
+       "        [0.1784]]), r_ij=tensor([[-0.0051, -0.0747,  0.0795],\n",
+       "        [ 0.0910, -0.0152, -0.0585],\n",
+       "        [ 0.0013,  0.1000,  0.0440],\n",
+       "        [-0.0872, -0.0100, -0.0650],\n",
+       "        [ 0.0961,  0.0594, -0.1380],\n",
+       "        [ 0.0064,  0.1747, -0.0356],\n",
+       "        [-0.0821,  0.0646, -0.1446],\n",
+       "        [-0.0897,  0.1152,  0.1024],\n",
+       "        [-0.1782,  0.0052, -0.0066],\n",
+       "        [-0.0885, -0.1100, -0.1090]]), only_unique_pairs=tensor(True))"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.local_cutoff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cd9fe76-89b7-41e7-9952-2e16922a4437",
+   "metadata": {},
+   "source": [
+    "Let us reduce the cutoff such that we will only include the C-H pairs (e.g., setting this to be 0.15)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "253e4370-f189-4896-a519-8ef13570e008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutoff = 0.15\n",
+    "\n",
+    "nlist = NeighborListForTraining(local_cutoff=cutoff, local_only_unique_pairs=True)\n",
+    "\n",
+    "output = nlist(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b75ec9ee-bdad-4453-9c82-de8db48b5e1d",
+   "metadata": {},
+   "source": [
+    "Here we can see that we have exluded all the H-H pairs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "e34454d4-99c0-42b1-a686-c3288c7c1fbb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PairlistData(pair_indices=tensor([[0, 0, 0, 0],\n",
+       "        [1, 2, 3, 4]]), d_ij=tensor([[0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092]]), r_ij=tensor([[-0.0051, -0.0747,  0.0795],\n",
+       "        [ 0.0910, -0.0152, -0.0585],\n",
+       "        [ 0.0013,  0.1000,  0.0440],\n",
+       "        [-0.0872, -0.0100, -0.0650]]), only_unique_pairs=tensor(True))"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.local_cutoff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09cb463c-7764-42cc-9408-05b59917465d",
+   "metadata": {},
+   "source": [
+    "### only unique pairs\n",
+    "\n",
+    "The example above sets `local_only_unique_pairs` to be `True`. If we toggle this to `False, we will see that we now have twice the pairs, as we now consider, e.g., (0, 1) to be distinct from (1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "508f9951-2579-461f-a2ad-9d9a3cd0ecbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cutoff = 0.15\n",
+    "\n",
+    "nlist = NeighborListForTraining(local_cutoff=cutoff, local_only_unique_pairs=False)\n",
+    "\n",
+    "output = nlist(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "ee0b9d00-95ed-4eae-b8fd-0ca9fd899c37",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PairlistData(pair_indices=tensor([[0, 0, 0, 0, 1, 2, 3, 4],\n",
+       "        [1, 2, 3, 4, 0, 0, 0, 0]]), d_ij=tensor([[0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092]]), r_ij=tensor([[-0.0051, -0.0747,  0.0795],\n",
+       "        [ 0.0910, -0.0152, -0.0585],\n",
+       "        [ 0.0013,  0.1000,  0.0440],\n",
+       "        [-0.0872, -0.0100, -0.0650],\n",
+       "        [ 0.0051,  0.0747, -0.0795],\n",
+       "        [-0.0910,  0.0152,  0.0585],\n",
+       "        [-0.0013, -0.1000, -0.0440],\n",
+       "        [ 0.0872,  0.0100,  0.0650]]), only_unique_pairs=tensor(False))"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.local_cutoff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b961c048-9910-412f-8339-f8e74ca48a7e",
+   "metadata": {},
+   "source": [
+    "### Operating on a batch\n",
+    "\n",
+    "As noted, the `NeighborListForTraining` class is designed to work with batches of systems.  Let us simple add another methane to an instance of NNPInput and examine the result. \n",
+    "\n",
+    "Here, the output should only be C-H pairs in each of the molecules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "42d928c2-e3d6-428b-9bad-ab5d967408b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_positions = torch.concatenate([positions, positions])\n",
+    "batch_atomic_numbers = torch.concatenate([atomic_numbers, atomic_numbers])\n",
+    "batch_atomic_sub_system_indices = torch.tensor([0,0,0,0,0,1,1,1,1,1], dtype=torch.int64)\n",
+    "\n",
+    "data_batch = NNPInput(positions=batch_positions, atomic_numbers=batch_atomic_numbers, atomic_subsystem_indices=batch_atomic_sub_system_indices, per_system_total_charge=None)\n",
+    "\n",
+    "cutoff = 0.15\n",
+    "\n",
+    "nlist = NeighborListForTraining(local_cutoff=cutoff, local_only_unique_pairs=True)\n",
+    "\n",
+    "output = nlist(data_batch)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "a7c896e7-c8c0-4124-9c88-84d8af6462c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PairlistData(pair_indices=tensor([[0, 0, 0, 0, 5, 5, 5, 5],\n",
+       "        [1, 2, 3, 4, 6, 7, 8, 9]]), d_ij=tensor([[0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092],\n",
+       "        [0.1092]]), r_ij=tensor([[-0.0051, -0.0747,  0.0795],\n",
+       "        [ 0.0910, -0.0152, -0.0585],\n",
+       "        [ 0.0013,  0.1000,  0.0440],\n",
+       "        [-0.0872, -0.0100, -0.0650],\n",
+       "        [-0.0051, -0.0747,  0.0795],\n",
+       "        [ 0.0910, -0.0152, -0.0585],\n",
+       "        [ 0.0013,  0.1000,  0.0440],\n",
+       "        [-0.0872, -0.0100, -0.0650]]), only_unique_pairs=tensor(True))"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.local_cutoff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20b5a2e7-3c7c-4258-b570-7614cad1f321",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9543a65-26c3-4325-9f7a-e9344b584039",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Pull Request Summary
The purpose of this PR is to do a refactor of the neighbor lists to ensure consistent behavior for the planned integration with NVALCHEMI-toolkit-ops for VDW. 

In particular, this adds in a new flag to control the "only_unique_pairs" option each of the levels in the multi neighbor list (local, vdw, and electrostatic). 

In the prior implementation, only a single variable could be set which control the behavior for the "local" neighbor list.  Since electrostatic interactions are pair wise, this had a step to remove non-unique pairs, and thus it did not care if 'only_unique_pairs` was True or False. Since TAD-DFTD3 recomputed neighbors internally, we didn't use the vdw neighbor list.  So only_unique_pairs only impacted local.  If switching to NVALCHEMI, which will take the neighbor list as input from VDW, we need to ensure that this will have the Full neighbor list, even if the local uses half.  

this more explicit treatment will prevent any possible issues.  The PairListData data container also contains information about the only_unique_pairs as well, allowing us to reference this information to know what the pair list contains to validate/double check in the algorithms. 

Since the only_unique_pairs (and not local_only_unique_pairs, vdw_only_unique_pairs, and electrostatic_only_unique pairs) are all register variables, this did require some massaging to support "legacy" checkpoints we load in the tests. 

This does not address the need for the image flags required for nvalchemi if we want to handle periodic systems.  That will be don in a separate PR. 

### Key changes
Notable points that this PR has either accomplished or will accomplish.
 - [ ] instead of a single "only_unique_pairs" parameter, we now have these for each level of the multiple cutoff neighbor list: local_only_unique_pairs, vdw_only_unique_pairs, electrostatic_only_unique_pairs
 - [ ] Default behavior is specified in the neighbor list, even though it can be toggled (VDW should be full list, electrostatics half list)
 - [ ] PairListOutput now contains information about "only_unique_pairs" to specify if half/full neighbor list. 

### Associated Issue(s)
 - [x] #403 

## Pull Request Checklist
 - [ ] Issue(s) raised/addressed and linked
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) added/updated
 - [ ] Appropriate .rst doc file(s) added/updated
 - [ ] PR is ready for review